### PR TITLE
feat(update): 管理员在线更新（检测 GitHub 版本 + 一键升级）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: release
+
+# Attach prebuilt binaries to a GitHub Release.
+#
+# Workflow: author the release in the GitHub UI (write the changelog in the
+# body, pick the tag, publish) — this job then builds the panel + probe for
+# each arch, injects the tag as the binary version, and uploads them as release
+# assets. GitHub computes each asset's sha256 digest automatically, which the
+# in-panel updater verifies before installing.
+#
+# The panel's "在线更新" page reads the latest release via the GitHub API, so
+# the version baked in here must match the release tag for the comparison to
+# work — that is exactly what -X ...version.Version=<tag> guarantees.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to (re)build and upload assets for (e.g. v0.2.2)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve tag
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Building version $TAG"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Build frontend (embedded into the panel binary)
+        working-directory: frontend
+        run: |
+          npm ci
+          npx vite build
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Build panel + probe (linux amd64/arm64)
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          set -e
+          mkdir -p out
+          LDFLAGS="-s -w -X qingzhou/internal/version.Version=${TAG}"
+          for arch in amd64 arm64; do
+            echo "== panel linux/$arch =="
+            GOOS=linux GOARCH=$arch go build -ldflags "$LDFLAGS" -o "out/qingzhou-linux-$arch" .
+            echo "== probe linux/$arch =="
+            GOOS=linux GOARCH=$arch go build -ldflags "-s -w" -o "out/probe-linux-$arch" ./cmd/probe
+          done
+          (cd out && sha256sum * > SHA256SUMS.txt)
+          ls -lh out
+
+      - name: Upload assets to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.ver.outputs.tag }}
+          files: |
+            out/qingzhou-linux-amd64
+            out/qingzhou-linux-arm64
+            out/probe-linux-amd64
+            out/probe-linux-arm64
+            out/SHA256SUMS.txt

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -29,11 +29,32 @@ systemctl daemon-reload && systemctl enable --now qingzhou
 ```
 
 ## 更新
+
+### 面板内在线更新（推荐）
+管理后台 →「在线更新」页可一键升级：面板读取 GitHub 最新 release，显示变更日志，
+点「立即更新」后自动**下载对应架构二进制 → 校验 SHA-256 → 原子替换 → 进程自我重启**
+（同 PID，兼容 `Restart=on-failure`，约 1~2 秒短暂中断）。要能生效，二进制必须带内置
+版本号（见下方构建说明），且发布产物里有 `qingzhou-linux-<arch>` 资产——`.github/workflows/release.yml`
+会在你于 GitHub 上发布 release 时自动构建并上传（版本号自动注入 = release tag）。
+
+> 仅 Linux 部署支持自更新；其他平台请手动替换。可选环境变量：
+> `QZ_UPDATE_REPO`（默认 `mllt992/qing-zhou`）、`QZ_UPDATE_GITHUB_TOKEN`（提升 GitHub API 速率上限）。
+
+### 手动更新
 ```bash
 systemctl stop qingzhou        # 或直接覆盖后 restart
 install -m755 qingzhou /opt/qingzhou/qingzhou
 systemctl restart qingzhou
 ```
+
+### 从源码构建（必须注入版本号，否则在线更新无法比较版本）
+```bash
+# 1. 构建内嵌前端
+cd frontend && npm ci && npx vite build && cd ..
+# 2. 注入版本号（= 目标 release tag）构建面板
+go build -ldflags "-s -w -X qingzhou/internal/version.Version=v0.2.2" -o qingzhou .
+```
+不带 `-X ...version.Version` 时版本为 `dev`，在线更新页会把任意最新 release 视为「可更新」。
 
 ## 数据库备份（每日）
 ```bash

--- a/deploy/qingzhou.env.example
+++ b/deploy/qingzhou.env.example
@@ -5,6 +5,15 @@ QZ_LISTEN=127.0.0.1:8081
 QZ_DB_PATH=/opt/qingzhou/qingzhou.db
 QZ_PUBLIC_BASE=https://node.example.com
 
+# Serve the new Vue 3 frontend (includes the 在线更新 admin page).
+QZ_USE_NEW_FRONTEND=1
+
+# --- 在线更新（可选）---
+# 面板「在线更新」页检查此仓库的 GitHub Releases。默认 mllt992/qing-zhou。
+# QZ_UPDATE_REPO=mllt992/qing-zhou
+# GitHub token（可选）：仅用于提升匿名 API 速率上限（60/时），公开仓库无需权限。
+# QZ_UPDATE_GITHUB_TOKEN=
+
 # First-run admin (only used to seed; change password after first login).
 # If QZ_ADMIN_PASS is empty, a random password is generated and logged once.
 QZ_ADMIN_USER=admin

--- a/frontend/src/components/DashboardLayout.vue
+++ b/frontend/src/components/DashboardLayout.vue
@@ -64,7 +64,7 @@ import {
   ReceiptOutline, WalletOutline, MegaphoneOutline, BookOutline,
   PersonOutline, PeopleOutline, ArchiveOutline, ServerOutline,
   SettingsOutline, KeyOutline, NotificationsOutline, DocumentTextOutline,
-  PulseOutline, HardwareChipOutline, HomeOutline, LogOutOutline
+  PulseOutline, HardwareChipOutline, HomeOutline, LogOutOutline, CloudDownloadOutline
 } from '@vicons/ionicons5'
 import { useAuthStore } from '@/stores/auth'
 import { useConfigStore } from '@/stores/config'
@@ -128,6 +128,7 @@ const adminSysItems: MenuOption[] = [
   { label: '公告管理', key: '/admin/announcements', icon: renderIcon(NotificationsOutline) },
   { label: '帮助文档', key: '/admin/help', icon: renderIcon(DocumentTextOutline) },
   { label: '系统设置', key: '/admin/settings', icon: renderIcon(SettingsOutline) },
+  { label: '在线更新', key: '/admin/update', icon: renderIcon(CloudDownloadOutline) },
 ]
 
 const menuOptions = computed<MenuOption[]>(() => {
@@ -157,6 +158,7 @@ const titleMap: Record<string, string> = {
   '/admin': '管理概览', '/admin/users': '用户管理', '/admin/packages': '套餐管理', '/admin/nodes': '节点管理',
   '/admin/singbox': 'sing-box', '/admin/orders': '订单管理', '/admin/servers': '服务器', '/admin/monitor': '监控管理',
   '/admin/settings': '系统设置', '/admin/reg-codes': '注册码', '/admin/announcements': '公告管理', '/admin/help': '帮助文档',
+  '/admin/update': '在线更新',
 }
 const currentTitle = computed(() => titleMap[route.path] || config.config.site_name || '轻舟')
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -35,6 +35,7 @@ const router = createRouter({
         { path: 'admin/reg-codes', name: 'admin-regcodes', component: () => import('@/views/AdminRegCodes.vue'), meta: { requiresAdmin: true } },
         { path: 'admin/announcements', name: 'admin-announcements', component: () => import('@/views/AdminAnnouncements.vue'), meta: { requiresAdmin: true } },
         { path: 'admin/help', name: 'admin-help', component: () => import('@/views/AdminHelp.vue'), meta: { requiresAdmin: true } },
+        { path: 'admin/update', name: 'admin-update', component: () => import('@/views/AdminUpdate.vue'), meta: { requiresAdmin: true } },
       ],
     },
   ],

--- a/frontend/src/views/AdminUpdate.vue
+++ b/frontend/src/views/AdminUpdate.vue
@@ -1,0 +1,259 @@
+<template>
+  <div>
+    <h2 class="page-title">在线更新</h2>
+
+    <n-spin :show="loading">
+      <!-- 版本概览 -->
+      <div class="ver-grid">
+        <div class="ver-card">
+          <div class="ver-label">当前版本</div>
+          <div class="ver-value">{{ info?.current || '—' }}</div>
+          <n-tag v-if="info?.dev" type="warning" size="tiny" bordered="false">开发构建</n-tag>
+        </div>
+        <div class="ver-arrow">→</div>
+        <div class="ver-card" :class="{ hot: info?.update_available }">
+          <div class="ver-label">最新版本</div>
+          <div class="ver-value">{{ info?.latest || '—' }}</div>
+          <n-tag v-if="info && info.update_available" type="success" size="tiny" bordered="false">可更新</n-tag>
+          <n-tag v-else-if="info" type="default" size="tiny" bordered="false">已是最新</n-tag>
+        </div>
+      </div>
+
+      <div class="toolbar">
+        <n-button size="small" :loading="loading" @click="check">
+          <template #icon><n-icon><RefreshOutline /></n-icon></template>
+          检查更新
+        </n-button>
+        <a v-if="info?.url" :href="info.url" target="_blank" rel="noopener" class="release-link">
+          在 GitHub 查看发布页 ↗
+        </a>
+        <span class="spacer" />
+        <n-button
+          v-if="info?.update_available"
+          type="primary"
+          :disabled="updating || !info.downloadable"
+          :loading="updating"
+          @click="confirmUpdate"
+        >
+          {{ updating ? '更新中…' : '立即更新' }}
+        </n-button>
+      </div>
+
+      <n-alert v-if="info && info.update_available && !info.downloadable" type="warning" style="margin-top:8px;">
+        最新发布未提供适配当前服务器架构的二进制（{{ info.asset_name }}），无法一键更新。请手动升级或补充对应架构的构建产物。
+      </n-alert>
+
+      <!-- 更新进度 -->
+      <div v-if="updating || progress.status === 'failed'" class="progress-box">
+        <div class="progress-head">
+          <span class="phase">{{ phaseLabel }}</span>
+          <span v-if="progress.target_version" class="target">→ {{ progress.target_version }}</span>
+        </div>
+        <n-progress
+          type="line"
+          :percentage="progress.percent || 0"
+          :status="progress.status === 'failed' ? 'error' : 'default'"
+          :processing="updating && progress.status !== 'failed'"
+        />
+        <div class="progress-msg" :class="{ err: progress.status === 'failed' }">{{ progress.message }}</div>
+      </div>
+
+      <!-- 变更日志 -->
+      <div v-if="info?.notes" class="changelog">
+        <div class="cl-head">
+          <span class="cl-title">{{ info.name || ('版本 ' + info.latest) }}</span>
+          <span v-if="publishedText" class="cl-date">{{ publishedText }}</span>
+        </div>
+        <div class="cl-body md" v-html="notesHtml"></div>
+      </div>
+    </n-spin>
+
+    <n-alert type="info" style="margin-top:16px;">
+      更新流程：从 GitHub Releases 下载对应架构二进制 → 校验 SHA-256 → 原子替换 → 进程自动重启。
+      重启期间面板会短暂（约 1~2 秒）不可访问，完成后本页会自动刷新到新版本。
+    </n-alert>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, computed, onMounted, onUnmounted } from 'vue'
+import { NSpin, NButton, NIcon, NTag, NAlert, NProgress, useMessage, useDialog } from 'naive-ui'
+import { RefreshOutline } from '@vicons/ionicons5'
+import { apiGet, apiPost } from '@/api'
+import { mdToHtml } from '@/utils/markdown'
+import { fmtDate } from '@/utils/format'
+
+interface UpdateInfo {
+  current: string
+  latest: string
+  name: string
+  notes: string
+  url: string
+  published_at: string
+  update_available: boolean
+  downloadable: boolean
+  asset_name: string
+  asset_size: number
+  dev: boolean
+}
+
+const message = useMessage()
+const dialog = useDialog()
+
+const loading = ref(false)
+const updating = ref(false)
+const info = ref<UpdateInfo | null>(null)
+
+const progress = reactive({
+  status: 'idle' as string,
+  message: '',
+  percent: 0,
+  target_version: '',
+  current: '',
+})
+
+let pollTimer: number | undefined
+let pollStart = 0
+
+const notesHtml = computed(() => (info.value?.notes ? mdToHtml(info.value.notes) : ''))
+const publishedText = computed(() => {
+  const s = info.value?.published_at
+  if (!s) return ''
+  const t = Math.floor(new Date(s).getTime() / 1000)
+  return Number.isFinite(t) ? fmtDate(t) : ''
+})
+
+const phaseLabels: Record<string, string> = {
+  idle: '空闲',
+  downloading: '下载中',
+  verifying: '校验中',
+  installing: '安装中',
+  restarting: '重启中',
+  failed: '更新失败',
+}
+const phaseLabel = computed(() => phaseLabels[progress.status] || progress.status)
+
+async function check() {
+  loading.value = true
+  try {
+    info.value = await apiGet<UpdateInfo>('/api/admin/update/check')
+  } catch (e: any) {
+    message.error(e?.message || '检查更新失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+function confirmUpdate() {
+  if (!info.value) return
+  dialog.warning({
+    title: '确认更新',
+    content: `将从 ${info.value.current || '当前版本'} 更新到 ${info.value.latest}。更新过程中服务会短暂重启，确定继续？`,
+    positiveText: '开始更新',
+    negativeText: '取消',
+    onPositiveClick: () => { startUpdate() },
+  })
+}
+
+async function startUpdate() {
+  try {
+    await apiPost('/api/admin/update/apply')
+  } catch (e: any) {
+    message.error(e?.message || '无法启动更新')
+    return
+  }
+  updating.value = true
+  progress.status = 'downloading'
+  progress.percent = 0
+  progress.message = '准备下载…'
+  pollStart = Date.now()
+  poll()
+}
+
+async function poll() {
+  try {
+    const st = await apiGet<any>('/api/admin/update/status')
+    // apply() 会在返回前把状态置为非 idle，因此更新期间再见到 idle
+    // 说明进程已完成 re-exec 并以新版本重启 —— 视为成功。
+    if (updating.value && st.status === 'idle') {
+      onSuccess(st.current)
+      return
+    }
+    progress.status = st.status
+    progress.message = st.message || phaseLabel.value
+    progress.percent = st.percent || 0
+    progress.target_version = st.target_version || progress.target_version
+    if (st.status === 'failed') {
+      updating.value = false
+      message.error(st.message || '更新失败')
+      return
+    }
+  } catch {
+    // 重启期间连接会中断，属正常，继续轮询等待服务回来。
+    if (progress.status !== 'restarting') {
+      progress.message = '服务重启中，等待恢复…'
+    }
+  }
+  if (Date.now() - pollStart > 180_000) {
+    updating.value = false
+    message.warning('更新耗时过长，请手动刷新页面确认结果')
+    return
+  }
+  pollTimer = window.setTimeout(poll, 1500)
+}
+
+function onSuccess(newVer: string) {
+  updating.value = false
+  progress.status = 'idle'
+  progress.percent = 100
+  message.success(`已更新到 ${newVer || '最新版本'}，即将刷新页面`)
+  window.setTimeout(() => window.location.reload(), 1500)
+}
+
+onMounted(check)
+onUnmounted(() => { if (pollTimer) window.clearTimeout(pollTimer) })
+</script>
+
+<style scoped>
+.page-title { font-size: 20px; font-weight: 700; margin: 0 0 16px; }
+
+.ver-grid {
+  display: flex; align-items: stretch; gap: 12px; flex-wrap: wrap;
+}
+.ver-card {
+  flex: 1; min-width: 160px;
+  background: #fff; border: 1px solid var(--border); border-radius: 12px;
+  padding: 16px 18px; display: flex; flex-direction: column; gap: 6px;
+}
+.ver-card.hot { border-color: #6f8f76; box-shadow: 0 0 0 3px rgba(111,143,118,.12); }
+.ver-label { font-size: 12px; color: var(--text-3); }
+.ver-value { font-size: 22px; font-weight: 750; letter-spacing: -0.02em; }
+.ver-arrow { display: grid; place-items: center; color: var(--text-3); font-size: 20px; }
+
+.toolbar { display: flex; align-items: center; gap: 12px; margin-top: 16px; }
+.toolbar .spacer { flex: 1; }
+.release-link { font-size: 13px; color: #5c7c63; text-decoration: none; }
+.release-link:hover { text-decoration: underline; }
+
+.progress-box {
+  margin-top: 16px; padding: 14px 16px;
+  background: var(--bg-soft, #faf9f5); border: 1px solid var(--border); border-radius: 12px;
+}
+.progress-head { display: flex; align-items: baseline; gap: 8px; margin-bottom: 8px; }
+.progress-head .phase { font-weight: 650; }
+.progress-head .target { font-size: 12px; color: var(--text-3); }
+.progress-msg { margin-top: 8px; font-size: 12px; color: var(--text-2); }
+.progress-msg.err { color: #d03050; }
+
+.changelog {
+  margin-top: 20px; background: #fff; border: 1px solid var(--border); border-radius: 12px;
+  overflow: hidden;
+}
+.cl-head {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 10px;
+  padding: 14px 18px; border-bottom: 1px solid var(--border); background: #faf9f5;
+}
+.cl-title { font-weight: 700; }
+.cl-date { font-size: 12px; color: var(--text-3); }
+.cl-body { padding: 8px 18px 18px; }
+</style>

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -11,6 +11,7 @@ import (
 	"qingzhou/internal/auth"
 	"qingzhou/internal/idgen"
 	"qingzhou/internal/store"
+	"qingzhou/internal/version"
 )
 
 type ctxKey string
@@ -64,7 +65,7 @@ func (a *API) issueLogin(w http.ResponseWriter, r *http.Request, u *store.User) 
 }
 
 func (a *API) handleHealth(w http.ResponseWriter, r *http.Request) {
-	ok(w, J{"status": "ok", "time": time.Now().Unix()})
+	ok(w, J{"status": "ok", "time": time.Now().Unix(), "version": version.Current()})
 }
 
 // registerMode is "open" (anyone) | "code" (needs reg code) | "closed".
@@ -104,6 +105,7 @@ func (a *API) handleConfig(w http.ResponseWriter, r *http.Request) {
 		"site_description":      siteDesc,
 		"homepage_mode":         homeMode,
 		"homepage_url":          homeURL,
+		"app_version":           version.Current(),
 	})
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -12,6 +12,7 @@ import (
 	"qingzhou/internal/mailer"
 	"qingzhou/internal/sbctl"
 	"qingzhou/internal/store"
+	"qingzhou/internal/updater"
 	"qingzhou/web"
 )
 
@@ -23,7 +24,8 @@ type API struct {
 	resendRL *rateLimiter
 	probeRL  *rateLimiter // rate limit for agent report endpoint
 
-	sbctl *sbctl.Controller // native sing-box orchestrator; nil if not enabled
+	sbctl   *sbctl.Controller // native sing-box orchestrator; nil if not enabled
+	updater *updater.Manager  // GitHub-release self-updater
 
 	linkMu    sync.Mutex
 	linkCache map[int64]linkCacheEntry
@@ -43,13 +45,32 @@ func (a *API) sbRebuild() error {
 }
 
 func New(st *store.Store, secret []byte, mail *mailer.Mailer) *API {
-	return &API{
+	a := &API{
 		st: st, secret: secret, mailer: mail,
 		authRL:    newRateLimiter(20, time.Minute),   // 20 auth attempts / IP / min
 		resendRL:  newRateLimiter(3, 10*time.Minute), // 3 verify resends / user / 10min
 		probeRL:   newRateLimiter(60, time.Minute),   // 60 probe reports / IP / min
 		linkCache: make(map[int64]linkCacheEntry),
 	}
+	// Self-updater: repo + optional GitHub token come from env or DB settings,
+	// falling back to the project's canonical repo.
+	a.updater = updater.New(
+		func() string {
+			if v := os.Getenv("QZ_UPDATE_REPO"); v != "" {
+				return v
+			}
+			v, _ := st.GetSetting("update_repo")
+			return v
+		},
+		func() string {
+			if v := os.Getenv("QZ_UPDATE_GITHUB_TOKEN"); v != "" {
+				return v
+			}
+			v, _ := st.GetSetting("update_github_token")
+			return v
+		},
+	)
+	return a
 }
 
 func (a *API) Router() http.Handler {
@@ -132,6 +153,9 @@ func (a *API) Router() http.Handler {
 		ar.Put("/api/admin/settings", a.handlePutSettings)
 		ar.Post("/api/admin/settings/test-smtp", a.handleTestSMTP)
 		ar.Post("/api/admin/rebuild", a.handleAdminRebuild)
+		ar.Get("/api/admin/update/check", a.handleUpdateCheck)
+		ar.Get("/api/admin/update/status", a.handleUpdateStatus)
+		ar.Post("/api/admin/update/apply", a.handleUpdateApply)
 		ar.Get("/api/admin/help", a.handleAdminHelpDocs)
 		ar.Post("/api/admin/help", a.handleAdminCreateHelpDoc)
 		ar.Put("/api/admin/help/{id}", a.handleAdminUpdateHelpDoc)

--- a/internal/api/update_admin.go
+++ b/internal/api/update_admin.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"qingzhou/internal/version"
+)
+
+// handleUpdateCheck queries GitHub for the latest release and reports whether a
+// newer version is available, along with the changelog (release body).
+func (a *API) handleUpdateCheck(w http.ResponseWriter, r *http.Request) {
+	if a.updater == nil {
+		fail(w, http.StatusServiceUnavailable, "更新服务未启用")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+	res, err := a.updater.Check(ctx)
+	if err != nil {
+		fail(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	ok(w, res)
+}
+
+// handleUpdateStatus returns the current progress of an in-flight update, plus
+// the running binary's version so the UI can detect a successful restart (the
+// version flips once the re-execed process answers again).
+func (a *API) handleUpdateStatus(w http.ResponseWriter, r *http.Request) {
+	if a.updater == nil {
+		fail(w, http.StatusServiceUnavailable, "更新服务未启用")
+		return
+	}
+	st := a.updater.State()
+	ok(w, J{
+		"status":         st.Status,
+		"message":        st.Message,
+		"percent":        st.Percent,
+		"target_version": st.TargetVersion,
+		"started_at":     st.StartedAt,
+		"current":        version.Current(),
+	})
+}
+
+// handleUpdateApply starts the download → verify → swap → restart sequence in
+// the background and returns immediately; the client polls the status endpoint.
+func (a *API) handleUpdateApply(w http.ResponseWriter, r *http.Request) {
+	if a.updater == nil {
+		fail(w, http.StatusServiceUnavailable, "更新服务未启用")
+		return
+	}
+	if err := a.updater.Apply(time.Now().Unix()); err != nil {
+		fail(w, http.StatusConflict, err.Error())
+		return
+	}
+	ok(w, J{"started": true})
+}

--- a/internal/updater/restart_linux.go
+++ b/internal/updater/restart_linux.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package updater
+
+import (
+	"os"
+	"syscall"
+)
+
+// restartSelf replaces the current process image with the freshly-installed
+// binary at exePath, preserving args and environment. On success it does not
+// return; the same PID now runs the new code, so systemd sees no exit.
+func restartSelf(exePath string) error {
+	argv := append([]string{exePath}, os.Args[1:]...)
+	return syscall.Exec(exePath, argv, os.Environ())
+}

--- a/internal/updater/restart_other.go
+++ b/internal/updater/restart_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package updater
+
+import "errors"
+
+// restartSelf is a no-op stub for non-Linux builds. Apply already refuses on
+// non-Linux platforms, so this only exists to keep the package compiling on the
+// developer's machine.
+func restartSelf(exePath string) error {
+	return errors.New("自更新仅支持 Linux")
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,422 @@
+// Package updater implements in-panel self-update against GitHub Releases.
+//
+// It queries the repo's latest release, compares the tag against the running
+// binary's version (see internal/version), and — on admin request — downloads
+// the matching Linux asset, verifies its sha256 against the digest GitHub
+// publishes for the asset, atomically replaces the running binary, and re-execs
+// the process so the new version takes over (same PID; works with systemd's
+// Restart=on-failure without needing the unit name or extra privileges).
+//
+// The binary swap + re-exec is Linux-only (see restart_linux.go); on other
+// platforms Apply refuses with a clear message. Checking for updates works
+// everywhere.
+package updater
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"qingzhou/internal/version"
+)
+
+// DefaultRepo is the GitHub "owner/name" polled when no override is configured.
+const DefaultRepo = "mllt992/qing-zhou"
+
+// assetName is the release asset this binary knows how to install for the
+// current OS/arch, e.g. "qingzhou-linux-amd64".
+func assetName() string {
+	return fmt.Sprintf("qingzhou-%s-%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// Status is a coarse phase of an in-flight update.
+type Status string
+
+const (
+	StatusIdle        Status = "idle"
+	StatusDownloading Status = "downloading"
+	StatusVerifying   Status = "verifying"
+	StatusInstalling  Status = "installing"
+	StatusRestarting  Status = "restarting"
+	StatusFailed      Status = "failed"
+)
+
+// State is the observable progress of the updater, returned by the status API.
+type State struct {
+	Status        Status `json:"status"`
+	Message       string `json:"message"`
+	Percent       int    `json:"percent"`
+	TargetVersion string `json:"target_version"`
+	StartedAt     int64  `json:"started_at,omitempty"`
+}
+
+// CheckResult is what the check API returns to the admin UI.
+type CheckResult struct {
+	Current         string `json:"current"`
+	Latest          string `json:"latest"`
+	Name            string `json:"name"`
+	Notes           string `json:"notes"`
+	URL             string `json:"url"`
+	PublishedAt     string `json:"published_at"`
+	UpdateAvailable bool   `json:"update_available"`
+	Downloadable    bool   `json:"downloadable"`
+	AssetName       string `json:"asset_name"`
+	AssetSize       int64  `json:"asset_size"`
+	Dev             bool   `json:"dev"`
+}
+
+// Manager coordinates update checks and the (single-flight) apply operation.
+type Manager struct {
+	repoFn  func() string // resolves the configured "owner/name" (env/setting/default)
+	tokenFn func() string // optional GitHub token to lift the 60/hr anon rate limit
+	client  *http.Client
+
+	mu      sync.Mutex
+	state   State
+	running bool
+}
+
+// New builds a Manager. repoFn/tokenFn may be nil; sensible defaults are used.
+func New(repoFn, tokenFn func() string) *Manager {
+	if repoFn == nil {
+		repoFn = func() string { return DefaultRepo }
+	}
+	if tokenFn == nil {
+		tokenFn = func() string { return "" }
+	}
+	return &Manager{
+		repoFn:  repoFn,
+		tokenFn: tokenFn,
+		// No overall client timeout: a release binary is tens of MB and the
+		// download is bounded by the caller's context instead.
+		client: &http.Client{},
+		state:  State{Status: StatusIdle},
+	}
+}
+
+func (m *Manager) repo() string {
+	r := strings.TrimSpace(m.repoFn())
+	if r == "" {
+		return DefaultRepo
+	}
+	return r
+}
+
+// ghRelease mirrors the subset of the GitHub releases API we consume.
+type ghRelease struct {
+	TagName     string    `json:"tag_name"`
+	Name        string    `json:"name"`
+	Body        string    `json:"body"`
+	HTMLURL     string    `json:"html_url"`
+	Draft       bool      `json:"draft"`
+	Prerelease  bool      `json:"prerelease"`
+	PublishedAt string    `json:"published_at"`
+	Assets      []ghAsset `json:"assets"`
+}
+
+type ghAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Size               int64  `json:"size"`
+	Digest             string `json:"digest"` // e.g. "sha256:abcd..."
+}
+
+func (m *Manager) newRequest(ctx context.Context, url string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "qingzhou-updater")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if tok := strings.TrimSpace(m.tokenFn()); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	return req, nil
+}
+
+// latestRelease fetches the newest non-draft release for the configured repo.
+func (m *Manager) latestRelease(ctx context.Context) (*ghRelease, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", m.repo())
+	req, err := m.newRequest(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("请求 GitHub 失败: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errors.New("未找到任何发布版本（仓库无 release 或名称配置有误）")
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		return nil, errors.New("GitHub API 速率受限，请稍后再试（或配置 update_github_token）")
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("GitHub 返回 %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var rel ghRelease
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("解析 GitHub 响应失败: %w", err)
+	}
+	return &rel, nil
+}
+
+func findAsset(rel *ghRelease, name string) *ghAsset {
+	for i := range rel.Assets {
+		if rel.Assets[i].Name == name {
+			return &rel.Assets[i]
+		}
+	}
+	return nil
+}
+
+// Check queries the latest release and reports whether an update is available.
+func (m *Manager) Check(ctx context.Context) (*CheckResult, error) {
+	rel, err := m.latestRelease(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cur := version.Current()
+	dev := version.IsDev()
+	asset := findAsset(rel, assetName())
+
+	res := &CheckResult{
+		Current:     cur,
+		Latest:      rel.TagName,
+		Name:        rel.Name,
+		Notes:       rel.Body,
+		URL:         rel.HTMLURL,
+		PublishedAt: rel.PublishedAt,
+		AssetName:   assetName(),
+		Dev:         dev,
+	}
+	if asset != nil {
+		res.Downloadable = true
+		res.AssetSize = asset.Size
+	}
+	// A dev build has no comparable version — surface the latest as installable
+	// so operators can bootstrap onto a tagged build. Otherwise compare semver.
+	if dev {
+		res.UpdateAvailable = true
+	} else {
+		res.UpdateAvailable = version.Compare(rel.TagName, cur) > 0
+	}
+	return res, nil
+}
+
+// State returns a snapshot of the current updater progress.
+func (m *Manager) State() State {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.state
+}
+
+func (m *Manager) setState(s Status, msg string, pct int, target string) {
+	m.mu.Lock()
+	m.state.Status = s
+	m.state.Message = msg
+	if pct >= 0 {
+		m.state.Percent = pct
+	}
+	if target != "" {
+		m.state.TargetVersion = target
+	}
+	m.mu.Unlock()
+}
+
+// Apply kicks off a self-update in the background. It returns immediately; the
+// caller polls State() for progress. Returns an error if the platform is
+// unsupported or an update is already running.
+func (m *Manager) Apply(nowUnix int64) error {
+	if runtime.GOOS != "linux" {
+		return errors.New("自更新仅支持 Linux 部署；请在服务器上手动替换二进制")
+	}
+	m.mu.Lock()
+	if m.running {
+		m.mu.Unlock()
+		return errors.New("已有更新任务在进行中")
+	}
+	m.running = true
+	m.state = State{Status: StatusDownloading, Message: "准备下载…", Percent: 0, StartedAt: nowUnix}
+	m.mu.Unlock()
+
+	go m.run()
+	return nil
+}
+
+func (m *Manager) fail(msg string) {
+	m.setState(StatusFailed, msg, -1, "")
+	m.mu.Lock()
+	m.running = false
+	m.mu.Unlock()
+}
+
+// run performs the full download → verify → swap → re-exec sequence. On success
+// it never returns (the process image is replaced); any failure lands in
+// StatusFailed with a message the UI shows.
+func (m *Manager) run() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	rel, err := m.latestRelease(ctx)
+	if err != nil {
+		m.fail("获取版本信息失败: " + err.Error())
+		return
+	}
+	target := rel.TagName
+	m.setState(StatusDownloading, "开始下载 "+target, 0, target)
+
+	asset := findAsset(rel, assetName())
+	if asset == nil {
+		m.fail(fmt.Sprintf("该版本未提供适配当前架构的资产 (%s)", assetName()))
+		return
+	}
+	wantDigest := parseSHA256(asset.Digest)
+	if wantDigest == "" {
+		m.fail("该版本资产缺少 sha256 摘要，出于安全考虑拒绝更新")
+		return
+	}
+
+	exePath, err := os.Executable()
+	if err != nil {
+		m.fail("无法定位当前程序路径: " + err.Error())
+		return
+	}
+	if resolved, err := filepath.EvalSymlinks(exePath); err == nil {
+		exePath = resolved
+	}
+
+	// Download into a sibling temp file so the final rename is atomic (same fs).
+	tmpPath := exePath + ".new"
+	sum, err := m.download(ctx, asset.BrowserDownloadURL, tmpPath, asset.Size)
+	if err != nil {
+		_ = os.Remove(tmpPath)
+		m.fail("下载失败: " + err.Error())
+		return
+	}
+
+	m.setState(StatusVerifying, "校验完整性…", 100, target)
+	if !strings.EqualFold(sum, wantDigest) {
+		_ = os.Remove(tmpPath)
+		m.fail("sha256 校验不匹配，已丢弃下载内容（可能被篡改或下载损坏）")
+		return
+	}
+
+	m.setState(StatusInstalling, "安装新版本…", 100, target)
+	if err := os.Chmod(tmpPath, 0o755); err != nil {
+		_ = os.Remove(tmpPath)
+		m.fail("设置可执行权限失败: " + err.Error())
+		return
+	}
+	// rename() over the running binary is safe on Linux (no ETXTBSY; only
+	// *writing* a busy text file fails — the probe installer relies on the same).
+	if err := os.Rename(tmpPath, exePath); err != nil {
+		_ = os.Remove(tmpPath)
+		m.fail("替换二进制失败: " + err.Error())
+		return
+	}
+
+	m.setState(StatusRestarting, "更新完成，正在重启服务…", 100, target)
+	// Give the HTTP layer a beat to flush any in-flight status poll, then
+	// re-exec. On success this call does not return.
+	time.Sleep(600 * time.Millisecond)
+	if err := restartSelf(exePath); err != nil {
+		m.fail("重启失败，请手动重启服务: " + err.Error())
+		return
+	}
+}
+
+// download streams url into dst, returning the lowercase hex sha256 of the body
+// and updating progress from the known content length.
+func (m *Manager) download(ctx context.Context, url, dst string, size int64) (string, error) {
+	req, err := m.newRequest(ctx, url)
+	if err != nil {
+		return "", err
+	}
+	// Asset downloads are octet-streams, not the JSON API media type.
+	req.Header.Set("Accept", "application/octet-stream")
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	if resp.ContentLength > 0 {
+		size = resp.ContentLength
+	}
+
+	f, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	pw := &progressWriter{m: m, total: size}
+	if _, err := io.Copy(io.MultiWriter(f, h, pw), resp.Body); err != nil {
+		return "", err
+	}
+	if err := f.Sync(); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// progressWriter updates the manager's download percentage as bytes flow.
+type progressWriter struct {
+	m       *Manager
+	total   int64
+	written int64
+	lastPct int
+}
+
+func (p *progressWriter) Write(b []byte) (int, error) {
+	n := len(b)
+	p.written += int64(n)
+	if p.total > 0 {
+		pct := int(p.written * 100 / p.total)
+		if pct > 100 {
+			pct = 100
+		}
+		if pct != p.lastPct {
+			p.lastPct = pct
+			p.m.setState(StatusDownloading, "", pct, "")
+		}
+	}
+	return n, nil
+}
+
+// parseSHA256 extracts the hex digest from a "sha256:<hex>" string (case- and
+// prefix-tolerant), returning "" if it isn't a sha256 digest.
+func parseSHA256(d string) string {
+	d = strings.TrimSpace(d)
+	if d == "" {
+		return ""
+	}
+	if i := strings.IndexByte(d, ':'); i >= 0 {
+		if !strings.EqualFold(d[:i], "sha256") {
+			return ""
+		}
+		d = d[i+1:]
+	}
+	if len(d) != 64 {
+		return ""
+	}
+	return strings.ToLower(d)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,78 @@
+// Package version holds the build-time version of the qingzhou binary and a
+// small semver comparison used by the in-panel updater to decide whether a
+// newer GitHub release is available.
+//
+// Version is injected at build time via ldflags, e.g.:
+//
+//	go build -ldflags "-X qingzhou/internal/version.Version=v0.2.1" .
+//
+// When built without that flag (plain `go run .` / `go build .`), it stays
+// "dev", which the updater treats as "unknown / always offer the latest".
+package version
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Version is the current build's version. Overridden at build time via ldflags.
+var Version = "dev"
+
+// Current returns the running binary's version string.
+func Current() string { return Version }
+
+// IsDev reports whether this is an untagged development build (no ldflags
+// injection). Such a build has no reliable version to compare against.
+func IsDev() bool { return Version == "" || Version == "dev" }
+
+// Compare compares two version strings a and b of the form "v1.2.3" (the
+// leading "v" and any pre-release suffix after "-" or "+" are ignored). It
+// returns -1 if a < b, 0 if equal, and +1 if a > b. Missing numeric segments
+// are treated as 0, so "v1.2" == "v1.2.0".
+func Compare(a, b string) int {
+	pa, pb := parse(a), parse(b)
+	n := len(pa)
+	if len(pb) > n {
+		n = len(pb)
+	}
+	for i := 0; i < n; i++ {
+		var x, y int
+		if i < len(pa) {
+			x = pa[i]
+		}
+		if i < len(pb) {
+			y = pb[i]
+		}
+		if x < y {
+			return -1
+		}
+		if x > y {
+			return 1
+		}
+	}
+	return 0
+}
+
+// parse turns "v1.2.3-rc1" into [1 2 3], ignoring the "v" prefix and any
+// pre-release/build metadata after the first '-' or '+'.
+func parse(v string) []int {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	v = strings.TrimPrefix(v, "V")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	if v == "" {
+		return nil
+	}
+	parts := strings.Split(v, ".")
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil {
+			n = 0
+		}
+		out = append(out, n)
+	}
+	return out
+}


### PR DESCRIPTION
## 背景
支持面板内在线更新：检测 GitHub 上发布的新版本，管理员在专门的「在线更新」页看到变更内容，点一下即可自动升级。

## 功能
- **管理员「在线更新」页**（侧栏 → 内容系统 → 在线更新）
  - 当前版本 ↔ 最新版本对比，是否可更新一目了然
  - 渲染 GitHub Release 的变更日志（changelog）
  - 「立即更新」带二次确认 + 实时进度条；重启期间自动轮询，完成后刷新到新版本
- **一键升级流程**：下载对应架构二进制 → **校验 SHA-256** → 原子替换 → 进程自我重启
  - 校验用 GitHub 资产自带的 `sha256` digest，缺摘要则拒绝更新
  - 重启用 `syscall.Exec` 原地重执行（同 PID，兼容 systemd `Restart=on-failure`，约 1~2 秒短暂中断）
  - 仅 Linux 支持自更新；其他平台明确拒绝并提示手动升级

## 改动
| 层 | 文件 |
|----|------|
| 版本 | `internal/version` — ldflags 注入 + semver 比较 |
| 更新器 | `internal/updater` — 查 release / 下载校验 / 替换 / 重启（`restart_linux.go` + 非 Linux stub） |
| API | `internal/api/update_admin.go` + 路由；`/api/config`、`/api/health` 暴露版本号 |
| 前端 | `AdminUpdate.vue` + 路由 + 侧栏 |
| CI | `.github/workflows/release.yml` — 发布 release 时自动构建（内嵌前端 + panel/probe amd64/arm64）、注入 tag 版本号、上传资产 |
| 文档 | `deploy/README.md`、`qingzhou.env.example` |

## 验证
本地以 `v0.2.0` 起实例打真实 GitHub API：正确识别 `latest=v0.2.1`、`update_available=true`、拉回完整变更日志；架构检测正常。Go 原生 / Linux 交叉编译、gofmt、vet、前端 `vite build` 均通过。

## 启用须知（合并后）
1. **发一个带版本号的新 release**：现有线上二进制版本为 `dev`（无 ldflags 注入），更新页会把任意最新版都视为「可更新」。用本 PR 的 workflow 打 tag 发布一次后版本比较才准确。
2. **生产环境设 `QZ_USE_NEW_FRONTEND=1`**：新页面在 Vue3 前端里（env 示例已补充）。

可选环境变量：`QZ_UPDATE_REPO`（默认 `mllt992/qing-zhou`）、`QZ_UPDATE_GITHUB_TOKEN`（提升 GitHub API 速率上限）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)