### PR TITLE
fix(sbstats): 统计轮询每分钟给每个节点漏一个 sshd

### DIFF
--- a/internal/sbctl/controller.go
+++ b/internal/sbctl/controller.go
@@ -559,6 +559,12 @@ func (c *Controller) remoteStats(ctx context.Context) []remoteResult {
 			client := sbstats.NewWithDialer(listen, func(dctx context.Context, _, addr string) (net.Conn, error) {
 				return c.remoteMgr.DialTunnel(dctx, cfg, addr)
 			})
+			// This client is built fresh every poll, so it must be released:
+			// each tunnel it dials carries its own *ssh.Client, which stays
+			// alive — as a live sshd session on the node — until the connection
+			// is closed. One poll per minute per server otherwise piles up
+			// sshd processes on the node until it runs out of memory.
+			defer client.Close()
 			t, err := client.QueryUserTraffic(sctx)
 			if err != nil {
 				err = fmt.Errorf("server %d (%s) stats: %w", sv.ID, sv.Name, err)

--- a/internal/sbstats/client.go
+++ b/internal/sbstats/client.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/net/http2"
@@ -38,9 +39,20 @@ type Traffic struct {
 const fullMethod = "/v2ray.core.app.stats.command.StatsService/QueryStats"
 
 // Client queries a sing-box v2ray_api gRPC endpoint over cleartext HTTP/2.
+//
+// A Client owns its transport and every connection that transport dialled, so a
+// caller that builds one per poll MUST Close it — see Close for why.
 type Client struct {
 	addr string // host:port of experimental.v2ray_api.listen
 	hc   *http.Client
+	tr   *http2.Transport
+
+	// dialed records every connection handed to the transport so Close can
+	// force them shut. The transport pools connections and never drops them on
+	// its own, and nothing here is reachable once the Client goes out of scope —
+	// GC does not close sockets.
+	mu     sync.Mutex
+	dialed []net.Conn
 }
 
 // DialFunc opens the transport connection to the stats endpoint.
@@ -59,13 +71,52 @@ func New(addr string) *Client {
 // Remote nodes bind the stats API on loopback, so their traffic can only be
 // collected through an SSH tunnel — see sshctl.RemoteManager.DialTunnel.
 func NewWithDialer(addr string, dial DialFunc) *Client {
-	tr := &http2.Transport{
+	c := &Client{addr: addr}
+	c.tr = &http2.Transport{
 		AllowHTTP: true, // h2c: prior-knowledge HTTP/2 over plaintext TCP
 		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-			return dial(ctx, network, addr)
+			conn, err := dial(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			c.mu.Lock()
+			c.dialed = append(c.dialed, conn)
+			c.mu.Unlock()
+			return conn, nil
 		},
 	}
-	return &Client{addr: addr, hc: &http.Client{Transport: tr, Timeout: 10 * time.Second}}
+	c.hc = &http.Client{Transport: c.tr, Timeout: 10 * time.Second}
+	return c
+}
+
+// Close releases every connection this Client opened. Callers that build a
+// Client per poll must call it; a long-lived Client (the local instance, which
+// dials 127.0.0.1 directly) can skip it and keep its pooled connection.
+//
+// This matters far beyond a stray socket when the dialer is an SSH tunnel:
+// sshctl's tunnelConn owns the *ssh.Client carrying it, so a connection that is
+// never closed keeps a full SSH session alive on the remote node. Stats polling
+// runs every minute per server, so skipping Close leaks one sshd process per
+// node per minute — enough to exhaust a small VPS in hours.
+func (c *Client) Close() error {
+	// Graceful path: hands pooled connections back so the transport stops
+	// tracking them.
+	c.tr.CloseIdleConnections()
+
+	// Force path: a request that failed mid-flight (context deadline, tunnel
+	// hiccup) can leave its connection marked busy, where CloseIdleConnections
+	// will not touch it. Closing directly is what actually guarantees the SSH
+	// session underneath goes away. Errors are ignored: a connection the
+	// graceful path already closed reports net.ErrClosed here, which is the
+	// expected case rather than a failure.
+	c.mu.Lock()
+	conns := c.dialed
+	c.dialed = nil
+	c.mu.Unlock()
+	for _, conn := range conns {
+		_ = conn.Close()
+	}
+	return nil
 }
 
 // QueryUserTraffic returns each user's up/down delta since the previous call

--- a/internal/sbstats/client_test.go
+++ b/internal/sbstats/client_test.go
@@ -1,0 +1,112 @@
+package sbstats
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// trackedConn records whether it was actually closed, which is the only thing
+// that releases the SSH client underneath a tunnelled connection in production.
+type trackedConn struct {
+	net.Conn
+	mu     sync.Mutex
+	closed bool
+}
+
+func (c *trackedConn) Close() error {
+	c.mu.Lock()
+	c.closed = true
+	c.mu.Unlock()
+	return c.Conn.Close()
+}
+
+func (c *trackedConn) isClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
+}
+
+// A stats poll dials a fresh connection every time, and when the dialer is
+// sshctl's tunnel that connection owns a whole *ssh.Client — closing it is what
+// ends the sshd session on the remote node. The transport pools connections and
+// never closes them on its own, so a Client that is dropped without Close leaks
+// one sshd process per node per minute; a 1-core VPS ran out of memory in hours
+// this way. The poll failing changes nothing: the connection was still dialled,
+// and a request that died mid-flight leaves it marked busy, where
+// CloseIdleConnections alone will not touch it.
+func TestClose_ClosesDialedConns_EvenWhenPollFails(t *testing.T) {
+	// Accept connections but never speak HTTP/2, so the request hangs until the
+	// context expires — the mid-flight failure the force path exists for.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	var (
+		acceptedMu sync.Mutex
+		accepted   []net.Conn
+	)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			acceptedMu.Lock()
+			accepted = append(accepted, conn) // hold it open, stay silent
+			acceptedMu.Unlock()
+		}
+	}()
+	defer func() {
+		acceptedMu.Lock()
+		for _, c := range accepted {
+			c.Close()
+		}
+		acceptedMu.Unlock()
+	}()
+
+	var (
+		dialedMu sync.Mutex
+		dialed   []*trackedConn
+	)
+	client := NewWithDialer(ln.Addr().String(), func(ctx context.Context, network, addr string) (net.Conn, error) {
+		raw, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		tc := &trackedConn{Conn: raw}
+		dialedMu.Lock()
+		dialed = append(dialed, tc)
+		dialedMu.Unlock()
+		return tc, nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	if _, err := client.QueryUserTraffic(ctx); err == nil {
+		t.Fatal("expected the poll to fail against a silent listener")
+	}
+
+	dialedMu.Lock()
+	n := len(dialed)
+	dialedMu.Unlock()
+	if n == 0 {
+		t.Fatal("dialer was never called; test proves nothing about Close")
+	}
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	dialedMu.Lock()
+	defer dialedMu.Unlock()
+	for i, c := range dialed {
+		if !c.isClosed() {
+			t.Errorf("conn %d still open after Close: leaks an sshd session on the node", i)
+		}
+	}
+}


### PR DESCRIPTION
## 问题

节点 `192.220.9.75`（1 核 / 709MiB / 无 swap）内存耗尽，OOM killer 已触发 6 次。现场：

```
202 个 sshd 进程，201 条 ESTABLISHED，全部来自面板 IP
每 60 秒稳定新增一条，最老一条存活 6h31m
可用内存 18MiB
```

这些会话**没有子进程** —— 是 direct-tcpip 隧道而非 exec，对应读取 sing-box v2ray_api 的路径。

## 根因

`sbstats.Client` 没有释放入口：`http2.Transport` 建在 `NewWithDialer` 内部，只能经 `c.hc.Transport` 触及。而 `controller.remoteStats` 每轮轮询新建一个 Client，查一次就丢掉 —— `http2.Transport` 池化并无限期保活连接，GC 不关闭 socket。

dialer 是 SSH 隧道时后果被放大：`tunnelConn` 持有承载它的 `*ssh.Client`，连接不关，节点上就一直挂着完整的 sshd 会话。**每节点每分钟泄漏一个 sshd。**

## 改动

- `Client` 持有 transport 并记录 dialer 交出的每条连接，新增 `Close()`
- `remoteStats` 里 `defer client.Close()`
- 回归测试

`main.go` 的 `sbstats.New()` 是本地实例的长生命周期 client，**不**加 Close —— 它本就该保住池化连接。

## 关于 Close() 里的强制关闭

不是防御性冗余。请求中途失败（context 超时、隧道抖动）时连接被标记为 busy，`CloseIdleConnections()` 碰不到它，而这正是隧道最常见的失败形态。测试覆盖的就是这条路径。

变异验证：抽掉强制关闭后测试失败于 `conn 0 still open after Close`，确认测试有效而非摆设。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
