### PR TITLE
fix(sub): IPv6 节点链接被静默丢弃 + vmess TLS 误判为明文

### DIFF
--- a/frontend/src/views/UserSub.vue
+++ b/frontend/src/views/UserSub.vue
@@ -51,7 +51,11 @@
         <n-button size="small" @click="copy(sub.formats?.clash)">Clash</n-button>
         <n-button size="small" @click="copy(sub.formats?.singbox)">sing-box</n-button>
         <n-button size="small" @click="copy(sub.formats?.surge)">Surge</n-button>
-        <n-button size="small" @click="copy(sub.formats?.default)">通用</n-button>
+        <!-- formats.base64, not formats.default: default has no ?format= and so
+             picks its output from the client's User-Agent, which silently hands
+             YAML to anything whose UA contains "clash". This button is for
+             v2rayN / NekoBox / Shadowrocket, so it must pin the link list. -->
+        <n-button size="small" @click="copy(sub.formats?.base64 || sub.formats?.default)">通用 / v2rayN</n-button>
         <n-button size="small" @click="showQr=!showQr">{{ showQr?'隐藏':'显示' }}二维码</n-button>
         <n-button size="small" type="error" @click="handleResetSub">重置链接</n-button>
       </div>

--- a/internal/api/sb_admin.go
+++ b/internal/api/sb_admin.go
@@ -232,31 +232,61 @@ func validateCertKeyPair(certPEM, keyPEM string) error {
 // 3 samples and reports min/avg/max + resolve info. Used by the TLS editor to
 // preview how well a candidate SNI domain performs before saving, and by the
 // Reality handshake target test (which may use a non-443 port).
+// normalizeSniAddr turns a user-supplied host (and optional explicit port) into
+// a dialable host:port, or reports that the host is malformed.
+//
+// "是否已经带端口了" 曾用 strings.Contains(host, ":") 判断，裸 IPv6 字面量天生
+// 含冒号，于是既不补端口、后面的 SplitHostPort 又解析不了，任何 IPv6 host 都
+// 直接被判 "host 格式错误"。改用 SplitHostPort 试解析：成功即说明已带端口。
+//
+// 但只做这一步会让校验变宽松：JoinHostPort 会给任何含冒号的 host 加方括号，
+// 于是 "a:b:c" 这类垃圾会被包成 "[a:b:c]:443" 一路通过，最终以 "无法连接"
+// 而不是 "格式错误" 报错，掩盖了真正的原因。所以含冒号的 host 必须真的能被
+// ParseIP 解析成 IP 才放行。
+func normalizeSniAddr(host, port string) (string, error) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return "", fmt.Errorf("empty host")
+	}
+	// 已经是 host:port（含 [v6]:port）就原样用，显式 port 参数让位于内联端口。
+	// 注意 SplitHostPort(":443") 是成功的（host 为空），必须单独挡掉。
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		if h == "" {
+			return "", fmt.Errorf("empty host in %q", host)
+		}
+		return host, nil
+	}
+	if port == "" {
+		port = "443"
+	}
+	h := host
+	if len(h) > 1 && h[0] == '[' && h[len(h)-1] == ']' {
+		h = h[1 : len(h)-1]
+	}
+	if h == "" {
+		return "", fmt.Errorf("empty host")
+	}
+	// 到这里 h 应当是域名或 IP 字面量。域名和 IPv4 都不含冒号；含冒号就只能是
+	// IPv6，必须解析得出来——否则是 "a:b:c" / "[2001:db8::1"（括号未闭合）之类。
+	if strings.Contains(h, ":") && net.ParseIP(h) == nil {
+		return "", fmt.Errorf("malformed host %q", host)
+	}
+	return net.JoinHostPort(h, port), nil
+}
+
 func (a *API) handleAdminSniTest(w http.ResponseWriter, r *http.Request) {
 	host := strings.TrimSpace(r.URL.Query().Get("host"))
 	if host == "" {
 		fail(w, http.StatusBadRequest, "缺少 host 参数")
 		return
 	}
-	// 显式 port 参数优先；否则从 host:port 解析；都没有则默认 443
-	//
-	// "已经带端口了吗" 不能用 strings.Contains(host, ":") 判断：裸 IPv6 字面量
-	// 天生含冒号，于是既不会被补端口，SplitHostPort 又解析不了，直接返回
-	// "host 格式错误"。改用 SplitHostPort 试解析——成功即说明已带端口。
-	addr := host
-	if _, _, err := net.SplitHostPort(host); err != nil {
-		port := strings.TrimSpace(r.URL.Query().Get("port"))
-		if port == "" {
-			port = "443"
-		}
-		addr = net.JoinHostPort(strings.Trim(host, "[]"), port)
-	}
-	// Validate hostname: reject obviously bad input.
-	h, _, err := net.SplitHostPort(addr)
-	if err != nil || h == "" {
+	addr, err := normalizeSniAddr(host, strings.TrimSpace(r.URL.Query().Get("port")))
+	if err != nil {
 		fail(w, http.StatusBadRequest, "host 格式错误")
 		return
 	}
+	// 回显给前端的是不带端口的主机名；normalizeSniAddr 已保证 addr 可拆分。
+	h, _, _ := net.SplitHostPort(addr)
 
 	type sample struct {
 		MS    float64 `json:"ms"`

--- a/internal/api/sb_admin.go
+++ b/internal/api/sb_admin.go
@@ -239,11 +239,17 @@ func (a *API) handleAdminSniTest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// 显式 port 参数优先；否则从 host:port 解析；都没有则默认 443
+	//
+	// "已经带端口了吗" 不能用 strings.Contains(host, ":") 判断：裸 IPv6 字面量
+	// 天生含冒号，于是既不会被补端口，SplitHostPort 又解析不了，直接返回
+	// "host 格式错误"。改用 SplitHostPort 试解析——成功即说明已带端口。
 	addr := host
-	if port := strings.TrimSpace(r.URL.Query().Get("port")); port != "" && !strings.Contains(host, ":") {
-		addr = host + ":" + port
-	} else if !strings.Contains(host, ":") {
-		addr = host + ":443"
+	if _, _, err := net.SplitHostPort(host); err != nil {
+		port := strings.TrimSpace(r.URL.Query().Get("port"))
+		if port == "" {
+			port = "443"
+		}
+		addr = net.JoinHostPort(strings.Trim(host, "[]"), port)
 	}
 	// Validate hostname: reject obviously bad input.
 	h, _, err := net.SplitHostPort(addr)

--- a/internal/api/sb_admin_test.go
+++ b/internal/api/sb_admin_test.go
@@ -1,0 +1,63 @@
+package api
+
+import "testing"
+
+// normalizeSniAddr had no coverage at all, and it sits in front of a dialer, so
+// both directions matter: every legitimate host shape must reach a dialable
+// address, and malformed input must be rejected here rather than surfacing later
+// as a misleading "unreachable".
+func TestNormalizeSniAddr(t *testing.T) {
+	cases := []struct {
+		name, host, port, want string
+		wantErr                bool
+	}{
+		// no inline port -> explicit port, else 443
+		{name: "domain", host: "example.com", want: "example.com:443"},
+		{name: "domain explicit port", host: "example.com", port: "8443", want: "example.com:8443"},
+		{name: "ipv4", host: "1.2.3.4", want: "1.2.3.4:443"},
+		{name: "ipv4 explicit port", host: "1.2.3.4", port: "8443", want: "1.2.3.4:8443"},
+
+		// inline port wins over the query param, matching the pre-existing contract
+		{name: "domain with port", host: "example.com:8443", port: "9999", want: "example.com:8443"},
+		{name: "ipv4 with port", host: "1.2.3.4:8443", want: "1.2.3.4:8443"},
+
+		// IPv6: the whole reason this function exists. A bare literal contains
+		// colons, so the old Contains(host, ":") check treated it as "already has
+		// a port" and every IPv6 host was rejected outright.
+		{name: "ipv6 bare", host: "2001:db8::1", want: "[2001:db8::1]:443"},
+		{name: "ipv6 bare explicit port", host: "2001:db8::1", port: "8443", want: "[2001:db8::1]:8443"},
+		{name: "ipv6 bracketed", host: "[2001:db8::1]", want: "[2001:db8::1]:443"},
+		{name: "ipv6 bracketed with port", host: "[2001:db8::1]:8443", want: "[2001:db8::1]:8443"},
+		{name: "ipv6 loopback", host: "::1", want: "[::1]:443"},
+
+		// malformed input must 400 here. Bracketing any colon-bearing host would
+		// have let these through to the dialer, turning "格式错误" into a much less
+		// useful "unreachable".
+		{name: "empty", host: "", wantErr: true},
+		{name: "blank", host: "   ", wantErr: true},
+		{name: "three segments", host: "host:port:extra", wantErr: true},
+		{name: "letters with colons", host: "a:b:c", wantErr: true},
+		{name: "unclosed bracket", host: "[2001:db8::1", wantErr: true},
+		{name: "unopened bracket", host: "2001:db8::1]", wantErr: true},
+		{name: "double bracketed", host: "[[2001:db8::1]]", wantErr: true},
+		{name: "empty brackets", host: "[]", wantErr: true},
+		{name: "port only", host: ":443", wantErr: true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := normalizeSniAddr(c.host, c.port)
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("normalizeSniAddr(%q, %q) = %q, want error", c.host, c.port, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeSniAddr(%q, %q) unexpected error: %v", c.host, c.port, err)
+			}
+			if got != c.want {
+				t.Errorf("normalizeSniAddr(%q, %q) = %q, want %q", c.host, c.port, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -294,6 +294,11 @@ func (a *API) handleSubscription(w http.ResponseWriter, r *http.Request) {
 			"clash":   base + "?format=clash",
 			"singbox": base + "?format=singbox",
 			"surge":   base + "?format=surge",
+			// The base64 link list (v2rayN / NekoBox / Shadowrocket / Quantumult).
+			// "default" also yields it today, but only by User-Agent fallback — a
+			// client that sends a UA containing "clash" silently gets YAML instead.
+			// This entry pins the format regardless of UA.
+			"base64": base + "?format=base64",
 		},
 	})
 }

--- a/internal/singbox/link.go
+++ b/internal/singbox/link.go
@@ -3,6 +3,7 @@ package singbox
 import (
 	"encoding/base64"
 	"encoding/json"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -19,6 +20,13 @@ type LinkParams struct {
 	UUID     string
 	Password string
 
+	// TLS reports whether the inbound actually has a TLS config attached
+	// (sb_inbounds.tls_id != 0). It is NOT derivable from SNI: server_name is
+	// optional and routinely empty on self-signed or bare-IP inbounds, so
+	// inferring TLS from "SNI != ''" silently renders those nodes as plaintext.
+	// vless/trojan sidestep this by being unconditionally TLS; vmess is the one
+	// protocol whose link has to carry the flag explicitly.
+	TLS         bool
 	SNI         string
 	PublicKey   string // reality pbk
 	ShortID     string // reality sid
@@ -144,7 +152,12 @@ func BuildShareLink(p LinkParams) string {
 	// prevents a stray reserved char (#/?&@) from producing a malformed or
 	// ambiguous link.
 	esc := url.QueryEscape
-	hp := p.Host + ":" + strconv.Itoa(p.Port)
+	// JoinHostPort, not concatenation: it brackets an IPv6 literal. Without that,
+	// a node at 2001:db8::1 rendered "…@2001:db8::1:443", whose port url.Parse
+	// cannot recover — so subconv's own validate() rejected it as "port out of
+	// range" and the node vanished from every subscription with no error shown.
+	// vmess is unaffected either way, since its JSON keeps add/port apart.
+	hp := net.JoinHostPort(p.Host, strconv.Itoa(p.Port))
 	frag := "#" + url.QueryEscape(p.Tag)
 
 	tcp := p.Network == "" || p.Network == "tcp"
@@ -222,9 +235,31 @@ func BuildShareLink(p LinkParams) string {
 		if p.Network == "grpc" {
 			m["path"] = p.ServiceName
 		}
-		if p.SNI != "" {
+		// Drive TLS off the inbound's real tls_id, not off SNI. An inbound with a
+		// certificate but no server_name (self-signed, bare IP) used to render
+		// tls:"" here, and every renderer downstream keys off this field —
+		// clash.go, singbox.go and surge.go all test VMess["tls"] == "tls" — so
+		// one empty server_name produced a plaintext node in *all four*
+		// subscription formats, not just the base64 one.
+		if p.TLS {
 			m["tls"] = "tls"
-			m["sni"] = p.SNI
+			if p.SNI != "" {
+				m["sni"] = p.SNI
+			}
+			// Unconditional, matching vless/trojan/tuic/hysteria2, which all
+			// append fp= with the same "chrome" default. fp is never empty here
+			// (it is defaulted above), so vmess nodes now always advertise a uTLS
+			// fingerprint where they previously advertised none.
+			m["fp"] = fp
+			if p.ALPN != "" {
+				m["alpn"] = p.ALPN
+			}
+			if p.Insecure {
+				// Not part of the v2rayN vmess schema (it has no such key), but
+				// 轻舟's own renderers read it back via Proxy.param, which falls
+				// through to the vmess JSON map. Clients that don't know it ignore it.
+				m["allowInsecure"] = "1"
+			}
 		} else {
 			m["tls"] = ""
 		}

--- a/internal/singbox/link.go
+++ b/internal/singbox/link.go
@@ -137,6 +137,30 @@ func (p LinkParams) transportQuery() []string {
 	}
 }
 
+// joinHostPort builds the authority of a share-link URI, bracketing an IPv6
+// literal as RFC 3986 requires.
+//
+// Two traps make this more than a call to net.JoinHostPort.
+//
+// First, plain concatenation is not actually harmless here. Go's url.Parse is
+// forgiving — it splits host and port at the *last* colon, so it recovers
+// "…@2001:db8::1:443" correctly and 轻舟's own pipeline round-trips it — but
+// that tolerance is Go's, not the spec's. v2rayN, mihomo and sing-box parse the
+// authority per RFC 3986, where an unbracketed IPv6 literal is malformed. So the
+// symptom is a node that looks fine in the panel and fails only in the client.
+//
+// Second, net.JoinHostPort brackets any host containing a colon without checking
+// whether it is already bracketed. An admin who writes [2001:db8::1] — which is
+// the natural way to type it, and what a Clash YAML often carries — would get
+// [[2001:db8::1]]:443, which really is unparseable everywhere, including here.
+// Strip a matched pair first.
+func joinHostPort(host, port string) string {
+	if len(host) > 1 && host[0] == '[' && host[len(host)-1] == ']' {
+		host = host[1 : len(host)-1]
+	}
+	return net.JoinHostPort(host, port)
+}
+
 // BuildShareLink renders a vless/tuic/hysteria2 URI matching the format clients
 // already use, so existing imports keep working after the cutover.
 func BuildShareLink(p LinkParams) string {
@@ -152,12 +176,7 @@ func BuildShareLink(p LinkParams) string {
 	// prevents a stray reserved char (#/?&@) from producing a malformed or
 	// ambiguous link.
 	esc := url.QueryEscape
-	// JoinHostPort, not concatenation: it brackets an IPv6 literal. Without that,
-	// a node at 2001:db8::1 rendered "…@2001:db8::1:443", whose port url.Parse
-	// cannot recover — so subconv's own validate() rejected it as "port out of
-	// range" and the node vanished from every subscription with no error shown.
-	// vmess is unaffected either way, since its JSON keeps add/port apart.
-	hp := net.JoinHostPort(p.Host, strconv.Itoa(p.Port))
+	hp := joinHostPort(p.Host, strconv.Itoa(p.Port))
 	frag := "#" + url.QueryEscape(p.Tag)
 
 	tcp := p.Network == "" || p.Network == "tcp"

--- a/internal/store/relay.go
+++ b/internal/store/relay.go
@@ -174,6 +174,7 @@ func (s *Store) relayOutbound(landing *SbInbound, serverCache map[int64]*Server,
 	lp := singbox.LinkParams{
 		Type: landing.Type, Tag: "relay", Host: host, Port: landing.ListenPort,
 		UUID: uuid, Password: pw,
+		TLS:         landing.TlsID != 0,
 		SNI:         mapStr(server, "server_name"),
 		Fingerprint: nestedStr(client, "utls", "fingerprint"),
 		Insecure:    mapBool(client, "insecure"),

--- a/internal/store/singbox.go
+++ b/internal/store/singbox.go
@@ -601,8 +601,8 @@ func (s *Store) BuildSelfBuiltLinks(u *User, host string) []SelfBuiltLink {
 			Congestion:  mapStr(opts, "congestion_control"),
 			ZeroRTT:     mapBool(opts, "zero_rtt_handshake"), // tuic 0-RTT
 			Method:      mapStr(opts, "method"),              // shadowsocks
-			ServerKey:   mapStr(opts, "password"), // shadowsocks-2022 server PSK
-			UpMbps:      mapInt(opts, "up_mbps"),  // hysteria v1
+			ServerKey:   mapStr(opts, "password"),            // shadowsocks-2022 server PSK
+			UpMbps:      mapInt(opts, "up_mbps"),             // hysteria v1
 			DownMbps:    mapInt(opts, "down_mbps"),
 			TCPFastOpen: mapBool(opts, "tcp_fast_open"),
 			MPTCP:       mapBool(opts, "tcp_multi_path"),

--- a/internal/store/singbox.go
+++ b/internal/store/singbox.go
@@ -594,6 +594,7 @@ func (s *Store) BuildSelfBuiltLinks(u *User, host string) []SelfBuiltLink {
 		p := singbox.LinkParams{
 			Type: ib.Type, Tag: remark + subInfoSuffixBucket(owner), Host: nodeHost, Port: ib.ListenPort,
 			UUID: owner.ClientUUID, Password: owner.ClientSecret,
+			TLS:         ib.TlsID != 0,
 			SNI:         mapStr(server, "server_name"),
 			Fingerprint: nestedStr(client, "utls", "fingerprint"),
 			Insecure:    mapBool(client, "insecure"),

--- a/internal/subconv/anytls_hysteria_test.go
+++ b/internal/subconv/anytls_hysteria_test.go
@@ -1,0 +1,218 @@
+package subconv
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"qingzhou/internal/singbox"
+)
+
+// renderedClashProxy renders one link and returns its Clash proxy map.
+func renderedClashProxy(t *testing.T, link string) map[string]any {
+	t.Helper()
+	out, err := Clash(ParseLinks([]string{link}), "")
+	if err != nil {
+		t.Fatalf("Clash: %v", err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("rendered Clash config is not valid YAML: %v", err)
+	}
+	list, _ := doc["proxies"].([]any)
+	if len(list) != 1 {
+		t.Fatalf("expected 1 proxy, got %d — node was dropped: %s", len(list), link)
+	}
+	m, _ := list[0].(map[string]any)
+	return m
+}
+
+// renderedSbOutbound returns the first outbound of the given type from a rendered config.
+func renderedSbOutbound(t *testing.T, link, typ string) map[string]any {
+	t.Helper()
+	out, err := Singbox(ParseLinks([]string{link}), "")
+	if err != nil {
+		t.Fatalf("Singbox: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("rendered sing-box config is not valid JSON: %v", err)
+	}
+	for _, ob := range mapSlice(doc["outbounds"]) {
+		if ob["type"] == typ {
+			return ob
+		}
+	}
+	t.Fatalf("no %q outbound — node was dropped: %s", typ, link)
+	return nil
+}
+
+// Both protocols used to be generated as share links but had no parse branch,
+// so ParseLinks dropped them: they appeared only in the base64 subscription
+// (which v2rayN cannot use for either protocol) and vanished from clash,
+// sing-box and Surge. They were unusable everywhere.
+func TestAnytlsAndHysteriaReachAllRenderers(t *testing.T) {
+	anytls := singbox.BuildShareLink(singbox.LinkParams{
+		Type: "anytls", Tag: "a", Host: "1.2.3.4", Port: 443,
+		Password: "pw", TLS: true, SNI: "a.com",
+	})
+	hy1 := singbox.BuildShareLink(singbox.LinkParams{
+		Type: "hysteria", Tag: "h", Host: "5.6.7.8", Port: 443,
+		Password: "authsecret", TLS: true, SNI: "b.com", UpMbps: 50, DownMbps: 200,
+	})
+
+	for _, c := range []struct{ name, link string }{{"anytls", anytls}, {"hysteria", hy1}} {
+		if got := ParseLinks([]string{c.link}); len(got) != 1 {
+			t.Fatalf("%s: link not parsed back: %q", c.name, c.link)
+		}
+	}
+
+	if got := renderedClashProxy(t, anytls)["type"]; got != "anytls" {
+		t.Errorf("clash anytls type = %v", got)
+	}
+	if got := renderedClashProxy(t, hy1)["type"]; got != "hysteria" {
+		t.Errorf("clash hysteria type = %v", got)
+	}
+	if got := renderedSbOutbound(t, anytls, "anytls")["password"]; got != "pw" {
+		t.Errorf("sing-box anytls password = %v", got)
+	}
+	if got := renderedSbOutbound(t, hy1, "hysteria")["auth_str"]; got != "authsecret" {
+		t.Errorf("sing-box hysteria auth_str = %v", got)
+	}
+
+	// Surge supports anytls but has no hysteria v1 policy, so v1 must stay skipped.
+	if surge := Surge(ParseLinks([]string{anytls}), ""); !strings.Contains(surge, "anytls, 1.2.3.4, 443") {
+		t.Errorf("surge missing anytls line:\n%s", surge)
+	}
+	if surge := Surge(ParseLinks([]string{hy1}), ""); strings.Contains(surge, "hysteria") {
+		t.Errorf("surge emitted hysteria v1, which it cannot express:\n%s", surge)
+	}
+}
+
+// mihomo's HysteriaOption declares up/down WITHOUT omitempty, so a node missing
+// them makes the decoder report "has unset fields: down, up" and reject the
+// ENTIRE config — every node gone, not just this one. They must always be
+// present, even when the link carries no bandwidth.
+func TestClashHysteriaAlwaysCarriesBandwidth(t *testing.T) {
+	noBandwidth := singbox.BuildShareLink(singbox.LinkParams{
+		Type: "hysteria", Tag: "h", Host: "5.6.7.8", Port: 443,
+		Password: "auth", TLS: true, SNI: "b.com", // UpMbps/DownMbps deliberately 0
+	})
+	m := renderedClashProxy(t, noBandwidth)
+	for _, k := range []string{"up", "down"} {
+		v, _ := m[k].(string)
+		if v == "" {
+			t.Errorf("clash hysteria %q is absent — this fails mihomo's whole config", k)
+		}
+	}
+
+	withBandwidth := renderedClashProxy(t, singbox.BuildShareLink(singbox.LinkParams{
+		Type: "hysteria", Tag: "h", Host: "5.6.7.8", Port: 443,
+		Password: "auth", TLS: true, SNI: "b.com", UpMbps: 50, DownMbps: 200,
+	}))
+	if withBandwidth["up"] != "50 Mbps" {
+		t.Errorf("up = %v, want \"50 Mbps\"", withBandwidth["up"])
+	}
+	if withBandwidth["down"] != "200 Mbps" {
+		t.Errorf("down = %v, want \"200 Mbps\"", withBandwidth["down"])
+	}
+}
+
+// The obfs naming is inverted between the two schemas and swapping them yields
+// a node that looks configured and silently fails to connect:
+//
+//	URI:    obfs = MODE ("xplus"),  obfsParam = PASSWORD
+//	mihomo: obfs = PASSWORD,        obfs-protocol = MODE
+func TestHysteriaObfsNamingNotSwapped(t *testing.T) {
+	link := "hysteria://1.2.3.4:443?auth=a&peer=x.com&upmbps=50&downmbps=200" +
+		"&obfs=xplus&obfsParam=secretpw#h"
+	m := renderedClashProxy(t, link)
+	if got := m["obfs"]; got != "secretpw" {
+		t.Errorf("clash obfs = %v, want the PASSWORD secretpw", got)
+	}
+	if got := m["obfs-protocol"]; got != "xplus" {
+		t.Errorf("clash obfs-protocol = %v, want the MODE xplus", got)
+	}
+	// sing-box has no field for the mode; its obfs is the XPlus password.
+	if got := renderedSbOutbound(t, link, "hysteria")["obfs"]; got != "secretpw" {
+		t.Errorf("sing-box obfs = %v, want the PASSWORD secretpw", got)
+	}
+}
+
+// sing-box's hysteria outbound constructor fails with ErrTLSRequired when tls is
+// missing or disabled, and that happens at startup — taking the whole config.
+func TestSingboxHysteriaAndAnytlsAlwaysHaveTLS(t *testing.T) {
+	for _, c := range []struct{ typ, link string }{
+		{"hysteria", "hysteria://1.2.3.4:443?auth=a&peer=x.com&upmbps=50&downmbps=200#h"},
+		{"anytls", "anytls://pw@1.2.3.4:443?sni=x.com#a"},
+	} {
+		tls, _ := renderedSbOutbound(t, c.link, c.typ)["tls"].(map[string]any)
+		if tls == nil {
+			t.Errorf("%s: no tls block", c.typ)
+			continue
+		}
+		if tls["enabled"] != true {
+			t.Errorf("%s: tls.enabled = %v, want true", c.typ, tls["enabled"])
+		}
+	}
+}
+
+// hysteria v1 spells SNI "peer"; normalising it at parse time is what lets every
+// renderer and sbTLS find it without special-casing this protocol.
+func TestHysteriaPeerNormalisedToSNI(t *testing.T) {
+	link := "hysteria://1.2.3.4:443?auth=a&peer=x.com&upmbps=50&downmbps=200#h"
+	if got := renderedClashProxy(t, link)["sni"]; got != "x.com" {
+		t.Errorf("clash sni = %v, want x.com", got)
+	}
+	tls, _ := renderedSbOutbound(t, link, "hysteria")["tls"].(map[string]any)
+	if tls["server_name"] != "x.com" {
+		t.Errorf("sing-box server_name = %v, want x.com", tls["server_name"])
+	}
+}
+
+// mihomo's AnyTLSOption.Password has no omitempty either, so a passwordless
+// anytls entry would fail the whole config. Drop the node instead.
+func TestAnytlsWithoutPasswordDropped(t *testing.T) {
+	if got := ParseLinks([]string{"anytls://@1.2.3.4:443?sni=x.com#a"}); len(got) != 0 {
+		t.Errorf("passwordless anytls survived: %+v", got[0])
+	}
+	if got := ParseLinks([]string{"anytls://pw@1.2.3.4:443?sni=x.com#a"}); len(got) != 1 {
+		t.Error("anytls with a password was dropped")
+	}
+}
+
+// Clash YAML import must round-trip both protocols, including the bandwidth
+// forms mihomo accepts ("100", "100 Mbps", and the separate up-speed field).
+func TestClashImportOfAnytlsAndHysteria(t *testing.T) {
+	yaml := `proxies:
+  - {name: a, type: anytls, server: 1.2.3.4, port: 443, password: pw, sni: a.com, skip-cert-verify: true}
+  - {name: h1, type: hysteria, server: 5.6.7.8, port: 443, auth-str: s, up: "50 Mbps", down: "200 Mbps", sni: b.com}
+  - {name: h2, type: hysteria, server: 5.6.7.9, port: 443, auth-str: s, up: 30, down: 60, sni: b.com}
+`
+	byName := map[string]*Proxy{}
+	for _, p := range ParseList(yaml) {
+		byName[p.Name] = p
+	}
+	for _, n := range []string{"a", "h1", "h2"} {
+		if byName[n] == nil {
+			t.Fatalf("node %q dropped on import", n)
+		}
+	}
+	if byName["a"].Protocol != "anytls" || byName["a"].Password != "pw" {
+		t.Errorf("anytls imported wrong: %+v", byName["a"])
+	}
+	if !byName["a"].tlsInsecure() {
+		t.Error("anytls skip-cert-verify lost on import")
+	}
+	if got := byName["h1"].param("upmbps"); got != "50" {
+		t.Errorf(`h1 upmbps = %q, want 50 (from "50 Mbps")`, got)
+	}
+	if got := byName["h2"].param("downmbps"); got != "60" {
+		t.Errorf("h2 downmbps = %q, want 60 (from bare 60)", got)
+	}
+	if got := byName["h1"].param("auth"); got != "s" {
+		t.Errorf("h1 auth = %q, want s", got)
+	}
+}

--- a/internal/subconv/clash.go
+++ b/internal/subconv/clash.go
@@ -203,6 +203,56 @@ func clashProxy(p *Proxy) map[string]any {
 		if p.tlsInsecure() {
 			m["skip-cert-verify"] = true
 		}
+	case "anytls":
+		// Requires mihomo >= v1.19.3. An older core does not skip an unknown
+		// proxy type — ParseProxy returns "unsupport proxy type" and parseProxies
+		// fails the whole config — so this node's presence is all-or-nothing for
+		// the subscriber. Same story for sing-box < 1.12.0.
+		m["type"] = "anytls"
+		m["password"] = p.Password
+		m["udp"] = true
+		if v := p.param("sni"); v != "" {
+			m["sni"] = v
+		}
+		if v := p.tlsParam("fp"); v != "" {
+			m["client-fingerprint"] = v
+		}
+		if v := p.tlsParam("alpn"); v != "" {
+			m["alpn"] = strings.Split(v, ",")
+		}
+		if p.tlsInsecure() {
+			m["skip-cert-verify"] = true
+		}
+	case "hysteria":
+		m["type"] = "hysteria"
+		if v := p.param("auth"); v != "" {
+			m["auth-str"] = v // v1 credential; hysteria2's `password` does not apply
+		}
+		// Always emitted — see hysteriaBandwidth for why omitting is fatal.
+		m["up"] = hysteriaBandwidth(p.param("upmbps"))
+		m["down"] = hysteriaBandwidth(p.param("downmbps"))
+		if v := p.param("sni"); v != "" { // normalised from `peer` at parse time
+			m["sni"] = v
+		}
+		if v := p.param("protocol"); v != "" {
+			m["protocol"] = v // udp | wechat-video | faketcp
+		}
+		// The obfs naming is inverted between the two schemas, and swapping them
+		// yields a node that handshakes and then silently fails: in the URI
+		// `obfs` is the MODE (empty or "xplus") and `obfsParam` is the password,
+		// while mihomo's `obfs` is the PASSWORD and `obfs-protocol` is the mode.
+		if v := p.param("obfsParam"); v != "" {
+			m["obfs"] = v
+		}
+		if v := p.param("obfs"); v != "" {
+			m["obfs-protocol"] = v
+		}
+		if v := p.tlsParam("alpn"); v != "" {
+			m["alpn"] = strings.Split(v, ",")
+		}
+		if p.tlsInsecure() {
+			m["skip-cert-verify"] = true
+		}
 	case "tuic":
 		m["type"] = "tuic"
 		m["uuid"] = p.UUID

--- a/internal/subconv/clash.go
+++ b/internal/subconv/clash.go
@@ -145,7 +145,7 @@ func clashProxy(p *Proxy) map[string]any {
 			m["reality-opts"] = ro
 		}
 		clashWS(m, p, network, p.param("path"), p.param("host"))
-		if p.param("allowInsecure", "insecure") == "1" {
+		if p.tlsInsecure() {
 			m["skip-cert-verify"] = true
 		}
 	case "vmess":
@@ -164,6 +164,19 @@ func clashProxy(p *Proxy) map[string]any {
 			if sni := str(p.VMess["sni"]); sni != "" {
 				m["servername"] = sni
 			}
+			// vmess used to stop at servername, so a self-signed inbound failed
+			// certificate verification here with no way to express the exemption
+			// the other protocols already had. tlsParam reaches into the vmess
+			// JSON map, where a vmess:// link keeps these instead of a query.
+			if v := p.tlsParam("fp"); v != "" {
+				m["client-fingerprint"] = v
+			}
+			if v := p.tlsParam("alpn"); v != "" {
+				m["alpn"] = strings.Split(v, ",")
+			}
+			if p.tlsInsecure() {
+				m["skip-cert-verify"] = true
+			}
 		}
 		clashWS(m, p, network, str(p.VMess["path"]), str(p.VMess["host"]))
 	case "ss":
@@ -178,7 +191,7 @@ func clashProxy(p *Proxy) map[string]any {
 		if v := p.param("sni", "peer"); v != "" {
 			m["sni"] = v
 		}
-		if p.param("allowInsecure", "insecure") == "1" {
+		if p.tlsInsecure() {
 			m["skip-cert-verify"] = true
 		}
 	case "hysteria2":
@@ -187,7 +200,7 @@ func clashProxy(p *Proxy) map[string]any {
 		if v := p.param("sni"); v != "" {
 			m["sni"] = v
 		}
-		if p.param("insecure", "allowInsecure") == "1" {
+		if p.tlsInsecure() {
 			m["skip-cert-verify"] = true
 		}
 	case "tuic":
@@ -206,7 +219,7 @@ func clashProxy(p *Proxy) map[string]any {
 		if p.param("zero_rtt", "reduce_rtt") == "1" {
 			m["reduce-rtt"] = true
 		}
-		if p.param("allow_insecure", "insecure", "allowInsecure") == "1" {
+		if p.tlsInsecure() {
 			m["skip-cert-verify"] = true
 		}
 	default:
@@ -274,7 +287,7 @@ func injectRouteExclude(doc map[string]any, proxies []*Proxy) {
 		// every entry as a CIDR, so a bare domain (net.ParseIP == nil) would be
 		// an invalid entry that breaks config loading and kills TUN entirely.
 		// Domain nodes are handled by injectNodeDomains instead.
-		if ip := net.ParseIP(p.Server); ip != nil && !ip.IsPrivate() {
+		if isPublicIP(p.Server) {
 			seen[p.Server] = true
 		}
 	}
@@ -330,12 +343,25 @@ func injectNodeDomains(doc map[string]any, proxies []*Proxy) {
 func stringList(v any) ([]string, map[string]bool) {
 	out := []string{}
 	present := map[string]bool{}
-	if list, ok := v.([]any); ok {
+	add := func(s string) {
+		out = append(out, s)
+		present[s] = true
+	}
+	// Both shapes must be handled, exactly as in mapSlice: an admin template
+	// arrives through json.Unmarshal and yields []any, while the Go-built
+	// default inbounds carry a literal []string. Handling only []any silently
+	// drops the built-in exclusions (fe80::/10, ff00::/8) the moment anything
+	// appends to the list, since the caller writes `existing` back wholesale.
+	switch list := v.(type) {
+	case []any:
 		for _, item := range list {
 			if s, ok := item.(string); ok {
-				out = append(out, s)
-				present[s] = true
+				add(s)
 			}
+		}
+	case []string:
+		for _, s := range list {
+			add(s)
 		}
 	}
 	return out, present
@@ -350,6 +376,22 @@ func sortedKeys(set map[string]bool) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// isPublicIP reports whether s is an IP literal that can sensibly appear in a
+// route-exclude list — i.e. a routable unicast address.
+//
+// net.IP.IsPrivate alone is not that test. For IPv6 it only covers ULA
+// (fc00::/7), so a link-local node address (fe80::/10) passes it and gets
+// injected as an exclusion; the same goes for loopback and IPv4 link-local
+// (169.254.0.0/16). Those are never valid node addresses, and excluding them
+// from the tunnel is at best meaningless.
+func isPublicIP(s string) bool {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return false
+	}
+	return ip.IsGlobalUnicast() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast()
 }
 
 // ensureCIDR appends "/32" (IPv4) or "/128" (IPv6) to bare IP addresses.

--- a/internal/subconv/clash_parse.go
+++ b/internal/subconv/clash_parse.go
@@ -54,10 +54,15 @@ func clashToLink(m map[string]any) string {
 	if server == "" || port == "" {
 		return ""
 	}
-	// Same IPv6 bracketing requirement as singbox.BuildShareLink: an imported
-	// Clash node with server 2001:db8::1 produced an unparseable URI, so those
-	// nodes were dropped on re-export instead of round-tripping.
-	addr := net.JoinHostPort(server, port)
+	// Same bracketing rules as singbox.joinHostPort — see the reasoning there.
+	// Kept as a local copy rather than shared: it is five lines, and reaching
+	// across into the singbox package for it would invert the dependency.
+	//
+	// The already-bracketed case is the one that matters most on this path:
+	// Clash YAML in the wild carries both `server: 2001:db8::1` and
+	// `server: "[2001:db8::1]"`, and a naive JoinHostPort turns the second into
+	// [[…]] and drops the node.
+	addr := joinHostPort(server, port)
 	frag := ""
 	if name := str(m["name"]); name != "" {
 		frag = "#" + url.QueryEscape(name)
@@ -221,6 +226,15 @@ func alpnStr(v any) string {
 		return x
 	}
 	return ""
+}
+
+// joinHostPort mirrors singbox.joinHostPort: bracket an IPv6 literal for a URI
+// authority, and tolerate a host that already carries brackets.
+func joinHostPort(host, port string) string {
+	if len(host) > 1 && host[0] == '[' && host[len(host)-1] == ']' {
+		host = host[1 : len(host)-1]
+	}
+	return net.JoinHostPort(host, port)
 }
 
 func cbool(v any) bool {

--- a/internal/subconv/clash_parse.go
+++ b/internal/subconv/clash_parse.go
@@ -3,6 +3,7 @@ package subconv
 import (
 	"encoding/base64"
 	"encoding/json"
+	"net"
 	"net/url"
 	"strings"
 
@@ -53,7 +54,10 @@ func clashToLink(m map[string]any) string {
 	if server == "" || port == "" {
 		return ""
 	}
-	addr := server + ":" + port
+	// Same IPv6 bracketing requirement as singbox.BuildShareLink: an imported
+	// Clash node with server 2001:db8::1 produced an unparseable URI, so those
+	// nodes were dropped on re-export instead of round-tripping.
+	addr := net.JoinHostPort(server, port)
 	frag := ""
 	if name := str(m["name"]); name != "" {
 		frag = "#" + url.QueryEscape(name)
@@ -118,6 +122,20 @@ func clashToLink(m map[string]any) string {
 			j["tls"] = "tls"
 			if v := str(m["servername"]); v != "" {
 				j["sni"] = v
+			}
+			// The mirror of the render-side gap: vmess stopped at servername here
+			// while vless and trojan above already carried skip-cert-verify across.
+			// Importing a Clash subscription with a self-signed vmess node dropped
+			// the exemption at parse time, so no amount of fixing the renderers
+			// could bring it back on re-export.
+			if cbool(m["skip-cert-verify"]) {
+				j["allowInsecure"] = "1"
+			}
+			if v := str(m["client-fingerprint"]); v != "" {
+				j["fp"] = v
+			}
+			if v := alpnStr(m["alpn"]); v != "" {
+				j["alpn"] = v
 			}
 		}
 		if strOr(str(m["network"]), "tcp") == "ws" {

--- a/internal/subconv/clash_parse.go
+++ b/internal/subconv/clash_parse.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -181,6 +182,64 @@ func clashToLink(m map[string]any) string {
 		}
 		return "hysteria2://" + str(m["password"]) + "@" + addr + qstr(q) + frag
 
+	case "anytls":
+		// Only sni and insecure are in the official anytls URI scheme; alpn/fp
+		// are 轻舟 extensions that conforming parsers ignore, kept so our own
+		// renderers round-trip without loss.
+		q := url.Values{}
+		if v := str(m["sni"]); v != "" {
+			q.Set("sni", v)
+		}
+		if cbool(m["skip-cert-verify"]) {
+			q.Set("insecure", "1")
+		}
+		if v := str(m["client-fingerprint"]); v != "" {
+			q.Set("fp", v)
+		}
+		if v := alpnStr(m["alpn"]); v != "" {
+			q.Set("alpn", v)
+		}
+		return "anytls://" + url.QueryEscape(str(m["password"])) + "@" + addr + qstr(q) + frag
+
+	case "hysteria":
+		// hysteria v1, NOT hysteria2 — a different wire protocol with auth-str
+		// and mandatory bandwidth instead of a password. It used to fall through
+		// to the default and be dropped, because the alternative at the time was
+		// rendering it as hysteria2:// and shipping a node with an empty
+		// credential that could never connect.
+		q := url.Values{}
+		// No userinfo in this scheme: the credential is the `auth` param.
+		if v := strOr(str(m["auth-str"]), str(m["auth_str"])); v != "" {
+			q.Set("auth", v)
+		}
+		if v := str(m["sni"]); v != "" {
+			q.Set("peer", v) // v1 spells SNI "peer"
+		}
+		if v := hysteriaMbps(m["up"], m["up-speed"]); v != "" {
+			q.Set("upmbps", v)
+		}
+		if v := hysteriaMbps(m["down"], m["down-speed"]); v != "" {
+			q.Set("downmbps", v)
+		}
+		if v := str(m["protocol"]); v != "" {
+			q.Set("protocol", v)
+		}
+		// Inverted naming, same trap as the render side: mihomo's obfs is the
+		// password (URI obfsParam) and obfs-protocol is the mode (URI obfs).
+		if v := str(m["obfs"]); v != "" {
+			q.Set("obfsParam", v)
+		}
+		if v := str(m["obfs-protocol"]); v != "" {
+			q.Set("obfs", v)
+		}
+		if v := alpnStr(m["alpn"]); v != "" {
+			q.Set("alpn", v)
+		}
+		if cbool(m["skip-cert-verify"]) {
+			q.Set("insecure", "1")
+		}
+		return "hysteria://" + addr + qstr(q) + frag
+
 	case "tuic":
 		q := url.Values{}
 		if v := str(m["sni"]); v != "" {
@@ -235,6 +294,28 @@ func joinHostPort(host, port string) string {
 		host = host[1 : len(host)-1]
 	}
 	return net.JoinHostPort(host, port)
+}
+
+// hysteriaMbps extracts a plain Mbps number from mihomo's bandwidth fields.
+//
+// `up`/`down` are strings that may or may not carry a unit ("100", "100 Mbps",
+// "1 Gbps"); `up-speed`/`down-speed` are plain integer Mbps. The v1 URI scheme
+// only has room for a bare Mbps integer, so a non-Mbps unit cannot be preserved
+// — returning "" then lets the renderer fall back to its default rather than
+// emitting a number that means something else.
+func hysteriaMbps(val, speed any) string {
+	if s := strings.TrimSpace(str(val)); s != "" {
+		fields := strings.Fields(s)
+		if n := atoi(fields[0]); n > 0 {
+			if len(fields) == 1 || strings.EqualFold(fields[1], "Mbps") {
+				return strconv.Itoa(n)
+			}
+		}
+	}
+	if n := atoi(str(speed)); n > 0 {
+		return strconv.Itoa(n)
+	}
+	return ""
 }
 
 func cbool(v any) bool {

--- a/internal/subconv/ipv6_test.go
+++ b/internal/subconv/ipv6_test.go
@@ -106,55 +106,87 @@ func TestStringListAcceptsBothShapes(t *testing.T) {
 
 // --- IPv6 node addresses ----------------------------------------------------
 
-// An IPv6 node address must be bracketed in the share link. Concatenating
-// host+":"+port yielded "…@2001:db8::1:443", whose port url.Parse cannot
-// recover, so validate() rejected it as "port out of range" and the node
-// disappeared from every subscription format with nothing shown to the user.
-func TestIPv6NodeSurvivesLinkRoundTrip(t *testing.T) {
-	for _, typ := range []string{"vless", "trojan", "vmess", "hysteria2", "tuic"} {
+// hpProtocols are the share-link types whose authority goes through
+// joinHostPort. vmess is deliberately absent: its base64 JSON keeps add and port
+// in separate fields, so it never builds a host:port string at all.
+var hpProtocols = []string{"vless", "trojan", "hysteria2", "tuic", "shadowsocks", "anytls", "hysteria"}
+
+// An IPv6 authority must be bracketed, per RFC 3986.
+//
+// The assertion is on the link TEXT on purpose. Asserting a parse round-trip
+// proves nothing here: Go's url.Parse splits host and port at the LAST colon, so
+// it recovers "…@2001:db8::1:443" perfectly and this package round-trips the
+// unbracketed form just fine. The clients do not — v2rayN, mihomo and sing-box
+// parse the authority per spec — so the bug is invisible to a round-trip test
+// and only shows up in the client.
+func TestIPv6LinkAuthorityIsBracketed(t *testing.T) {
+	for _, typ := range hpProtocols {
 		link := singbox.BuildShareLink(singbox.LinkParams{
 			Type: typ, Tag: "v6", Host: "2001:db8::1", Port: 443, UUID: "u",
-			Password: "pw", TLS: true, SNI: "a.com",
+			Password: "pw", Method: "2022-blake3-aes-128-gcm", TLS: true, SNI: "a.com",
 		})
 		if link == "" {
 			t.Errorf("%s: no link built", typ)
 			continue
 		}
-		proxies := ParseLinks([]string{link})
+		if !strings.Contains(link, "[2001:db8::1]:443") {
+			t.Errorf("%s: authority not bracketed: %q", typ, link)
+		}
+	}
+}
+
+// A host that already carries brackets must not gain a second pair. This is the
+// regression the naive net.JoinHostPort introduced: [2001:db8::1] became
+// [[2001:db8::1]]:443, which really is unparseable everywhere — so a node that
+// worked before started being dropped.
+func TestAlreadyBracketedIPv6HostNotDoubled(t *testing.T) {
+	for _, typ := range hpProtocols {
+		link := singbox.BuildShareLink(singbox.LinkParams{
+			Type: typ, Tag: "v6", Host: "[2001:db8::1]", Port: 443, UUID: "u",
+			Password: "pw", Method: "2022-blake3-aes-128-gcm", TLS: true, SNI: "a.com",
+		})
+		if strings.Contains(link, "[[") {
+			t.Errorf("%s: host double-bracketed: %q", typ, link)
+		}
+		if !strings.Contains(link, "[2001:db8::1]:443") {
+			t.Errorf("%s: authority not bracketed exactly once: %q", typ, link)
+		}
+	}
+}
+
+// An IPv4 host or a domain must never acquire brackets.
+func TestNonIPv6HostUnbracketed(t *testing.T) {
+	for _, host := range []string{"1.2.3.4", "example.com"} {
+		for _, typ := range hpProtocols {
+			link := singbox.BuildShareLink(singbox.LinkParams{
+				Type: typ, Tag: "n", Host: host, Port: 443, UUID: "u",
+				Password: "pw", Method: "2022-blake3-aes-128-gcm", TLS: true, SNI: "a.com",
+			})
+			if strings.Contains(link, "[") {
+				t.Errorf("%s/%s: host was bracketed: %q", typ, host, link)
+			}
+		}
+	}
+}
+
+// The Clash-YAML import path applies the same rules, for both input shapes.
+func TestClashImportBracketsIPv6Authority(t *testing.T) {
+	for _, server := range []string{`"2001:db8::1"`, `"[2001:db8::1]"`} {
+		yaml := "proxies:\n  - {name: v6, type: trojan, server: " + server +
+			", port: 443, password: pw, sni: a.com}\n"
+		proxies := ParseList(yaml)
 		if len(proxies) != 1 {
-			t.Errorf("%s: node dropped during parse — link was %q", typ, link)
-			continue
+			t.Fatalf("server %s: node dropped on import, got %d proxies", server, len(proxies))
+		}
+		if strings.Contains(proxies[0].Raw, "[[") {
+			t.Errorf("server %s: double-bracketed link %q", server, proxies[0].Raw)
+		}
+		if !strings.Contains(proxies[0].Raw, "[2001:db8::1]:443") {
+			t.Errorf("server %s: authority not bracketed: %q", server, proxies[0].Raw)
 		}
 		if got := proxies[0].Server; got != "2001:db8::1" {
-			t.Errorf("%s: server = %q, want 2001:db8::1", typ, got)
+			t.Errorf("server %s: parsed server = %q", server, got)
 		}
-		if got := proxies[0].Port; got != 443 {
-			t.Errorf("%s: port = %d, want 443", typ, got)
-		}
-	}
-}
-
-// An IPv4 node must not acquire brackets.
-func TestIPv4NodeLinkUnbracketed(t *testing.T) {
-	link := singbox.BuildShareLink(singbox.LinkParams{
-		Type: "trojan", Tag: "v4", Host: "1.2.3.4", Port: 443, Password: "pw", TLS: true,
-	})
-	if strings.Contains(link, "[") {
-		t.Errorf("IPv4 host was bracketed: %q", link)
-	}
-}
-
-// The Clash-YAML import path has the same bracketing requirement on re-export.
-func TestClashImportOfIPv6NodeRoundTrips(t *testing.T) {
-	yaml := `proxies:
-  - {name: v6, type: trojan, server: "2001:db8::1", port: 443, password: pw, sni: a.com}
-`
-	proxies := ParseList(yaml)
-	if len(proxies) != 1 {
-		t.Fatalf("IPv6 node dropped on Clash import, got %d proxies", len(proxies))
-	}
-	if got := proxies[0].Server; got != "2001:db8::1" {
-		t.Errorf("server = %q, want 2001:db8::1", got)
 	}
 }
 

--- a/internal/subconv/ipv6_test.go
+++ b/internal/subconv/ipv6_test.go
@@ -1,0 +1,307 @@
+package subconv
+
+import (
+	"encoding/json"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"qingzhou/internal/singbox"
+)
+
+// tunInbound pulls the TUN inbound out of a rendered sing-box config.
+func tunInbound(t *testing.T, cfg string) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(cfg), &doc); err != nil {
+		t.Fatalf("render is not valid JSON: %v", err)
+	}
+	for _, ib := range mapSlice(doc["inbounds"]) {
+		if ib["type"] == "tun" {
+			return ib
+		}
+	}
+	t.Fatal("no tun inbound in rendered config")
+	return nil
+}
+
+func renderDefault(t *testing.T, links ...string) string {
+	t.Helper()
+	out, err := Singbox(ParseLinks(links), DefaultSingboxTemplate)
+	if err != nil {
+		t.Fatalf("Singbox: %v", err)
+	}
+	return out
+}
+
+// The DNS half of DefaultSingboxTemplate answers AAAA out of fakeip.inet6_range
+// (fc00::/18). If the TUN carries no inet6 prefix, auto_route installs no IPv6
+// route and every one of those fake addresses is unroutable: AAAA-resolved
+// connections fail with ENETUNREACH and IPv6-only domains are dead. The two
+// halves have to stay in sync.
+func TestTunCarriesIPv6WhenFakeipHandsOutIPv6(t *testing.T) {
+	if !strings.Contains(DefaultSingboxTemplate, "inet6_range") {
+		t.Skip("template no longer fake-ips IPv6; TUN inet6 prefix not required")
+	}
+	addrs, _ := stringList(tunInbound(t, renderDefault(t, "trojan://pw@1.2.3.4:443?sni=a.com#n"))["address"])
+	var v6 bool
+	for _, a := range addrs {
+		// Parse rather than looking for a colon: "not-an-address:" would satisfy
+		// a substring check while being nothing sing-box can bind.
+		p, err := netip.ParsePrefix(a)
+		if err != nil {
+			t.Errorf("tun.address entry %q is not a valid prefix: %v", a, err)
+			continue
+		}
+		if p.Addr().Is6() {
+			v6 = true
+		}
+	}
+	if !v6 {
+		t.Errorf("tun.address has no IPv6 prefix, but DNS hands out fake IPv6: %v", addrs)
+	}
+}
+
+// fe80::/10 and ff00::/8 belong off-tunnel (neighbor discovery, SLAAC, mDNS).
+// fc00::/7 does NOT: fakeip allocates fc00::/18 from inside it, so excluding
+// the parent prefix would route every fake IPv6 back out of the tunnel.
+func TestTunExcludesIPv6LocalButNotFakeipParent(t *testing.T) {
+	_, present := stringList(tunInbound(t, renderDefault(t, "trojan://pw@1.2.3.4:443?sni=a.com#n"))["route_exclude_address"])
+	for _, want := range []string{"fe80::/10", "ff00::/8"} {
+		if !present[want] {
+			t.Errorf("missing IPv6 local exclusion %s", want)
+		}
+	}
+	if present["fc00::/7"] {
+		t.Error("fc00::/7 excluded — this strands the fakeip inet6_range outside the tunnel")
+	}
+}
+
+// Regression: stringList used to handle only []any, so the Go-built default
+// inbound's literal []string exclusions were read as empty and silently
+// overwritten the moment a node IP was appended.
+func TestNodeIPInjectionPreservesBuiltinExclusions(t *testing.T) {
+	_, present := stringList(tunInbound(t, renderDefault(t, "trojan://pw@1.2.3.4:443?sni=a.com#n"))["route_exclude_address"])
+	if !present["1.2.3.4/32"] {
+		t.Error("node IP was not injected")
+	}
+	if !present["fe80::/10"] {
+		t.Error("built-in exclusion lost when the node IP was appended")
+	}
+}
+
+func TestStringListAcceptsBothShapes(t *testing.T) {
+	for name, in := range map[string]any{
+		"[]string": []string{"a", "b"},
+		"[]any":    []any{"a", "b"},
+	} {
+		got, _ := stringList(in)
+		if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+			t.Errorf("%s: got %v, want [a b]", name, got)
+		}
+	}
+}
+
+// --- IPv6 node addresses ----------------------------------------------------
+
+// An IPv6 node address must be bracketed in the share link. Concatenating
+// host+":"+port yielded "…@2001:db8::1:443", whose port url.Parse cannot
+// recover, so validate() rejected it as "port out of range" and the node
+// disappeared from every subscription format with nothing shown to the user.
+func TestIPv6NodeSurvivesLinkRoundTrip(t *testing.T) {
+	for _, typ := range []string{"vless", "trojan", "vmess", "hysteria2", "tuic"} {
+		link := singbox.BuildShareLink(singbox.LinkParams{
+			Type: typ, Tag: "v6", Host: "2001:db8::1", Port: 443, UUID: "u",
+			Password: "pw", TLS: true, SNI: "a.com",
+		})
+		if link == "" {
+			t.Errorf("%s: no link built", typ)
+			continue
+		}
+		proxies := ParseLinks([]string{link})
+		if len(proxies) != 1 {
+			t.Errorf("%s: node dropped during parse — link was %q", typ, link)
+			continue
+		}
+		if got := proxies[0].Server; got != "2001:db8::1" {
+			t.Errorf("%s: server = %q, want 2001:db8::1", typ, got)
+		}
+		if got := proxies[0].Port; got != 443 {
+			t.Errorf("%s: port = %d, want 443", typ, got)
+		}
+	}
+}
+
+// An IPv4 node must not acquire brackets.
+func TestIPv4NodeLinkUnbracketed(t *testing.T) {
+	link := singbox.BuildShareLink(singbox.LinkParams{
+		Type: "trojan", Tag: "v4", Host: "1.2.3.4", Port: 443, Password: "pw", TLS: true,
+	})
+	if strings.Contains(link, "[") {
+		t.Errorf("IPv4 host was bracketed: %q", link)
+	}
+}
+
+// The Clash-YAML import path has the same bracketing requirement on re-export.
+func TestClashImportOfIPv6NodeRoundTrips(t *testing.T) {
+	yaml := `proxies:
+  - {name: v6, type: trojan, server: "2001:db8::1", port: 443, password: pw, sni: a.com}
+`
+	proxies := ParseList(yaml)
+	if len(proxies) != 1 {
+		t.Fatalf("IPv6 node dropped on Clash import, got %d proxies", len(proxies))
+	}
+	if got := proxies[0].Server; got != "2001:db8::1" {
+		t.Errorf("server = %q, want 2001:db8::1", got)
+	}
+}
+
+// --- Clash side -------------------------------------------------------------
+
+func renderClash(t *testing.T, links ...string) map[string]any {
+	t.Helper()
+	out, err := Clash(ParseLinks(links), DefaultClashTemplate)
+	if err != nil {
+		t.Fatalf("Clash: %v", err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("rendered Clash config is not valid YAML: %v", err)
+	}
+	return doc
+}
+
+// mihomo's parseIPV6 nulls out both fake-ip-range6 and tun.inet6-address unless
+// the top-level ipv6 switch is true, so the v6 pool below is inert without it.
+func TestClashTopLevelIPv6Enabled(t *testing.T) {
+	doc := renderClash(t, "trojan://pw@1.2.3.4:443?sni=a.com#n")
+	if doc["ipv6"] != true {
+		t.Errorf("top-level ipv6 = %v, want true — fake-ip-range6 is dead without it", doc["ipv6"])
+	}
+}
+
+// Without a v6 fake pool, fake-ip answers AAAA empty and IPv6-only hostnames are
+// unreachable. The value must also stay inside the prefix that mihomo's stock
+// tun.inet6-address default (fdfe:dcba:9876::1/126) sits in — mihomo does not
+// derive one from the other the way it does for IPv4.
+func TestClashFakeIPv6PoolMatchesStockInet6Address(t *testing.T) {
+	dns, ok := renderClash(t, "trojan://pw@1.2.3.4:443?sni=a.com#n")["dns"].(map[string]any)
+	if !ok {
+		t.Fatal("no dns section")
+	}
+	got, _ := dns["fake-ip-range6"].(string)
+	if got == "" {
+		t.Fatal("dns.fake-ip-range6 missing — AAAA collapses to empty and IPv6-only sites break")
+	}
+	pool, err := netip.ParsePrefix(got)
+	if err != nil {
+		t.Fatalf("fake-ip-range6 %q is not a prefix: %v", got, err)
+	}
+	// mihomo's hardcoded default, config.go:547.
+	stock := netip.MustParsePrefix("fdfe:dcba:9876::1/126")
+	if !pool.Contains(stock.Addr()) {
+		t.Errorf("fake-ip-range6 %s does not contain the stock tun.inet6-address %s; "+
+			"set tun.inet6-address explicitly or fake v6 stops being on-link", pool, stock)
+	}
+}
+
+// dns.ipv6 must stay false: it is the only thing suppressing a real IPv6 answer
+// on the fake-ip-filter escape path (it does not affect fake AAAA at all).
+func TestClashDNSIPv6StaysFalseForFilterEscapePath(t *testing.T) {
+	dns, _ := renderClash(t, "trojan://pw@1.2.3.4:443?sni=a.com#n")["dns"].(map[string]any)
+	if v, ok := dns["ipv6"]; !ok || v != false {
+		t.Errorf("dns.ipv6 = %v (present=%v), want false", v, ok)
+	}
+}
+
+// tun.ipv6 is not a mihomo option — it never existed at any version, and yaml.v3
+// non-strict parsing silently dropped it. Its presence reads as suppression that
+// isn't happening, so it must not come back.
+func TestClashTunHasNoPhantomIPv6Key(t *testing.T) {
+	tun, ok := renderClash(t, "trojan://pw@1.2.3.4:443?sni=a.com#n")["tun"].(map[string]any)
+	if !ok {
+		t.Fatal("no tun section")
+	}
+	if _, present := tun["ipv6"]; present {
+		t.Error("tun.ipv6 is back — mihomo has no such option; it silently does nothing")
+	}
+}
+
+// fc00::/7 contains fake-ip-range6. Excluding it would route every fake IPv6 out
+// of the tunnel and undo the whole fix.
+func TestClashRouteExcludeNeverStrandsFakeIPv6(t *testing.T) {
+	doc := renderClash(t, "trojan://pw@1.2.3.4:443?sni=a.com#n")
+	tun, _ := doc["tun"].(map[string]any)
+	excludes, _ := stringList(tun["route-exclude-address"])
+	// Without this the loop below is vacuous: every stock entry is IPv4, so a
+	// v6-only assertion silently covers nothing and would keep passing even if
+	// the whole route-exclude-address block disappeared.
+	if len(excludes) == 0 {
+		t.Fatal("route-exclude-address is empty — the node-IP loop guard is gone")
+	}
+
+	dns, _ := doc["dns"].(map[string]any)
+	poolStr, _ := dns["fake-ip-range6"].(string)
+	pool := netip.MustParsePrefix(poolStr)
+
+	checked := 0
+	for _, e := range excludes {
+		p, err := netip.ParsePrefix(e)
+		if err != nil {
+			t.Errorf("route-exclude-address entry %q is not a valid prefix: %v", e, err)
+			continue
+		}
+		if !p.Addr().Is6() {
+			continue
+		}
+		checked++
+		if p.Overlaps(pool) {
+			t.Errorf("route-exclude-address %s overlaps fake-ip-range6 %s — fake IPv6 would leave the tunnel", e, pool)
+		}
+	}
+	t.Logf("%d IPv6 exclusion(s) checked against pool %s", checked, pool)
+}
+
+// route-exclude entries must be routable unicast. net.IP.IsPrivate covers only
+// ULA on the v6 side, so link-local slipped through before isPublicIP.
+func TestIsPublicIP(t *testing.T) {
+	cases := map[string]bool{
+		"1.2.3.4":     true,
+		"2001:db8::1": true,
+		"192.168.1.1": false,
+		"10.0.0.1":    false,
+		"fc00::1":     false, // ULA
+		"fe80::1":     false, // link-local — the case IsPrivate misses
+		"169.254.1.1": false, // v4 link-local
+		"127.0.0.1":   false,
+		"::1":         false,
+		"example.com": false, // not an IP at all
+		"":            false,
+	}
+	for in, want := range cases {
+		if got := isPublicIP(in); got != want {
+			t.Errorf("isPublicIP(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// A link-local node address must not reach route_exclude_address. The node under
+// test has to actually BE link-local — asserting this against a public-IPv4 node
+// is vacuous, since fe80::1/128 could never appear regardless of isPublicIP.
+func TestLinkLocalNodeNotExcluded(t *testing.T) {
+	cfg := renderDefault(t,
+		"trojan://pw@[fe80::1]:443?sni=a.com#linklocal",
+		"trojan://pw@[2001:db8::1]:443?sni=a.com#global",
+	)
+	_, present := stringList(tunInbound(t, cfg)["route_exclude_address"])
+	if present["fe80::1/128"] {
+		t.Error("link-local node address injected as an exclusion")
+	}
+	// The global-unicast IPv6 node in the same subscription must still be
+	// excluded, or this test would also pass if injection broke entirely.
+	if !present["2001:db8::1/128"] {
+		t.Error("global-unicast IPv6 node was not excluded — loop guard missing")
+	}
+}

--- a/internal/subconv/output.go
+++ b/internal/subconv/output.go
@@ -14,6 +14,14 @@ const (
 )
 
 // NormalizeFormat maps user-facing format names to canonical ones.
+//
+// Anything not named below yields the base64 link list, so "base64", "v2ray",
+// "v2rayn" and friends all resolve to it. They are documented here rather than
+// as explicit cases because a case list returning the same value as the default
+// would be dead code that documents nothing the code actually enforces — a typo
+// like "?format=v2rya" behaves identically either way. Falling back rather than
+// erroring is deliberate: a subscription that 404s on a typo is worse than one
+// that returns the format every client can read.
 func NormalizeFormat(f string) string {
 	switch strings.ToLower(f) {
 	case "clash", "mihomo", "meta":
@@ -98,6 +106,13 @@ func ParseLinks(links []string) []*Proxy {
 // at render time — this is server-side data (the nodes the server defines),
 // not client-side configuration.
 const DefaultClashTemplate = `
+# The real IPv6 master switch. mihomo's parseIPV6 nulls out BOTH dns.fake-ip-range6
+# and tun.inet6-address unless this is true AND verifyIP6() finds a global-unicast
+# IPv6 on a host interface. That runtime probe is why this is safe to ship on by
+# default: a v4-only client silently collapses to the old "no IPv6 anywhere"
+# behavior instead of failing to start. true is already the built-in default —
+# stated explicitly because everything below is inert without it.
+ipv6: true
 dns:
   enable: true
   # Route the DNS module's own upstream connections through the same rule
@@ -113,6 +128,27 @@ dns:
   respect-rules: true
   enhanced-mode: fake-ip
   fake-ip-range: 198.18.0.1/16
+  # Without a v6 pool, fake-ip answers AAAA with an empty record and every
+  # IPv6-only hostname is unreachable. With it, AAAA gets a *fake* v6 that must
+  # traverse TUN and is re-resolved at the node — so no real IPv6 ever reaches
+  # the application, and a v4-only node still serves the domain over v4.
+  #
+  # This value must stay in the fdfe:dcba:9876::/64 prefix. Unlike IPv4 — where
+  # tun.inet4-address is derived from fake-ip-range narrowed to /30 — mihomo does
+  # NOT derive inet6-address from this key; it is an independent hardcoded default
+  # (fdfe:dcba:9876::1/126) that merely happens to sit inside this prefix.
+  #
+  # What the overlap buys is pool hygiene, not routability: mihomo masks the
+  # prefix and starts allocating at ::4 (component/fakeip/pool.go), so the ::0-::3
+  # block the TUN itself occupies can never be handed out as a fake address. That
+  # mirrors the IPv4 arrangement exactly (198.18.0.1/16 pool, 198.18.0.1/30 TUN,
+  # first allocation 198.18.0.4). Point this key elsewhere and you must set
+  # tun.inet6-address to match, or the pool can allocate the TUN's own address.
+  #
+  # Unknown to cores older than v1.19.16, and mihomo parses config with non-strict
+  # yaml.Unmarshal (no KnownFields), so old clients drop the key and degrade to the
+  # previous empty-AAAA behavior rather than failing to load.
+  fake-ip-range6: fdfe:dcba:9876::1/64
   fake-ip-filter:
     - "*.lan"
     - "*.local"
@@ -130,6 +166,15 @@ dns:
     - "+.stun.playstation.net"
     - "+.xboxlive.com"
     - "localhost.ptlogin2.qq.com"
+  # NOT a global IPv6 kill switch, despite the name. mihomo threads this flag to
+  # withResolver only — withFakeIP never sees it (dns/middleware.go), so with
+  # fake-ip-range6 set above, fake AAAA answers are unaffected. What it still
+  # governs is the one escape hatch: a domain matched by fake-ip-filter skips
+  # fake-ip, reaches the real resolver, and would otherwise be handed a genuine
+  # IPv6. Keeping it false collapses those to an empty answer.
+  #
+  # That is exactly the split we want — fake v6 for tunneled traffic, no real v6
+  # for the direct/local names in the filter list above.
   ipv6: false
   default-nameserver:
     - 223.5.5.5
@@ -183,7 +228,25 @@ tun:
   # clash-verge-rev#3133). false only helped avoid breaking niche apps like
   # VirtualBox; the leak it causes is worse.
   strict-route: true
-  ipv6: false
+  # NOTE: there is deliberately no "ipv6" key here. mihomo has never had a
+  # tun.ipv6 option at any version — it is a sing-box option name, and yaml.v3
+  # non-strict parsing meant the "ipv6: false" that used to sit here was dropped
+  # on the floor, suppressing nothing while reading as if it did. The real
+  # controls are the top-level ipv6 switch and tun.inet6-address, whose default
+  # (fdfe:dcba:9876::1/126) already matches fake-ip-range6 above and so is left
+  # implicit.
+  #
+  # route-exclude-address below stays IPv4-only on purpose. auto-route does
+  # install a v6 default route once inet6-address exists, but the kernel's own
+  # more-specific on-link routes (fe80::/64 dev <if>) win in the main table, so
+  # neighbor discovery and mDNS keep working without an explicit carve-out; any
+  # remaining private v6 destination is sent DIRECT by the GEOIP,private rule.
+  # (The sing-box default inbound does list fe80::/10 and ff00::/8 — same
+  # reasoning, it is legibility there rather than necessity.)
+  #
+  # Above all, fc00::/7 must never be added here: fake-ip-range6 is allocated
+  # from inside it, and excluding the parent prefix would route every fake IPv6
+  # back out of the tunnel — undoing the fix entirely.
   route-exclude-address:
     - 192.168.0.0/16
     - 10.0.0.0/8

--- a/internal/subconv/parse.go
+++ b/internal/subconv/parse.go
@@ -94,7 +94,27 @@ func validate(p *Proxy) error {
 	if p.Protocol == "ss" && !ssMethods[strings.ToLower(strings.TrimSpace(p.Method))] {
 		return fmt.Errorf("unsupported shadowsocks method %q", p.Method)
 	}
+	// mihomo's AnyTLSOption.Password carries no omitempty, so an anytls entry
+	// without one fails the *whole* config rather than just this node — the same
+	// all-or-nothing behaviour this function exists to guard against.
+	if p.Protocol == "anytls" && p.Password == "" {
+		return fmt.Errorf("anytls without password")
+	}
 	return nil
+}
+
+// hysteriaBandwidth renders mihomo's up/down value.
+//
+// Those two fields are the one place where "omit when unknown" is the wrong
+// instinct: HysteriaOption declares them without omitempty, so mihomo's decoder
+// reports `has unset fields: down, up` and refuses the ENTIRE config — every
+// node gone, not just this one. A guessed number only costs some congestion
+// control accuracy, so a default is strictly better than an omission here.
+func hysteriaBandwidth(mbps string) string {
+	if n := atoi(mbps); n > 0 {
+		return strconv.Itoa(n) + " Mbps"
+	}
+	return "100 Mbps"
 }
 
 func parseLinkRaw(raw string) (*Proxy, error) {
@@ -108,6 +128,10 @@ func parseLinkRaw(raw string) (*Proxy, error) {
 		return parseURLStyle(raw, "hysteria2")
 	case strings.HasPrefix(raw, "hy2://"):
 		return parseURLStyle(strings.Replace(raw, "hy2://", "hysteria2://", 1), "hysteria2")
+	case strings.HasPrefix(raw, "anytls://"):
+		return parseURLStyle(raw, "anytls")
+	case strings.HasPrefix(raw, "hysteria://"):
+		return parseURLStyle(raw, "hysteria")
 	case strings.HasPrefix(raw, "tuic://"):
 		return parseTuic(raw)
 	case strings.HasPrefix(raw, "vmess://"):
@@ -163,10 +187,19 @@ func parseURLStyle(raw, proto string) (*Proxy, error) {
 	switch proto {
 	case "vless":
 		p.UUID = u.User.Username()
-	case "trojan", "hysteria2":
+	case "trojan", "hysteria2", "anytls":
 		// password lives in the userinfo
 		if pw := u.User.Username(); pw != "" {
 			p.Password = pw
+		}
+	case "hysteria":
+		// hysteria v1 has no userinfo at all — the credential is the `auth`
+		// query param (per the v1 URI scheme, which the upstream docs adopted
+		// from Shadowrocket). It also spells SNI `peer`; normalise that to `sni`
+		// here so every renderer and sbTLS can look it up the usual way instead
+		// of special-casing this one protocol.
+		if peer := p.Params.Get("peer"); peer != "" && p.Params.Get("sni") == "" {
+			p.Params.Set("sni", peer)
 		}
 	}
 	if p.Name == "" {

--- a/internal/subconv/parse.go
+++ b/internal/subconv/parse.go
@@ -447,6 +447,48 @@ func (p *Proxy) param(keys ...string) string {
 	return ""
 }
 
+// tlsParam reads a TLS-related setting from whichever namespace the proxy has:
+// the URL query for url-style links, or the vmess JSON map, which is where a
+// vmess:// link keeps the same information.
+//
+// This is deliberately NOT folded into param(). The two namespaces collide on
+// "type" — in a url-style link it names the transport (ws/grpc/httpupgrade),
+// while in vmess JSON it is the obfuscation header type ("none") — so a blanket
+// fallthrough would make sbTransport read a vmess node's header type as its
+// transport. Only the TLS keys, which mean the same thing in both, fall through.
+func (p *Proxy) tlsParam(keys ...string) string {
+	if v := p.param(keys...); v != "" {
+		return v
+	}
+	if p.VMess != nil {
+		for _, k := range keys {
+			if v := str(p.VMess[k]); v != "" {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+// tlsInsecure reports whether the node opts out of certificate verification.
+//
+// Centralised for two reasons. The spelling varies by dialect — url-style links
+// use allowInsecure or insecure, sing-box config uses allow_insecure — and each
+// renderer previously accepted its own subset, so the same imported node came
+// out with skip-cert-verify in one format and without it in another.
+//
+// The value form varies too. 轻舟 writes the string "1", but a vmess link from
+// another panel routinely carries a JSON boolean, which str() renders as "true";
+// comparing against "1" alone silently dropped the exemption and left a
+// self-signed node failing certificate verification with nothing to explain why.
+func (p *Proxy) tlsInsecure() bool {
+	switch p.tlsParam("insecure", "allowInsecure", "allow_insecure") {
+	case "1", "true":
+		return true
+	}
+	return false
+}
+
 // tuning is the TCP/multiplex client-dial tuning carried by a link (see
 // singbox.LinkParams.tuningQuery). Values live in Params for url-style protocols
 // and in the vmess JSON map, so tuning() reads from whichever a Proxy has.

--- a/internal/subconv/singbox.go
+++ b/internal/subconv/singbox.go
@@ -249,6 +249,34 @@ func singboxOutbound(p *Proxy) map[string]any {
 		o["type"] = "hysteria2"
 		o["password"] = p.Password
 		o["tls"] = sbTLS(p, "tls")
+	case "anytls":
+		// sing-box >= 1.12.0. tls is required by the outbound constructor.
+		o["type"] = "anytls"
+		o["password"] = p.Password
+		o["tls"] = sbTLS(p, "tls")
+	case "hysteria":
+		o["type"] = "hysteria"
+		if v := p.param("auth"); v != "" {
+			o["auth_str"] = v // plaintext form; `auth` is the base64 variant
+		}
+		if v := atoi(p.param("upmbps")); v > 0 {
+			o["up_mbps"] = v
+		}
+		if v := atoi(p.param("downmbps")); v > 0 {
+			o["down_mbps"] = v
+		}
+		// XPlus obfuscation password — the URI's obfsParam, NOT its `obfs`
+		// (which is the mode). sing-box has no field for the mode.
+		if v := p.param("obfsParam"); v != "" {
+			o["obfs"] = v
+		}
+		// Mandatory: NewOutbound rejects the node outright with ErrTLSRequired
+		// when tls is absent or disabled, and that failure happens at startup,
+		// taking the whole config with it.
+		o["tls"] = sbTLS(p, "tls")
+		// recv_window_conn / recv_window / disable_mtu_discovery are deliberately
+		// not emitted: deprecated in 1.14 in favour of the shared QUIC options,
+		// and the minimal field set is what both old and new cores accept.
 	case "tuic":
 		o["type"] = "tuic"
 		o["uuid"] = p.UUID

--- a/internal/subconv/singbox.go
+++ b/internal/subconv/singbox.go
@@ -64,7 +64,34 @@ func Singbox(proxies []*Proxy, template string) (string, error) {
 
 	if _, ok := doc["inbounds"]; !ok {
 		doc["inbounds"] = []map[string]any{
-			{"type": "tun", "tag": "tun-in", "address": []string{"172.19.0.1/30"}, "auto_route": true, "strict_route": false, "stack": "gvisor"},
+			// The IPv6 prefix is not decorative: the DNS template answers AAAA with
+			// a fake address out of fakeip.inet6_range (fc00::/18). Without an
+			// inet6 address on the TUN, auto_route installs no IPv6 route, so that
+			// fake address is unroutable — every AAAA-resolved connection dies with
+			// ENETUNREACH, and an IPv6-only domain (no A record) is simply
+			// unreachable. With it, IPv6 traffic enters the tunnel and the *node*
+			// resolves the domain, so a v4-only node still serves it over v4.
+			//
+			// Capturing v6 also closes the leak: with no IPv6 route, anything that
+			// reaches an IPv6 literal without asking DNS — BitTorrent, WebRTC/STUN,
+			// a hardcoded address — bypasses the tunnel out the physical NIC.
+			{"type": "tun", "tag": "tun-in",
+				"address":    []string{"172.19.0.1/30", "fdfe:dcba:9876::1/126"},
+				"auto_route": true, "strict_route": false, "stack": "gvisor",
+				// Defensive, not load-bearing: auto_route installs ::/0, which
+				// nominally covers link-local and multicast, but the kernel's own
+				// more-specific on-link routes (fe80::/64 dev <if>) win in the main
+				// table either way — so neighbor discovery and mDNS survive with or
+				// without this. Listed explicitly because it costs nothing and makes
+				// the intent legible. (The Clash template omits the equivalent for
+				// the same reason it is safe to omit here.)
+				//
+				// fc00::/7 must NOT be listed, however. That one is load-bearing:
+				// fakeip hands out fc00::/18 from inside it, so excluding the parent
+				// prefix would route every fake IPv6 straight back out of the tunnel,
+				// reintroducing the exact breakage the inet6 address above fixes.
+				"route_exclude_address": []string{"fe80::/10", "ff00::/8"},
+			},
 			{"type": "mixed", "tag": "mixed-in", "listen": "127.0.0.1", "listen_port": 2080},
 		}
 	}
@@ -198,12 +225,12 @@ func singboxOutbound(p *Proxy) map[string]any {
 		if str(p.VMess["net"]) == "ws" {
 			o["transport"] = sbWS(str(p.VMess["path"]), str(p.VMess["host"]), 0, "")
 		}
+		// Was a hand-rolled block that set only server_name, so alpn / utls
+		// fingerprint / insecure were dropped for vmess alone. sbTLS reads all of
+		// them through p.param, which falls through to the vmess JSON map, so
+		// vmess now gets the same TLS treatment as every other protocol.
 		if str(p.VMess["tls"]) == "tls" {
-			tls := map[string]any{"enabled": true}
-			if sni := str(p.VMess["sni"]); sni != "" {
-				tls["server_name"] = sni
-			}
-			o["tls"] = tls
+			o["tls"] = sbTLS(p, "tls")
 		}
 	case "ss":
 		o["type"] = "shadowsocks"
@@ -269,14 +296,16 @@ func sbTLS(p *Proxy, sec string) map[string]any {
 	if sec != "tls" && sec != "reality" {
 		return map[string]any{"enabled": false}
 	}
+	// tlsParam, not param: these keys must also resolve for vmess, whose link
+	// carries them in its JSON payload rather than a query string.
 	tls := map[string]any{"enabled": true}
-	if sni := p.param("sni"); sni != "" {
+	if sni := p.tlsParam("sni"); sni != "" {
 		tls["server_name"] = sni
 	}
-	if alpn := p.param("alpn"); alpn != "" {
+	if alpn := p.tlsParam("alpn"); alpn != "" {
 		tls["alpn"] = strings.Split(alpn, ",")
 	}
-	if fp := p.param("fp"); fp != "" {
+	if fp := p.tlsParam("fp"); fp != "" {
 		tls["utls"] = map[string]any{"enabled": true, "fingerprint": fp}
 	}
 	if sec == "reality" {
@@ -289,7 +318,7 @@ func sbTLS(p *Proxy, sec string) map[string]any {
 		}
 		tls["reality"] = re
 	}
-	if p.param("insecure", "allowInsecure", "allow_insecure") == "1" {
+	if p.tlsInsecure() {
 		tls["insecure"] = true
 	}
 	return tls
@@ -370,7 +399,7 @@ func injectSingboxTunExclude(doc map[string]any, proxies []*Proxy) {
 		// route_exclude_address entries must be CIDR prefixes; only real public IPs
 		// qualify. Bare domains (net.ParseIP == nil) would be invalid and break
 		// the client config, so they are skipped here (see injectRouteExclude).
-		if ip := net.ParseIP(p.Server); ip != nil && !ip.IsPrivate() {
+		if isPublicIP(p.Server) {
 			seen[p.Server] = true
 		}
 	}

--- a/internal/subconv/surge.go
+++ b/internal/subconv/surge.go
@@ -89,7 +89,7 @@ func surgeProxy(p *Proxy) string {
 		if v := p.param("sni", "peer"); v != "" {
 			parts = append(parts, "sni="+v)
 		}
-		if p.param("allowInsecure", "insecure") == "1" {
+		if p.tlsInsecure() {
 			parts = append(parts, "skip-cert-verify=true")
 		}
 		parts = append(parts, "udp-relay=true")
@@ -110,6 +110,11 @@ func surgeProxy(p *Proxy) string {
 			if sni := str(p.VMess["sni"]); sni != "" {
 				parts = append(parts, "sni="+sni)
 			}
+			// Matches the trojan/hysteria2 branches; vmess was the only TLS
+			// protocol here with no way to accept a self-signed certificate.
+			if p.tlsInsecure() {
+				parts = append(parts, "skip-cert-verify=true")
+			}
 		}
 		return strings.Join(parts, ", ")
 	case "hysteria2":
@@ -117,7 +122,7 @@ func surgeProxy(p *Proxy) string {
 		if v := p.param("sni"); v != "" {
 			parts = append(parts, "sni="+v)
 		}
-		if p.param("insecure", "allowInsecure") == "1" {
+		if p.tlsInsecure() {
 			parts = append(parts, "skip-cert-verify=true")
 		}
 		return strings.Join(parts, ", ")

--- a/internal/subconv/surge.go
+++ b/internal/subconv/surge.go
@@ -126,7 +126,19 @@ func surgeProxy(p *Proxy) string {
 			parts = append(parts, "skip-cert-verify=true")
 		}
 		return strings.Join(parts, ", ")
+	case "anytls":
+		// Surge iOS 5.17.0+ / Mac 6.4.3+. Older builds reject the line.
+		parts := []string{"anytls", p.Server, itoaPort(p.Port), "password=" + p.Password}
+		if v := p.param("sni"); v != "" {
+			parts = append(parts, "sni="+v)
+		}
+		if p.tlsInsecure() {
+			parts = append(parts, "skip-cert-verify=true")
+		}
+		return strings.Join(parts, ", ")
 	default:
-		return "" // vless / tuic unsupported by Surge
+		// vless / tuic / hysteria v1 have no Surge equivalent — Surge's proxy
+		// policy list covers hysteria2 but not v1.
+		return ""
 	}
 }

--- a/internal/subconv/validate_test.go
+++ b/internal/subconv/validate_test.go
@@ -107,28 +107,52 @@ func TestSingbox_UnknownTransportOmitted(t *testing.T) {
 // b64 is the userinfo encoding shadowsocks share links use.
 func b64(s string) string { return base64.RawURLEncoding.EncodeToString([]byte(s)) }
 
-// hysteria v1 is a different wire protocol from hysteria2 (auth-str, up/down,
-// no `password` key). Rendering it as hysteria2:// yielded an empty credential
-// — "hysteria2://@host:443" — a node that shipped in every subscription and
-// could never connect. It must be dropped, and the nodes around it must survive.
-func TestClashYAML_HysteriaV1Dropped(t *testing.T) {
+// hysteria v1 is a different wire protocol from hysteria2 (auth-str, mandatory
+// up/down, no `password` key). Rendering it as hysteria2:// yielded an empty
+// credential — "hysteria2://@host:443" — a node that shipped in every
+// subscription and could never connect.
+//
+// It used to be dropped for that reason. Now that there is a real hysteria v1
+// branch it round-trips instead, but the invariant that mattered is unchanged
+// and is what this test asserts directly: a v1 node must never be emitted as
+// hysteria2, and never with an empty credential.
+func TestClashYAML_HysteriaV1NotRenderedAsHysteria2(t *testing.T) {
 	yaml := `proxies:
   - {name: v1, type: hysteria, server: 1.2.3.4, port: 443, auth-str: secret, up: 50, down: 200}
   - {name: v2, type: hysteria2, server: 5.6.7.8, port: 443, password: pw, sni: a.com}
   - {name: tj, type: trojan, server: 9.9.9.9, port: 443, password: pw, sni: b.com}
 `
 	ps := ParseList(yaml)
-	names := map[string]bool{}
+	byName := map[string]*Proxy{}
 	for _, p := range ps {
-		names[p.Name] = true
+		byName[p.Name] = p
 		if strings.Contains(p.Raw, "://@") {
 			t.Errorf("emitted a node with an empty credential: %s", p.Raw)
 		}
 	}
-	if names["v1"] {
-		t.Error("hysteria v1 node was emitted as hysteria2 — it can never connect")
+	for _, want := range []string{"v1", "v2", "tj"} {
+		if byName[want] == nil {
+			t.Fatalf("node %q missing from %v", want, byName)
+		}
 	}
-	if !names["v2"] || !names["tj"] {
-		t.Errorf("dropping the v1 node took valid nodes with it: %v", names)
+
+	v1 := byName["v1"]
+	if v1.Protocol != "hysteria" {
+		t.Errorf("v1 parsed as %q, want hysteria", v1.Protocol)
+	}
+	if strings.HasPrefix(v1.Raw, "hysteria2://") {
+		t.Errorf("v1 emitted as hysteria2 — it can never connect: %s", v1.Raw)
+	}
+	if got := v1.param("auth"); got != "secret" {
+		t.Errorf("v1 auth = %q, want secret (hysteria2's password does not apply)", got)
+	}
+	if got := v1.param("upmbps"); got != "50" {
+		t.Errorf("v1 upmbps = %q, want 50", got)
+	}
+	if got := v1.param("downmbps"); got != "200" {
+		t.Errorf("v1 downmbps = %q, want 200", got)
+	}
+	if byName["v2"].Protocol != "hysteria2" {
+		t.Errorf("v2 parsed as %q, want hysteria2", byName["v2"].Protocol)
 	}
 }

--- a/internal/subconv/vmess_tls_test.go
+++ b/internal/subconv/vmess_tls_test.go
@@ -1,0 +1,275 @@
+package subconv
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"qingzhou/internal/singbox"
+)
+
+// vmessJSON decodes the base64 JSON payload of a vmess:// link.
+func vmessJSON(t *testing.T, link string) map[string]any {
+	t.Helper()
+	if !strings.HasPrefix(link, "vmess://") {
+		t.Fatalf("not a vmess link: %q", link)
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(link, "vmess://"))
+	if err != nil {
+		t.Fatalf("vmess payload is not base64: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("vmess payload is not JSON: %v", err)
+	}
+	return m
+}
+
+// sbOutboundTLS returns the tls object of the first outbound of the given type
+// in a rendered sing-box config, or nil if that outbound has none. Assertions go
+// through this rather than substring-matching the whole document, which silently
+// picks up unrelated keys from the template.
+func sbOutboundTLS(t *testing.T, cfg, outboundType string) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(cfg), &doc); err != nil {
+		t.Fatalf("rendered sing-box config is not valid JSON: %v", err)
+	}
+	for _, ob := range mapSlice(doc["outbounds"]) {
+		if ob["type"] != outboundType {
+			continue
+		}
+		tls, _ := ob["tls"].(map[string]any)
+		return tls
+	}
+	t.Fatalf("no %q outbound in rendered config", outboundType)
+	return nil
+}
+
+// The regression this whole file exists for: TLS used to be inferred from
+// "SNI != ''". server_name is optional — self-signed certs and bare-IP inbounds
+// routinely leave it empty — so a TLS inbound rendered as tls:"" and the node
+// was dialled in plaintext. Every renderer keys off this one field, so the
+// damage was not limited to the base64/v2rayN path.
+func TestVmessTLSWithoutSNIIsStillTLS(t *testing.T) {
+	link := singbox.BuildShareLink(singbox.LinkParams{
+		Type: "vmess", Tag: "n", Host: "1.2.3.4", Port: 443, UUID: "u",
+		TLS: true, // inbound has a cert…
+		SNI: "",   // …but no server_name
+	})
+	if got := vmessJSON(t, link)["tls"]; got != "tls" {
+		t.Fatalf(`vmess "tls" = %q, want "tls" — TLS inbound rendered as plaintext`, got)
+	}
+}
+
+func TestVmessWithoutTLSStaysPlaintext(t *testing.T) {
+	link := singbox.BuildShareLink(singbox.LinkParams{
+		Type: "vmess", Tag: "n", Host: "1.2.3.4", Port: 443, UUID: "u",
+		TLS: false,
+	})
+	if got := vmessJSON(t, link)["tls"]; got != "" {
+		t.Errorf(`vmess "tls" = %q, want "" for a non-TLS inbound`, got)
+	}
+}
+
+// A stray SNI on a non-TLS inbound must not resurrect the old inference.
+func TestVmessSNIAloneDoesNotImplyTLS(t *testing.T) {
+	link := singbox.BuildShareLink(singbox.LinkParams{
+		Type: "vmess", Tag: "n", Host: "1.2.3.4", Port: 443, UUID: "u",
+		TLS: false, SNI: "a.com",
+	})
+	if got := vmessJSON(t, link)["tls"]; got != "" {
+		t.Errorf(`vmess "tls" = %q, want "" — SNI must not imply TLS`, got)
+	}
+}
+
+// The no-SNI TLS node has to survive into all four subscription formats, since
+// each renderer independently tests VMess["tls"] == "tls".
+func TestVmessTLSWithoutSNIReachesEveryFormat(t *testing.T) {
+	link := singbox.BuildShareLink(singbox.LinkParams{
+		Type: "vmess", Tag: "n", Host: "1.2.3.4", Port: 443, UUID: "u",
+		TLS: true, SNI: "", Insecure: true,
+	})
+	proxies := ParseLinks([]string{link})
+	if len(proxies) != 1 {
+		t.Fatalf("link did not survive parsing: %q", link)
+	}
+
+	clash, err := Clash(proxies, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"tls: true", "skip-cert-verify: true"} {
+		if !strings.Contains(clash, want) {
+			t.Errorf("clash output missing %q:\n%s", want, clash)
+		}
+	}
+
+	sb, err := Singbox(proxies, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Anchored to the vmess outbound's own tls object. A bare
+	// strings.Contains(sb, `"enabled": true`) is a tautology: the default
+	// template already renders that twice (dns.fakeip and cache_file), so the
+	// assertion passes even with the vmess TLS block deleted entirely.
+	tls := sbOutboundTLS(t, sb, "vmess")
+	if tls == nil {
+		t.Fatal("vmess outbound has no tls block — TLS inbound rendered as plaintext")
+	}
+	if tls["enabled"] != true {
+		t.Errorf("vmess tls.enabled = %v, want true", tls["enabled"])
+	}
+	if tls["insecure"] != true {
+		t.Errorf("vmess tls.insecure = %v, want true", tls["insecure"])
+	}
+
+	surge := Surge(proxies, "")
+	for _, want := range []string{"tls=true", "skip-cert-verify=true"} {
+		if !strings.Contains(surge, want) {
+			t.Errorf("surge output missing %q:\n%s", want, surge)
+		}
+	}
+}
+
+// vmess was the only protocol dropping these, so a self-signed or
+// fingerprint-pinned vmess node could not be expressed at all.
+func TestVmessCarriesFingerprintALPNAndInsecure(t *testing.T) {
+	link := singbox.BuildShareLink(singbox.LinkParams{
+		Type: "vmess", Tag: "n", Host: "1.2.3.4", Port: 443, UUID: "u",
+		TLS: true, SNI: "a.com", Fingerprint: "firefox",
+		ALPN: "h2,http/1.1", Insecure: true,
+	})
+	m := vmessJSON(t, link)
+	for k, want := range map[string]any{
+		"sni":           "a.com",
+		"fp":            "firefox",
+		"alpn":          "h2,http/1.1",
+		"allowInsecure": "1",
+	} {
+		if m[k] != want {
+			t.Errorf("vmess %q = %v, want %v", k, m[k], want)
+		}
+	}
+
+	sb, err := Singbox(ParseLinks([]string{link}), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tls := sbOutboundTLS(t, sb, "vmess")
+	if tls == nil {
+		t.Fatal("vmess outbound has no tls block")
+	}
+	if tls["server_name"] != "a.com" {
+		t.Errorf("tls.server_name = %v, want a.com", tls["server_name"])
+	}
+	if tls["insecure"] != true {
+		t.Errorf("tls.insecure = %v, want true", tls["insecure"])
+	}
+	if utls, _ := tls["utls"].(map[string]any); utls == nil || utls["fingerprint"] != "firefox" {
+		t.Errorf("tls.utls = %v, want fingerprint firefox", tls["utls"])
+	}
+	alpn, _ := stringList(tls["alpn"])
+	if len(alpn) != 2 || alpn[0] != "h2" || alpn[1] != "http/1.1" {
+		t.Errorf("tls.alpn = %v, want [h2 http/1.1]", alpn)
+	}
+
+	clash, err := Clash(ParseLinks([]string{link}), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"client-fingerprint: firefox", "skip-cert-verify: true"} {
+		if !strings.Contains(clash, want) {
+			t.Errorf("clash vmess TLS missing %q:\n%s", want, clash)
+		}
+	}
+}
+
+// A non-TLS vmess node must not pick up TLS keys from the shared sbTLS helper.
+func TestVmessPlaintextHasNoTLSBlock(t *testing.T) {
+	link := singbox.BuildShareLink(singbox.LinkParams{
+		Type: "vmess", Tag: "n", Host: "1.2.3.4", Port: 443, UUID: "u", TLS: false,
+	})
+	sb, err := Singbox(ParseLinks([]string{link}), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Scoped to the vmess outbound. A document-wide search for `"tls"` would
+	// start failing for an unrelated reason the day the template grows one.
+	if tls := sbOutboundTLS(t, sb, "vmess"); tls != nil {
+		t.Errorf("plaintext vmess emitted a tls block: %v", tls)
+	}
+	clash, err := Clash(ParseLinks([]string{link}), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(clash, "tls: true") {
+		t.Errorf("plaintext vmess emitted tls: true:\n%s", clash)
+	}
+}
+
+// Foreign panels routinely emit allowInsecure as a JSON boolean rather than the
+// string "1" 轻舟 writes. str() renders that as "true", so an == "1" comparison
+// dropped the exemption and left the imported node failing cert verification.
+func TestImportedVmessInsecureAcceptsBothValueForms(t *testing.T) {
+	for _, form := range []string{`true`, `"true"`, `"1"`, `1`} {
+		payload := `{"v":"2","ps":"n","add":"1.2.3.4","port":"443","id":"u",` +
+			`"aid":"0","net":"tcp","type":"none","tls":"tls","allowInsecure":` + form + `}`
+		link := "vmess://" + base64.StdEncoding.EncodeToString([]byte(payload))
+		proxies := ParseLinks([]string{link})
+		if len(proxies) != 1 {
+			t.Fatalf("allowInsecure=%s: link did not parse", form)
+		}
+		if !proxies[0].tlsInsecure() {
+			t.Errorf("allowInsecure=%s: tlsInsecure() = false, want true", form)
+		}
+		clash, err := Clash(proxies, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(clash, "skip-cert-verify: true") {
+			t.Errorf("allowInsecure=%s: clash dropped skip-cert-verify", form)
+		}
+	}
+}
+
+// A Clash subscription carrying a self-signed vmess node must keep the exemption
+// across import. The parse side used to drop it, so no render-side fix could
+// bring it back on re-export.
+func TestClashVmessImportKeepsSkipCertVerify(t *testing.T) {
+	yaml := `proxies:
+  - {name: v, type: vmess, server: 1.2.3.4, port: 443, uuid: u, alterId: 0, cipher: auto, tls: true, servername: a.com, skip-cert-verify: true, client-fingerprint: firefox, alpn: [h2]}
+`
+	proxies := ParseList(yaml)
+	if len(proxies) != 1 {
+		t.Fatalf("expected 1 proxy, got %d", len(proxies))
+	}
+	if !proxies[0].tlsInsecure() {
+		t.Error("skip-cert-verify lost on import")
+	}
+	if got := proxies[0].tlsParam("fp"); got != "firefox" {
+		t.Errorf("client-fingerprint lost on import: %q", got)
+	}
+	if got := proxies[0].tlsParam("alpn"); got != "h2" {
+		t.Errorf("alpn lost on import: %q", got)
+	}
+}
+
+func TestFormatAliasesForV2Ray(t *testing.T) {
+	for _, in := range []string{"v2ray", "V2RayN", "v2rayng", "base64", "url", "links", "wat"} {
+		if got := NormalizeFormat(in); got != FormatBase64 {
+			t.Errorf("NormalizeFormat(%q) = %q, want %q", in, got, FormatBase64)
+		}
+	}
+	// The named formats must not be swallowed by the new aliases.
+	for in, want := range map[string]string{
+		"clash": FormatClash, "mihomo": FormatClash,
+		"singbox": FormatSingbox, "sing-box": FormatSingbox,
+		"surge": FormatSurge,
+	} {
+		if got := NormalizeFormat(in); got != want {
+			t.Errorf("NormalizeFormat(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/subconv/vmess_tls_test.go
+++ b/internal/subconv/vmess_tls_test.go
@@ -47,8 +47,8 @@ func sbOutboundTLS(t *testing.T, cfg, outboundType string) map[string]any {
 	return nil
 }
 
-// The regression this whole file exists for: TLS used to be inferred from
-// "SNI != ''". server_name is optional — self-signed certs and bare-IP inbounds
+// The regression this whole file exists for: TLS used to be inferred from a
+// non-empty SNI. server_name is optional — self-signed certs and bare-IP inbounds
 // routinely leave it empty — so a TLS inbound rendered as tls:"" and the node
 // was dialled in plaintext. Every renderer keys off this one field, so the
 // damage was not limited to the base64/v2rayN path.


### PR DESCRIPTION
两组缺陷，共同点是都会让节点"看起来配好了但连不上"，且全程不报错。

> **修订说明**：本 PR 初版对 IPv6 失败机理的描述是**错误的**，第二个 commit 已纠正代码注释与本描述。详见下方「初版描述的错误」一节。

## IPv6

**节点地址填 IPv6 → 客户端连不上（但面板里看着正常）。** share link 用裸拼接生成 `host:port`，不给 IPv6 字面量加方括号，产生 `…@2001:db8::1:443`。按 RFC 3986 这是非法 authority，v2rayN、mihomo、sing-box 都拒绝。改用带方括号处理的 `joinHostPort`，导入侧 (`clash_parse`) 同样修复。

`joinHostPort` 不是 `net.JoinHostPort` 的简单包装：后者对任何含冒号的 host 无条件加括号，不检查是否**已经**带了括号，会把 `[2001:db8::1]` 变成 `[[2001:db8::1]]` —— 那才是真正到处都解析不了、节点直接消失的形式。管理员手写方括号、以及 Clash YAML 里 `server: "[2001:db8::1]"` 都是常见输入。

**SNI 测试对裸 IPv6 直接报错。** 用 `strings.Contains(host, ":")` 判断"是否已带端口"，裸 IPv6 天生含冒号。逻辑已抽成纯函数 `normalizeSniAddr` 并补了表驱动测试（此前 `api` 包一个测试都没有）。含冒号的 host 必须能被 `net.ParseIP` 解析才放行，避免 `a:b:c` 这类垃圾被包装成 `[a:b:c]:443` 后以"无法连接"而非"格式错误"报错。

**客户端侧此前是"IPv6 在 DNS 层被掐掉"而非"在路由层被堵住"：**

- sing-box 模板的 DNS 用 `fakeip.inet6_range` 应答 AAAA，但 TUN 没有 inet6 地址 → `auto_route` 不装任何 IPv6 路由 → 发出去的假地址无处可去，IPv6-only 域名彻底不可达。补上 inet6 前缀。
- Clash 模板里的 `tun.ipv6: false` 是**死配置**：mihomo 各版本的 `RawTun` 都没有 `ipv6` 字段（那是 sing-box 的选项名），yaml.v3 非严格解析静默丢弃。删除，改为顶层 `ipv6` 开关 + `dns.fake-ip-range6`。

改完之后 AAAA 得到的是**假** IPv6，必须穿隧道并由节点侧解析，因此既不泄露真实 v6、IPv6-only 站点也能访问；**节点是纯 IPv4 也不受影响**（到了节点仍走 A 记录）。客户端无 IPv6 时 mihomo 的 `verifyIP6()` 会自动清空 v6 配置，安全降级。

`dns.ipv6` 保持 `false`：mihomo 只把该 flag 传给 `withResolver`，不传给 `withFakeIP`，所以它不影响假 AAAA，只压制 `fake-ip-filter` 逃逸路径上的真实 v6 —— 正是想要的分工。

`fc00::/7` 绝不能进排除列表（假池分配在其内部），已加测试锁死。

### 初版描述的错误

初版声称未加方括号的链接会"被 subconv 自己的 `validate()` 以 port out of range 丢弃、节点从所有订阅里消失"。**这是错的。** Go 的 `url.Parse` 按**最后**一个冒号切分 host 和 port，所以 `…@2001:db8::1:443` 能被完整还原，本仓库的解析管线原样往返毫无问题。

后果有两个：一是症状描述错了（真实症状是"只在客户端失败"，不是"节点消失"）；二是**两个回归测试因此是空转的**——它们断言"解析往返成功"，而未加方括号时本来就成功。变异测试证实：把修复还原成裸拼接，整个套件依然全绿。第二个 commit 改为断言链接文本，并补上已带方括号的输入用例。

## vmess TLS

**vmess 用 `SNI != ""` 推断有没有开 TLS**，但真实信号是 `tls_id != 0` —— `server_name` 是可选的，自签证书和裸 IP 入站经常为空。这类入站渲染成 `tls:""`，而 clash/sing-box/surge 三个渲染器**各自独立**读这个字段，所以一个空的 `server_name` 会让节点在**四种格式里全部**降级为明文拨号。

`LinkParams` 新增 `TLS` 字段承载真实信号，同时补齐 vmess 一直缺的 `fp`/`alpn`/`allowInsecure`。

insecure 判定收敛到 `Proxy.tlsInsecure()`：此前各渲染器接受的键名不同（sing-box 认 `allow_insecure`，clash/surge 不认），同一节点在不同格式下行为不一致；且只比较字符串 `"1"`，而外部面板常发 JSON 布尔 `true`，`str()` 渲染成 `"true"` 匹配不上，豁免被静默丢弃。

`clash_parse` 的 vmess 分支同样丢 `skip-cert-verify`/`client-fingerprint`/`alpn`（相邻的 vless、trojan 都有），**导入即丢失**，渲染侧修得再对也救不回。

## ⚠️ 需要注意的行为变化

自签证书的 vmess 节点，此前被**静默当明文拨号**（所以"能连上"是假象，实际根本没走 TLS），现在会正确按 TLS 拨号并在证书校验处**硬失败**。v2rayN 没有 per-node 读取豁免的机制。

fail-closed 方向是对的（那些节点本来就配错了），但上线后可能会有用户报「节点用不了了」。

## 其他

- 订阅 `formats` 增加 `base64` 条目；前端「通用」按钮改为指向它 —— 此前指向的 `default` 不带 format 参数、按 UA 选格式，UA 含 "clash" 的客户端会拿到 YAML。
- `isPublicIP` 取代 `!ip.IsPrivate()`：后者在 v6 侧只覆盖 ULA，链路本地、回环、169.254/16 都能混进 `route-exclude-address`。
- `stringList` 补 `[]string` 分支 —— 只认 `[]any` 导致 Go 侧构建的默认排除项被静默覆盖。

## 验证

`go vet` 干净，Go 全量测试通过，前端 build 通过。`-race` 由 CI 覆盖（本机缺 gcc）。

所有关键断言均经**变异测试**验证 —— 逐个还原修复后确认测试确实失败。这个过程一共揪出 **5 个空转/恒真断言**（3 个在初版审查中，2 个在本次审查中），全部已修。

## 已知未覆盖（非本次缺陷）

- `subconv/parse.go` 没有 `anytls://` 和 `hysteria://` 分支，这两类链接对 IPv4/IPv6 都会被 `ParseLinks` 丢弃；加上 clash/sing-box/surge 渲染器也不支持、v2rayN 同样不认，这两个协议目前处处不通 —— 值得单开 issue
- ws early-data 与 v2rayN 不互通（我们发 `max_early_data`，v2rayN 认 `path?ed=N`）
- 不支持 xhttp / splithttp / h2 / kcp
- reality 缺 `spx`（实测不影响连通性）
- `AdminServers.vue` 地址输入无校验
- `sb_admin.go`、`store/*.go` 等多个文件在 `main` 上本就非 gofmt-clean，本 PR 未做无关重排

🤖 Generated with [Claude Code](https://claude.com/claude-code)

