### PR TITLE
修复节点一键重装：装成功了却报「安装失败」

### DIFF
--- a/frontend/src/views/AdminServers.vue
+++ b/frontend/src/views/AdminServers.vue
@@ -32,10 +32,17 @@
           </div>
           <div class="nv-side">
             <span v-if="n.checked_at" class="nv-time">{{ fmtDateTime(n.checked_at) }}</span>
-            <n-button size="tiny" :disabled="!n.upgradable" :loading="upgradingId === n.server_id"
+            <n-button size="tiny" :disabled="!n.upgradable || n.upgrading" :loading="n.upgrading"
                       @click="confirmUpgrade(n)">
-              {{ n.version ? '重装' : '安装' }}
+              {{ n.upgrading ? '安装中' : (n.version ? '重装' : '安装') }}
             </n-button>
+          </div>
+          <!-- 安装是后台跑的（要往节点上拉 ~60MB 的二进制），这里显示脚本的输出。 -->
+          <div v-if="n.upgrading" class="nv-err" style="color:var(--text-3);">
+            正在安装…（往节点下载 sing-box 约 60MB，通常 1–3 分钟；离开本页不影响安装）
+          </div>
+          <div v-else-if="n.upgrade_error" class="nv-err">
+            安装失败：<pre class="nv-out">{{ n.upgrade_error }}</pre>
           </div>
           <div v-if="n.error" class="nv-err">探测失败：{{ n.error }}</div>
           <div v-else-if="n.version && !n.has_v2ray_api" class="nv-err">
@@ -130,7 +137,6 @@ async function load(){loading.value=true;try{servers.value=await apiList('/api/a
 const versions = ref<any[]>([])
 const minSupported = ref('1.12.0')
 const verLoading = ref(false)
-const upgradingId = ref<number | null>(null)
 
 async function loadVersions(){
   try{
@@ -162,14 +168,28 @@ function confirmUpgrade(n:any){
   })
 }
 
+// 安装在后端后台跑：往节点拉 ~60MB 的二进制，同步等会被服务端 WriteTimeout 掐断，
+// 于是装成功了前端却报错。这里只负责发起 + 轮询节点列表里的任务状态。
 async function doUpgrade(n:any){
-  upgradingId.value = n.server_id
   try{
     await apiPost(`/api/admin/nodes/${n.server_id}/singbox/upgrade`)
-    message.success('安装完成')
+  }catch(e:any){ message.error(e?.message || '安装启动失败', { duration: 10000 }); return }
+  message.info('已开始安装，完成后本页会自动刷新')
+  await loadVersions()
+  pollUpgrade(n.server_id)
+}
+
+// 轮询到该节点的任务结束为止。设上限，免得后端异常时无限轮询。
+async function pollUpgrade(id:number){
+  for (let i = 0; i < 120; i++){
+    await new Promise(r => setTimeout(r, 5000))
     await loadVersions()
-  }catch(e:any){ message.error(e?.message || '安装失败', { duration: 10000 }) }
-  finally{ upgradingId.value = null }
+    const row = versions.value.find(v => v.server_id === id)
+    if (!row || row.upgrading) continue
+    if (row.upgrade_error) message.error('安装失败，详情见下方输出', { duration: 10000 })
+    else message.success(`安装完成${row.version ? '：' + row.version : ''}`)
+    return
+  }
 }
 
 onMounted(() => { load(); loadVersions() })
@@ -190,4 +210,11 @@ onMounted(() => { load(); loadVersions() })
 .nv-side { display:flex; align-items:center; gap:10px; }
 .nv-time { font-size:11px; color:var(--text-3); }
 .nv-err { flex-basis:100%; font-size:11px; line-height:1.7; color:var(--warning,#d97706); }
+/* 脚本输出可能很长，限高 + 可滚动，免得一次失败把整页撑开。 */
+.nv-out {
+  margin:4px 0 0; padding:8px 10px; max-height:220px; overflow:auto;
+  font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:11px; line-height:1.6;
+  white-space:pre-wrap; word-break:break-all;
+  background:var(--code-bg,rgba(128,128,128,.1)); border-radius:6px; color:var(--text-2);
+}
 </style>

--- a/internal/api/nodeupgrade_test.go
+++ b/internal/api/nodeupgrade_test.go
@@ -1,0 +1,178 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"qingzhou/internal/store"
+)
+
+func newNodeUpgradeAPI(t *testing.T) (*API, *store.Store) {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	if err := st.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+	return New(st, []byte("secret"), nil), st
+}
+
+func upgradeReq(id int64) *http.Request {
+	path := "/api/admin/nodes/" + strconv.FormatInt(id, 10) + "/singbox/upgrade"
+	req := httptest.NewRequest("POST", path, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.FormatInt(id, 10))
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// TestNodeSingboxUpgradeReturnsBeforeInstallFinishes is the regression test for
+// the reason this handler is asynchronous.
+//
+// The install pushes a ~60MB sing-box onto the node, which routinely runs past
+// the server's 30s WriteTimeout (main.go). A synchronous handler therefore had
+// its response torn off the wire while the install was still going, and the
+// panel reported 安装失败 for a node that had in fact installed correctly. So
+// what matters is not merely that the endpoint works, but that it ANSWERS
+// promptly and leaves the work running behind it.
+func TestNodeSingboxUpgradeReturnsBeforeInstallFinishes(t *testing.T) {
+	a, st := newNodeUpgradeAPI(t)
+	// A host that cannot be dialled: the point is when the handler returns, not
+	// whether the install succeeds. SSH will sit in its own timeout well past
+	// the assertion below.
+	id, err := st.CreateServer(store.Server{
+		Name: "landing", Host: "192.0.2.1", Port: 22, SSHUser: "root",
+		SSHPassword: "hunter2", Enabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	start := time.Now()
+	a.handleAdminNodeSingboxUpgrade(w, upgradeReq(id))
+	elapsed := time.Since(start)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", w.Code, w.Body.String())
+	}
+	// Generous: a correct handler returns in microseconds. Anything near the
+	// 30s WriteTimeout means the work is being awaited inline again.
+	if elapsed > 2*time.Second {
+		t.Fatalf("handler blocked for %v; the install must run in the background", elapsed)
+	}
+	var body struct {
+		Data struct {
+			Started bool `json:"started"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode %s: %v", w.Body.String(), err)
+	}
+	if !body.Data.Started {
+		t.Fatalf("expected started=true, got %s", w.Body.String())
+	}
+
+	// The job is visible while it runs, so the node list the UI polls can report
+	// "安装中" instead of looking idle.
+	if j, ok := a.upgradeSnapshot()[id]; !ok || !j.Running {
+		t.Fatalf("expected a running job for server %d, got %+v", id, j)
+	}
+
+	// A second click while the first is in flight must be refused: two runs of
+	// the install script on one machine would race over the same binary and
+	// systemd unit.
+	w2 := httptest.NewRecorder()
+	a.handleAdminNodeSingboxUpgrade(w2, upgradeReq(id))
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("concurrent upgrade: status = %d, want 409; body %s", w2.Code, w2.Body.String())
+	}
+}
+
+// A node the panel has no way into must be refused up front rather than
+// becoming a background job that fails a minute later somewhere the operator
+// has to go looking for it.
+func TestNodeSingboxUpgradeRejectsUnreachableConfig(t *testing.T) {
+	a, st := newNodeUpgradeAPI(t)
+	noCreds, err := st.CreateServer(store.Server{
+		Name: "no-creds", Host: "192.0.2.2", Port: 22, SSHUser: "root", Enabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		id   int64
+	}{
+		{"no ssh credentials", noCreds},
+		{"unknown server", noCreds + 999},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			a.handleAdminNodeSingboxUpgrade(w, upgradeReq(tc.id))
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body %s", w.Code, w.Body.String())
+			}
+			if _, ok := a.upgradeSnapshot()[tc.id]; ok {
+				t.Fatal("a rejected request must not leave a job behind")
+			}
+		})
+	}
+}
+
+// finishUpgrade is what the node list reads to decide between 安装中, a result,
+// and a failure — including carrying the script's output, which is the whole
+// diagnosis when an install goes wrong.
+func TestUpgradeJobLifecycle(t *testing.T) {
+	a, _ := newNodeUpgradeAPI(t)
+	const id int64 = 7
+
+	if !a.claimUpgrade(id) {
+		t.Fatal("first claim must succeed")
+	}
+	if a.claimUpgrade(id) {
+		t.Fatal("second claim while running must fail")
+	}
+
+	a.finishUpgrade(id, "downloading...\ndone", nil)
+	j := a.upgradeSnapshot()[id]
+	if j.Running {
+		t.Fatal("job should be finished")
+	}
+	if j.Error != "" {
+		t.Fatalf("unexpected error %q", j.Error)
+	}
+	if j.Output != "downloading...\ndone" {
+		t.Fatalf("output = %q", j.Output)
+	}
+	if j.FinishedAt == 0 {
+		t.Fatal("FinishedAt should be stamped")
+	}
+
+	// Once finished, the node can be reinstalled again.
+	if !a.claimUpgrade(id) {
+		t.Fatal("claim after completion must succeed")
+	}
+	a.finishUpgrade(id, "curl: (7) failed to connect", context.DeadlineExceeded)
+	j = a.upgradeSnapshot()[id]
+	if j.Error == "" {
+		t.Fatal("expected an error to be recorded")
+	}
+	// The failure message must carry the script's own output, not just the Go
+	// error: "exit status 1" alone gives the operator nothing to act on.
+	if !strings.Contains(j.Error, "curl: (7)") {
+		t.Fatalf("error %q should include the script output", j.Error)
+	}
+}

--- a/internal/api/nodever_admin.go
+++ b/internal/api/nodever_admin.go
@@ -36,6 +36,12 @@ type nodeVersionView struct {
 	HasV2RayAPI bool   `json:"has_v2ray_api"`
 	CheckedAt   int64  `json:"checked_at"`
 	Error       string `json:"error"`
+	// Reinstall job state, so the list the UI already polls is also what tells it
+	// how the reinstall went. See nodeUpgradeJob.
+	Upgrading     bool   `json:"upgrading"`
+	UpgradeOutput string `json:"upgrade_output,omitempty"`
+	UpgradeError  string `json:"upgrade_error,omitempty"`
+	UpgradedAt    int64  `json:"upgraded_at,omitempty"`
 	// TooOld means the generated config would be rejected by this binary — which
 	// on a node means the panel has silently stopped being able to deploy to it.
 	TooOld bool `json:"too_old"`
@@ -62,9 +68,10 @@ func (a *API) handleAdminNodeVersions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows := []nodeVersionView{viewFor(store.LocalNodeID, "面板本机", "", true, true, observed)}
+	jobs := a.upgradeSnapshot()
+	rows := []nodeVersionView{viewFor(store.LocalNodeID, "面板本机", "", true, true, observed, jobs)}
 	for _, sv := range servers {
-		v := viewFor(sv.ID, sv.Name, sv.Host, false, sv.Enabled, observed)
+		v := viewFor(sv.ID, sv.Name, sv.Host, false, sv.Enabled, observed, jobs)
 		// Without credentials there is no way in, so the button must not pretend.
 		v.Upgradable = sv.SSHKey != "" || sv.SSHPassword != ""
 		rows = append(rows, v)
@@ -76,7 +83,7 @@ func (a *API) handleAdminNodeVersions(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func viewFor(id int64, name, host string, local, enabled bool, observed map[int64]*store.NodeSingbox) nodeVersionView {
+func viewFor(id int64, name, host string, local, enabled bool, observed map[int64]*store.NodeSingbox, jobs map[int64]nodeUpgradeJob) nodeVersionView {
 	v := nodeVersionView{ServerID: id, Name: name, Host: host, Local: local, Enabled: enabled}
 	if local {
 		// The local upgrade shells out to bash; the install script is Linux-only.
@@ -86,6 +93,10 @@ func viewFor(id int64, name, host string, local, enabled bool, observed map[int6
 		v.Version, v.Raw, v.HasV2RayAPI = n.Version, n.Raw, n.HasV2RayAPI
 		v.CheckedAt, v.Error = n.CheckedAt, n.Error
 		v.TooOld = sbver.Info{Version: n.Version}.TooOld()
+	}
+	if j, ok := jobs[id]; ok {
+		v.Upgrading, v.UpgradeOutput, v.UpgradeError = j.Running, j.Output, j.Error
+		v.UpgradedAt = j.FinishedAt
 	}
 	return v
 }
@@ -102,33 +113,122 @@ func (a *API) handleAdminNodeVersionRefresh(w http.ResponseWriter, r *http.Reque
 	ok(w, J{"started": true})
 }
 
-// POST /api/admin/nodes/{id}/singbox/upgrade — reinstall sing-box on one node.
-//
-// Synchronous on purpose: the download is tens of megabytes and the operator
-// needs the script's output when it fails. The handler's own timeout bounds it.
-func (a *API) handleAdminNodeSingboxUpgrade(w http.ResponseWriter, r *http.Request) {
-	id := atoi(chi.URLParam(r, "id"))
-	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Minute)
-	defer cancel()
+// nodeUpgradeJob is the state of one node's reinstall, kept in memory so the
+// node list can report it. Memory rather than a table: a job cannot outlive the
+// process that runs it, and a panel restart mid-install leaves the node's
+// actual version to be settled by the next probe anyway.
+type nodeUpgradeJob struct {
+	Running    bool
+	FinishedAt int64
+	Output     string
+	Error      string
+}
 
-	var out string
-	var err error
-	if id == store.LocalNodeID {
-		out, err = upgradeLocalSingBox(ctx)
-	} else {
-		out, err = a.upgradeRemoteSingBox(ctx, id)
+// upgradeSnapshot copies the job table for reading.
+func (a *API) upgradeSnapshot() map[int64]nodeUpgradeJob {
+	a.upgradeMu.Lock()
+	defer a.upgradeMu.Unlock()
+	out := make(map[int64]nodeUpgradeJob, len(a.upgradeJobs))
+	for id, j := range a.upgradeJobs {
+		out[id] = *j
 	}
+	return out
+}
+
+// claimUpgrade reserves the job slot for one node, reporting false when a
+// reinstall is already running there. Two concurrent runs of the install script
+// on one machine would race over the same binary and unit file.
+func (a *API) claimUpgrade(id int64) bool {
+	a.upgradeMu.Lock()
+	defer a.upgradeMu.Unlock()
+	if a.upgradeJobs == nil {
+		a.upgradeJobs = map[int64]*nodeUpgradeJob{}
+	}
+	if j := a.upgradeJobs[id]; j != nil && j.Running {
+		return false
+	}
+	a.upgradeJobs[id] = &nodeUpgradeJob{Running: true}
+	return true
+}
+
+func (a *API) finishUpgrade(id int64, out string, err error) {
+	a.upgradeMu.Lock()
+	defer a.upgradeMu.Unlock()
+	j := a.upgradeJobs[id]
+	if j == nil {
+		return
+	}
+	j.Running, j.FinishedAt, j.Output = false, time.Now().Unix(), trimOutput(out)
 	if err != nil {
 		// The script's output is the diagnosis; without it the operator gets
 		// "exit status 1" and nothing to act on.
-		fail(w, http.StatusBadGateway, trimOutput(err.Error()+"\n"+out))
+		j.Error = trimOutput(err.Error() + "\n" + out)
+	}
+}
+
+// POST /api/admin/nodes/{id}/singbox/upgrade — reinstall sing-box on one node.
+//
+// Starts the job and returns immediately; the client polls the node list, which
+// carries the result. It cannot be synchronous: the script downloads a sing-box
+// of ~60MB onto the node, which routinely takes longer than the server's
+// WriteTimeout (main.go), so the response was torn off mid-flight and the panel
+// reported a failure for an install that had in fact succeeded. Same reason
+// sbRebuildLog exists — see the note on it in router.go.
+//
+// What the node did is not lost by going async: the script's output is kept on
+// the job and shown when the poll picks it up.
+func (a *API) handleAdminNodeSingboxUpgrade(w http.ResponseWriter, r *http.Request) {
+	id := atoi(chi.URLParam(r, "id"))
+	// Everything that can be judged without touching the node is judged now, so
+	// a misconfigured server still answers with a real error instead of a job
+	// that fails a minute later somewhere the operator has to go looking.
+	if id == store.LocalNodeID {
+		if !runtimeIsLinux() {
+			fail(w, http.StatusBadRequest, errLinuxOnly.Error())
+			return
+		}
+	} else if err := a.checkRemoteUpgradable(id); err != nil {
+		fail(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	// Re-probe so the panel shows the new number rather than the old one.
-	if a.sbctl != nil {
-		a.sbctl.RefreshVersions()
+	if !a.claimUpgrade(id) {
+		fail(w, http.StatusConflict, "该节点正在安装中，请等待本次完成")
+		return
 	}
-	ok(w, J{"output": trimOutput(out)})
+
+	go func() {
+		// context.Background, not r.Context: the request is already answered, and
+		// inheriting its context would cancel the install the moment it is.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+		var out string
+		var err error
+		if id == store.LocalNodeID {
+			out, err = upgradeLocalSingBox(ctx)
+		} else {
+			out, err = a.upgradeRemoteSingBox(ctx, id)
+		}
+		a.finishUpgrade(id, out, err)
+		// Re-probe so the panel shows the new number rather than the old one.
+		// After the job is marked done, so a poll that sees "finished" sees the
+		// refreshed version too.
+		if err == nil && a.sbctl != nil {
+			a.sbctl.RefreshVersions()
+		}
+	}()
+	ok(w, J{"started": true})
+}
+
+// checkRemoteUpgradable reports why a node cannot be reinstalled, or nil.
+func (a *API) checkRemoteUpgradable(id int64) error {
+	sv, err := a.st.GetServer(id)
+	if err != nil || sv == nil {
+		return errNotFound
+	}
+	if sv.SSHKey == "" && sv.SSHPassword == "" {
+		return errNoCreds
+	}
+	return nil
 }
 
 func (a *API) upgradeRemoteSingBox(ctx context.Context, id int64) (string, error) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -32,6 +32,10 @@ type API struct {
 
 	linkMu    sync.Mutex
 	linkCache map[int64]linkCacheEntry
+
+	// In-flight per-node sing-box reinstalls; see nodever_admin.go.
+	upgradeMu   sync.Mutex
+	upgradeJobs map[int64]*nodeUpgradeJob
 }
 
 // SetSbController attaches the native sing-box controller so admin changes to


### PR DESCRIPTION
## 问题

PR #11 的节点一键重装做成了同步接口（注释写「Synchronous on purpose」，给了 6 分钟 context），但 `main.go` 上的 `http.Server` 是 `WriteTimeout: 30s`。两者对不上：

- handler 跑满几分钟 → 30 秒时连接已被服务端关掉 → 浏览器拿到 EOF → 前端 `message.error('安装失败')`
- 而节点那边其实**装成功了**

实测复现过：handler 自己的 `w.Write` 甚至返回 `nil`（写的是 bufio，错误在 flush 时才暴露），客户端稳定拿到 `EOF`。

不是边角情况——安装脚本要往节点上拉面板发布的 sing-box，用 CI 同款 tag 列表交叉编译出来 **61MB**，一台普通落地机拉完远不止 30 秒。这个按钮在真实使用中基本必然报错。

本仓库踩过同一个坑：`router.go` 上 `sbRebuildLog` 的注释写的就是它（「无法加载响应数据」，保存其实成功了）。

## 改法

按 `sbRebuildLog` 同样的路子：

- 接口先做完所有**不碰节点**就能判断的校验（本机非 Linux / 服务器不存在 / 没配 SSH 凭据），不合法的请求照旧拿到真正的 400
- 通过校验就占坑并起后台任务，立即返回 `{"started":true}`
- 任务状态（运行中 / 脚本输出 / 失败原因）挂在内存里，由**节点列表接口**一并带出——前端本来就在轮询这个列表，不新增端点
- 后台任务用 `context.Background` 而非 `r.Context`：请求已经答复，继承请求 context 会在答复瞬间把安装取消掉
- 同一节点重复点击返回 409：两份安装脚本会抢同一个二进制和 systemd unit

顺带两处相关修正：

- 原来成功后在 handler 里同步调 `RefreshVersions()`，它会串行 SSH 探测每台启用节点（每台 20s 超时）且不受请求 context 约束，等于在已经超支的响应上再加几分钟。现在跟着后台任务走。
- 前端不再 await 安装本身，改为发起后每 5 秒轮询节点列表；失败时把脚本输出原样显示（限高可滚动）——这是排障唯一有用的东西。

脚本输出没有因为改异步而丢失：记在任务上，轮询取回后照常展示。

## 验证

- `go build` / `go vet` / `go test ./...` 全绿
- 新增 `internal/api/nodeupgrade_test.go`：断言 handler **在安装完成前就返回**（回归的正是这条）、重复点击 409、无凭据/不存在的节点前置 400 且不留下任务、任务生命周期与脚本输出保留
- 起真实面板实测：`GET /api/admin/nodes/singbox` 带出 `upgrading` 字段；非 Linux 上本机重装返回 400 而不是留下一个必失败的后台任务
- `npx vite build` 通过

> 未能跑 `-race`：本机没有 gcc，`-race` 需要 cgo。相关状态全部由 `upgradeMu` 保护，快照按值拷贝。

🤖 Generated with [Claude Code](https://claude.com/claude-code)