### PR TITLE
fix(egress): 链式代理出口延迟与稳定性，出口克隆 / 粘贴导入

### DIFF
--- a/frontend/src/views/AdminSingbox.vue
+++ b/frontend/src/views/AdminSingbox.vue
@@ -120,6 +120,7 @@
       <n-tab-pane name="egress" tab="代理出口">
         <div class="page-toolbar">
           <span class="spacer" />
+          <n-button size="small" @click="openEgressImport()">粘贴导入</n-button>
           <n-button size="small" type="primary" @click="openEgress()">添加出口</n-button>
         </div>
         <n-spin :show="loading">
@@ -136,14 +137,36 @@
                 <span class="kv">地址 <b>{{ r.host }}:{{ r.port }}</b></span>
                 <span class="kv">用户名 <b>{{ r.username || '—' }}</b></span>
                 <span v-if="r.tls_enabled && r.sni" class="kv">SNI <b>{{ r.sni }}</b></span>
+                <span class="kv">UDP <b>{{ r.udp_mode_effective === 'block' ? '阻断' : '透传' }}</b></span>
+                <span class="kv">超时 <b>{{ r.connect_timeout_effective_ms }}ms</b></span>
                 <span class="kv">入站数 <b>{{ r.inbound_count ?? 0 }}</b></span>
               </div>
               <div v-if="r._test" class="egress-test" :class="r._test.ok ? 'ok' : 'err'">
-                <template v-if="r._test.ok">✅ 出口 IP <b>{{ r._test.ip }}</b> · {{ r._test.latency_ms }}ms · 经 {{ r._test.via_server }}</template>
+                <template v-if="r._test.mode === 'probe'">
+                  <template v-if="r._test.ok_count + r._test.fail_count === 0">
+                    ❓ 并发探测没有拿到结果（经 {{ r._test.via_server }}）：{{ r._test.output || '节点无输出' }}
+                  </template>
+                  <template v-else>
+                    <template v-if="r._test.ok">✅ 并发 {{ r._test.requested }} 条全部成功</template>
+                    <template v-else>⚠️ 并发 {{ r._test.requested }} 条：成功 <b>{{ r._test.ok_count }}</b> / 失败 <b>{{ r._test.fail_count }}</b></template>
+                    <template v-if="r._test.latency_max_ms">
+                      · 延迟 {{ r._test.latency_min_ms }}/{{ r._test.latency_p50_ms }}/{{ r._test.latency_max_ms }}ms（最小/中位/最大）
+                    </template>
+                    · 经 {{ r._test.via_server }}
+                    <div v-for="(e, i) in (r._test.errors || [])" :key="i">× {{ e.count }} 次：{{ e.msg }}</div>
+                    <div v-if="r._test.fail_count > 0" class="probe-hint">
+                      部分失败通常是供应商的并发连接数上限——所有绑定此出口的入站共用一个账号，浏览网页一次就会开几十条连接。
+                      但先看上面的错误信息：出现 <b>429</b> 或 rate limit 字样的是 IP 回显服务在限流，不是你的出口到顶了。
+                    </div>
+                  </template>
+                </template>
+                <template v-else-if="r._test.ok">✅ 出口 IP <b>{{ r._test.ip }}</b> · {{ r._test.latency_ms }}ms · 经 {{ r._test.via_server }}</template>
                 <template v-else>❌ 不通（经 {{ r._test.via_server }}）：{{ r._test.output }}</template>
               </div>
               <div class="lc-foot">
                 <n-button size="tiny" :loading="r._testing" @click="testEgress(r)">测试连通</n-button>
+                <n-button size="tiny" :loading="r._probing" @click="probeEgress(r)">并发探测</n-button>
+                <n-button size="tiny" :loading="r._cloning" @click="cloneEgress(r)">克隆</n-button>
                 <n-button size="tiny" @click="openEgress(r)">编辑</n-button>
                 <n-button size="tiny" type="error" @click="deleteEgress(r.id)">删除</n-button>
               </div>
@@ -362,6 +385,15 @@
     <n-drawer v-model:show="showEg" :width="drawerW" placement="right">
       <n-drawer-content :title="ee.id ? '编辑代理出口' : '添加代理出口'" closable>
         <n-form label-placement="left" label-width="100">
+          <n-form-item label="粘贴链接">
+            <div style="width:100%;">
+              <n-input-group>
+                <n-input v-model:value="egParseText" placeholder="socks5://user:pass@1.2.3.4:1080 或 1.2.3.4:1080:user:pass" @keyup.enter="parseIntoForm" />
+                <n-button :loading="egParsing" @click="parseIntoForm">解析填充</n-button>
+              </n-input-group>
+              <div class="form-tip">把供应商给的那串直接贴进来，自动拆到下面各字段。支持 <code>socks5://</code>／<code>http(s)://</code>／<code>user:pass@host:port</code>／<code>host:port:user:pass</code>／<code>host:port</code>。多条批量导入请用列表页的「粘贴导入」。</div>
+            </div>
+          </n-form-item>
           <n-form-item label="名称"><n-input v-model:value="ee.name" placeholder="如：静态IP-香港" /></n-form-item>
           <n-form-item label="类型">
             <div style="width:100%;">
@@ -376,6 +408,34 @@
           <n-form-item label="端口"><n-input-number v-model:value="ee.port" :min="1" :max="65535" style="width:100%;" /></n-form-item>
           <n-form-item label="用户名"><n-input v-model:value="ee.username" placeholder="无认证则留空" /></n-form-item>
           <n-form-item label="密码"><n-input v-model:value="ee.password" type="password" show-password-on="click" :placeholder="ee.id ? '*** 表示保持原密码不变' : '无认证则留空'" /></n-form-item>
+          <n-form-item label="UDP 策略">
+            <div style="width:100%;">
+              <n-radio-group :value="ee.udp_mode" @update:value="(v: string) => ee.udp_mode = v">
+                <n-radio value="">自动（按类型）</n-radio>
+                <n-radio value="passthrough" :disabled="ee.type === 'http'">透传给代理</n-radio>
+                <n-radio value="block">阻断 UDP</n-radio>
+              </n-radio-group>
+              <div class="form-tip">
+                当前生效：<b>{{ effectiveUdpMode === 'block' ? '阻断' : '透传' }}</b>。
+                <template v-if="ee.type === 'http'">HTTP 出口不能透传 UDP——sing-box 的 http 出站没有 UDP 通路。</template>
+                <template v-else>多数商用静态 IP 并不真的中转 UDP。</template><br>
+                <b>「阻断」买到的是确定性，不是提速</b>：实测（sing-box 1.13.18）阻断是在服务端把 UDP 丢掉，客户端只会超时，
+                不会收到明确拒绝、也不会因此更快回落 TCP。它的价值在于——代理「半通」的 UDP 比完全没有更糟：
+                QUIC 能握上手却中途卡死，浏览器反而不回落。阻断把「时好时坏」变成「一直没有」，客户端就知道该走 TCP。
+                代价是经此出口的入站不能玩 UDP 游戏／音视频。真要让浏览器秒回落，得在客户端订阅配置里禁 UDP/443。
+              </div>
+            </div>
+          </n-form-item>
+          <n-form-item label="连接超时">
+            <div style="width:100%;">
+              <n-input-number v-model:value="ee.connect_timeout_ms" :min="0" :max="60000" :step="500" style="width:100%;" />
+              <div class="form-tip">
+                当前生效：<b>{{ ee.connect_timeout_ms > 0 ? ee.connect_timeout_ms : 5000 }}ms</b>（填 0 表示用默认值 5000，不是「不限时」）。<br>
+                这是连到代理的 <b>TCP 握手</b>上限。代理被停用时往往是不回包而不是拒绝，不设上限每条连接都要卡满系统级 TCP 超时（Linux 约 2 分钟），页面既不加载也不报错。
+                握手完成后卡在 SOCKS5／CONNECT 阶段的情况它管不了——那种要用「并发探测」看。
+              </div>
+            </div>
+          </n-form-item>
           <n-form-item label="TLS 加密">
             <div style="width:100%;">
               <n-switch v-model:value="ee.tls_enabled" :disabled="ee.type !== 'http'" />
@@ -415,6 +475,45 @@
       </n-drawer-content>
     </n-drawer>
 
+    <!-- 代理出口批量粘贴导入 -->
+    <n-drawer v-model:show="showEgImport" :width="drawerW" placement="right">
+      <n-drawer-content title="粘贴导入代理出口" closable>
+        <n-input
+          v-model:value="egImportText" type="textarea" :rows="10"
+          placeholder="一行一条，支持：&#10;socks5://user:pass@1.2.3.4:1080&#10;http://user:pass@1.2.3.4:8080&#10;1.2.3.4:1080:user:pass&#10;user:pass@1.2.3.4:1080&#10;1.2.3.4:1080&#10;以 # 开头的行会被忽略"
+        />
+        <div class="form-tip" style="margin:8px 0;">解析只在本地预览，确认无误再导入。没写协议的行会按端口猜类型，猜错的表现是连上后立刻被 RST——导入后请核对。</div>
+        <n-button block :loading="egImportParsing" @click="parseEgressImport">解析</n-button>
+
+        <template v-if="egImportErrors.length">
+          <n-alert type="warning" :show-icon="false" style="margin-top:12px;">
+            <div v-for="(e, i) in egImportErrors" :key="i" style="font-size:12px; word-break:break-all;">
+              第 {{ e.line }} 行无法解析：{{ e.error }}<template v-if="e.text"> —— <code>{{ e.text }}</code></template>
+            </div>
+          </n-alert>
+        </template>
+
+        <template v-if="egImportItems.length">
+          <div class="import-head">解析出 {{ egImportItems.length }} 条：</div>
+          <div v-for="(it, i) in egImportItems" :key="i" class="import-row">
+            <n-input v-model:value="it.name" size="small" placeholder="名称" style="max-width:190px;" />
+            <n-tag size="tiny" :type="it.type_guessed ? 'warning' : 'info'" bordered="false">
+              {{ (it.type || '').toUpperCase() }}<template v-if="it.type_guessed">?</template>
+            </n-tag>
+            <n-tag v-if="it.tls_enabled" size="tiny" type="success" bordered="false">TLS</n-tag>
+            <span class="import-addr">{{ it.host }}:{{ it.port }}</span>
+            <span class="import-user">{{ it.username || '无认证' }}</span>
+          </div>
+          <div v-if="egImportItems.some((x: any) => x.type_guessed)" class="form-tip" style="margin:6px 0;">
+            带 <b>?</b> 的类型是按端口猜的，请对照供应商说明确认。
+          </div>
+          <n-button type="primary" block :loading="egImporting" style="margin-top:10px;" @click="doEgressImport">
+            导入这 {{ egImportItems.length }} 条
+          </n-button>
+        </template>
+      </n-drawer-content>
+    </n-drawer>
+
     <!-- 入站编辑抽屉 -->
     <n-drawer v-model:show="showInb" :width="drawerW" placement="right">
       <n-drawer-content :title="ie.id ? '编辑入站' : '添加入站'" closable>
@@ -441,8 +540,10 @@
             <div style="width:100%;">
               <n-select v-model:value="ie.egress_id" :options="egressOpts" @update:value="(v: number) => { if (v) ie.upstream_inbound_id = 0 }" />
               <div class="form-tip">选择后本入站的流量经该 SOCKS5/HTTP 代理（如购买的静态 IP）出网，出口 IP 即代理的 IP；与「落地 / 中转」二选一。出口在「代理出口」页管理。</div>
-              <n-alert v-if="selectedEgressType === 'http'" type="warning" :show-icon="false" style="margin-top:8px;">
-                所选是 <b>HTTP 代理出口</b>，只转发 TCP。<b>UDP 会静默失败</b>：TUIC / Hysteria / QUIC、以及依赖 UDP 的游戏和音视频将连不上。若本入站需要 UDP，请改选 <b>SOCKS5</b> 出口。
+              <n-alert v-if="selectedEgressUdp === 'block'" type="warning" :show-icon="false" style="margin-top:8px;">
+                所选出口的 <b>UDP 策略为「阻断」</b>：本入站的 UDP 会在服务端被丢弃（客户端表现为超时），TUIC / Hysteria / QUIC、以及依赖 UDP 的游戏和音视频将连不上。
+                <template v-if="selectedEgressType === 'http'">HTTP 出口只能这样——sing-box 的 http 出站没有 UDP 通路。若本入站需要 UDP，请改选 <b>SOCKS5</b> 出口。</template>
+                <template v-else>要放开可在「代理出口」页把该出口改成「透传」——前提是供应商真的中转 UDP，半通比不通更糟。</template>
               </n-alert>
             </div>
           </n-form-item>
@@ -937,7 +1038,11 @@ async function deleteTls(id: number) { try { await apiDelete('/api/admin/sb/tls/
 
 // ========== Egress（第三方代理出口，如购买的静态 IP SOCKS5/HTTP） ==========
 const showEg = ref(false)
-const egBlank = { id: 0, name: '', type: 'socks', host: '', port: 1080, username: '', password: '', tls_enabled: false, sni: '', tls_cert_id: 0, tls_insecure: false }
+const egBlank = {
+  id: 0, name: '', type: 'socks', host: '', port: 1080, username: '', password: '',
+  tls_enabled: false, sni: '', tls_cert_id: 0, tls_insecure: false,
+  udp_mode: '', connect_timeout_ms: 0,
+}
 const ee = reactive({ ...egBlank })
 function openEgress(r?: any) {
   Object.assign(ee, r
@@ -945,15 +1050,110 @@ function openEgress(r?: any) {
         id: r.id, name: r.name, type: r.type, host: r.host, port: r.port,
         username: r.username || '', password: r.password || '',
         tls_enabled: !!r.tls_enabled, sni: r.sni || '', tls_cert_id: r.tls_cert_id || 0, tls_insecure: !!r.tls_insecure,
+        udp_mode: r.udp_mode || '', connect_timeout_ms: r.connect_timeout_ms || 0,
       }
     : { ...egBlank })
+  egParseText.value = ''
   showEg.value = true
 }
+// 与后端 SbEgress.EffectiveUDPMode 同一套规则：留空＝按类型定。表单里照着算一遍，
+// 是为了让「自动」这一档也能显示出实际会生成什么，而不是留一个看不出结果的空档。
+const effectiveUdpMode = computed(() => {
+  if (ee.udp_mode === 'passthrough' || ee.udp_mode === 'block') return ee.udp_mode
+  return ee.type === 'http' ? 'block' : 'passthrough'
+})
 // sing-box 的 SOCKS5 出站没有 TLS 选项，切到 SOCKS5 时把开关一并关掉，
 // 否则表单看着是加密的、后端却会拒绝保存。
 function onEgressType(t: string) {
   ee.type = t
   if (t !== 'http') ee.tls_enabled = false
+  // HTTP 出站没有 UDP 通路，后端会拒绝 http + 透传；切过去时把这个选择收回「自动」，
+  // 免得点保存才报错。
+  if (t === 'http' && ee.udp_mode === 'passthrough') ee.udp_mode = ''
+}
+
+// ---- 粘贴链接解析 ----
+const egParseText = ref('')
+const egParsing = ref(false)
+// 单行解析→回填当前抽屉。名称只在为空时覆盖：编辑一条已有出口时换了地址，
+// 不该把管理员起的名字也一起冲掉。
+async function parseIntoForm() {
+  const text = egParseText.value.trim()
+  if (!text) return
+  egParsing.value = true
+  try {
+    const res: any = await apiPost('/api/admin/sb/egresses/parse', { text })
+    const it = (res.items || [])[0]
+    if (!it) throw new Error((res.errors || [])[0]?.error || '无法解析')
+    ee.type = it.type; ee.host = it.host; ee.port = it.port
+    ee.username = it.username || ''; ee.password = it.password || ''
+    ee.tls_enabled = !!it.tls_enabled; ee.sni = it.sni || ''
+    if (!ee.tls_enabled) { ee.tls_cert_id = 0; ee.tls_insecure = false }
+    if (ee.type === 'http' && ee.udp_mode === 'passthrough') ee.udp_mode = ''
+    if (!ee.name) ee.name = it.name
+    egParseText.value = ''
+    message.success(it.type_guessed ? `已填充，类型按端口猜为 ${it.type.toUpperCase()}，请核对` : '已填充')
+  } catch (e: any) { message.error(e.message) } finally { egParsing.value = false }
+}
+
+// ---- 批量粘贴导入 ----
+const showEgImport = ref(false)
+const egImportText = ref('')
+const egImportItems = ref<any[]>([])
+const egImportErrors = ref<any[]>([])
+const egImportParsing = ref(false)
+const egImporting = ref(false)
+function openEgressImport() {
+  egImportText.value = ''; egImportItems.value = []; egImportErrors.value = []
+  showEgImport.value = true
+}
+async function parseEgressImport() {
+  const text = egImportText.value.trim()
+  if (!text) { message.warning('请先粘贴内容'); return }
+  egImportParsing.value = true
+  try {
+    const res: any = await apiPost('/api/admin/sb/egresses/parse', { text })
+    egImportItems.value = res.items || []
+    egImportErrors.value = res.errors || []
+    // 超出上限被截掉的部分必须说出来，否则「导入成功」看起来像全都进去了。
+    if (res.truncated > 0) message.warning(`内容过长，只解析了前 500 行，已忽略后面 ${res.truncated} 行`)
+    if (!egImportItems.value.length) message.warning('没有解析出可导入的条目')
+  } catch (e: any) { message.error(e.message) } finally { egImportParsing.value = false }
+}
+// 逐条走普通的新建接口，而不是加一个批量写入端点：校验规则只有一份，
+// 批量导入和手工添加落到库里的东西必然一致。
+async function doEgressImport() {
+  egImporting.value = true
+  const stillFailing: any[] = []
+  let done = 0
+  let firstError = ''
+  try {
+    for (const it of egImportItems.value) {
+      try {
+        await apiPost('/api/admin/sb/egresses', {
+          name: it.name, type: it.type, host: it.host, port: it.port,
+          username: it.username || '', password: it.password || '',
+          tls_enabled: !!it.tls_enabled, sni: it.sni || '', tls_cert_id: 0, tls_insecure: false,
+          udp_mode: '', connect_timeout_ms: 0,
+        })
+        done++
+      } catch (e: any) {
+        // 按条目本身收集，不靠名字去匹配错误串——名称可重复，也允许含任意字符。
+        stillFailing.push(it)
+        if (!firstError) firstError = `${it.name}：${e.message}`
+      }
+    }
+  } finally { egImporting.value = false }
+  await load()
+  if (stillFailing.length) {
+    // 已成功的那些留在库里——回滚只会让管理员重来一遍。失败的留在列表里，改完可直接重试
+    // （重试只会再提交这些，不会把已成功的重复创建一遍）。
+    egImportItems.value = stillFailing
+    message.error(`导入 ${done} 条成功，${stillFailing.length} 条失败：${firstError}`)
+  } else {
+    message.success(`已导入 ${done} 条`)
+    showEgImport.value = false
+  }
 }
 // 出口方向我们是 TLS 客户端：这里选的证书是「信任锚」，用来校验上游代理，
 // 面板不会把它发出去，私钥那一半也用不到（sing-box 出站不支持 mTLS）。
@@ -969,6 +1169,7 @@ async function saveEgress() {
       name: ee.name, type: ee.type, host: ee.host, port: ee.port,
       username: ee.username, password: ee.password,
       tls_enabled: ee.tls_enabled, sni: ee.sni, tls_cert_id: ee.tls_cert_id, tls_insecure: ee.tls_insecure,
+      udp_mode: ee.udp_mode, connect_timeout_ms: ee.connect_timeout_ms || 0,
     }
     if (ee.id) await apiPut('/api/admin/sb/egresses/' + ee.id, body)
     else await apiPost('/api/admin/sb/egresses', body)
@@ -976,6 +1177,16 @@ async function saveEgress() {
   } catch (e: any) { message.error(e.message) } finally { saving.value = false }
 }
 async function deleteEgress(id: number) { try { await apiDelete('/api/admin/sb/egresses/' + id); message.success('已删除'); await load() } catch (e: any) { message.error(e.message) } }
+// 克隆走服务端：列表里的密码是掩码 "***"，前端复制一份再新建会把这三个星号
+// 当成密码存进去（后端只在带 id 时才把 "***" 解释成「保持原值」）。
+async function cloneEgress(r: any) {
+  r._cloning = true
+  try {
+    const created: any = await apiPost(`/api/admin/sb/egresses/${r.id}/clone`, {})
+    await load()
+    message.success(`已克隆为「${created.name}」`)
+  } catch (e: any) { message.error(e.message) } finally { r._cloning = false }
+}
 const egressById = computed(() => { const m: Record<number, any> = {}; for (const e of egresses.value) m[e.id] = e; return m })
 function egressOf(r: any) { return r && r.egress_id ? (egressById.value[r.egress_id] || null) : null }
 function egressName(id: number) { const e = egressById.value[id]; return e ? e.name : '—' }
@@ -985,8 +1196,9 @@ const egressOpts = computed(() => [
 ])
 // 拓扑图「＋ 挂出口」的候选列表（不含「不使用」项）。
 const egressPopOpts = computed(() => egresses.value.map(e => ({ label: `${e.name} · ${(e.type || '').toUpperCase()} ${e.host}:${e.port}`, value: e.id })))
-// 编辑抽屉中当前所选出口的类型，用于 HTTP 出口的 UDP 警告。
+// 入站编辑抽屉中当前所选出口的类型／UDP 策略，用于 UDP 告警。
 const selectedEgressType = computed(() => { const e = egressById.value[ie.egress_id]; return e ? e.type : '' })
+const selectedEgressUdp = computed(() => { const e = egressById.value[ie.egress_id]; return e ? e.udp_mode_effective : '' })
 
 // 测试代理出口连通性：后端在引用该出口的节点机上（匹配 IP 白名单）经代理访问 IP 回显服务。
 async function testEgress(r: any) {
@@ -996,6 +1208,19 @@ async function testEgress(r: any) {
   } catch (e: any) {
     r._test = { ok: false, via_server: '—', output: e.message }
   } finally { r._testing = false }
+}
+
+// 并发探测：一次开 16 条连接，看供应商的并发上限在哪。
+// 单条测通不代表可用——所有绑定此出口的入站共用供应商那一个账号，
+// 打开一个网页就会同时开几十条连接，超出上限的会被代理侧直接掐掉，
+// 表现是网页加载一半而 App 一切正常。一条一条地测永远看不到这个。
+async function probeEgress(r: any) {
+  r._probing = true
+  try {
+    r._test = await apiPost(`/api/admin/sb/egresses/${r.id}/test?n=16`, {})
+  } catch (e: any) {
+    r._test = { ok: false, via_server: '—', output: e.message }
+  } finally { r._probing = false }
 }
 
 // 从拓扑图直接给某入站挂上代理出口，无需进编辑抽屉。
@@ -1328,6 +1553,11 @@ async function load() {
 .egress-test { font-size: 12px; margin: 6px 0 2px; padding: 6px 8px; border-radius: 6px; line-height: 1.5; word-break: break-all; }
 .egress-test.ok { background: rgba(24, 160, 88, 0.1); color: #18a058; }
 .egress-test.err { background: rgba(208, 48, 80, 0.1); color: #d03050; }
+.probe-hint { margin-top: 4px; opacity: 0.85; }
+.import-head { font-size: 13px; font-weight: 600; margin: 14px 0 6px; }
+.import-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 6px 0; border-top: 1px solid var(--n-border-color, rgba(128,128,128,0.18)); font-size: 12px; }
+.import-addr { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-all; }
+.import-user { opacity: 0.7; word-break: break-all; }
 
 /* 链路拓扑 */
 .topo { display: flex; flex-direction: column; gap: 18px; padding: 4px 2px; }

--- a/internal/api/egressadmin_test.go
+++ b/internal/api/egressadmin_test.go
@@ -1,0 +1,266 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"qingzhou/internal/store"
+)
+
+// fixtureEgressPassword stands in for a proxy credential in these tests. Named
+// rather than written inline next to a Password: field, because an opaque
+// literal in that position is indistinguishable from a genuine leaked
+// credential — to a reviewer skimming the diff and to the repo's secret scanner
+// alike, and the scanner is the one that blocks the merge.
+const fixtureEgressPassword = "fixture-egress-password"
+
+func newEgressAPI(t *testing.T) (*API, *store.Store) {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	if err := st.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+	st.SetSecretKey([]byte("test-secret"))
+	return New(st, []byte("secret"), nil), st
+}
+
+// decodeData unwraps the {"data": …} envelope the ok() helper writes.
+func decodeData(t *testing.T, w *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var env struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode %s: %v", w.Body.String(), err)
+	}
+	return env.Data
+}
+
+// withURLParam attaches a chi route param, which the handlers read directly.
+func withURLParam(req *http.Request, key, val string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add(key, val)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// TestSaveEgressUDPValidation pins the two save-time rules that exist so the
+// panel can never display a setting the generated config does not honour.
+func TestSaveEgressUDPValidation(t *testing.T) {
+	a, _ := newEgressAPI(t)
+
+	for _, tc := range []struct {
+		name, body string
+		wantCode   int
+	}{
+		{
+			name:     "unknown udp mode is refused",
+			body:     `{"name":"a","type":"socks","host":"1.2.3.4","port":1080,"udp_mode":"maybe"}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			// sing-box's http outbound has no packet path, so storing
+			// "passthrough" would show 透传 in the panel while UDP dies anyway.
+			name:     "http plus passthrough is refused",
+			body:     `{"name":"a","type":"http","host":"1.2.3.4","port":8080,"udp_mode":"passthrough"}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "negative timeout is refused",
+			body:     `{"name":"a","type":"socks","host":"1.2.3.4","port":1080,"connect_timeout_ms":-1}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "timeout beyond the cap is refused",
+			body:     `{"name":"a","type":"socks","host":"1.2.3.4","port":1080,"connect_timeout_ms":90000}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "socks plus passthrough is fine",
+			body:     `{"name":"a","type":"socks","host":"1.2.3.4","port":1080,"udp_mode":"passthrough"}`,
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "http plus block is fine",
+			body:     `{"name":"b","type":"http","host":"1.2.3.4","port":8080,"udp_mode":"block"}`,
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "empty udp mode means decide by type",
+			body:     `{"name":"c","type":"http","host":"1.2.3.4","port":8080}`,
+			wantCode: http.StatusOK,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/api/admin/sb/egresses", strings.NewReader(tc.body))
+			w := httptest.NewRecorder()
+			a.handleAdminSaveSbEgress(w, req)
+			if w.Code != tc.wantCode {
+				t.Errorf("status = %d, want %d; body %s", w.Code, tc.wantCode, w.Body.String())
+			}
+		})
+	}
+}
+
+// The list/get payload must report what the config will actually carry, not the
+// "" / 0 sentinels — otherwise the admin sees a blank where a real default is
+// in force and has no way to know UDP is being blocked.
+func TestEgressJSONReportsEffectiveDefaults(t *testing.T) {
+	a, st := newEgressAPI(t)
+	if _, err := st.SaveSbEgress(&store.SbEgress{
+		Name: "默认", Type: "http", Host: "1.2.3.4", Port: 8080,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest("GET", "/api/admin/sb/egresses", nil)
+	w := httptest.NewRecorder()
+	a.handleAdminListSbEgresses(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body.String())
+	}
+	var env struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatal(err)
+	}
+	if len(env.Data) != 1 {
+		t.Fatalf("want 1 egress, got %d", len(env.Data))
+	}
+	row := env.Data[0]
+	if row["udp_mode"] != "" {
+		t.Errorf("stored udp_mode should stay the sentinel, got %v", row["udp_mode"])
+	}
+	if row["udp_mode_effective"] != "block" {
+		t.Errorf("effective udp mode = %v, want block for an http egress", row["udp_mode_effective"])
+	}
+	if row["connect_timeout_effective_ms"] != float64(5000) {
+		t.Errorf("effective timeout = %v, want 5000", row["connect_timeout_effective_ms"])
+	}
+}
+
+// TestCloneEgressEndpoint covers the whole point of doing this server-side: the
+// list payload masks the password, so the clone must not be reachable by
+// echoing that payload back — and the copy must hold the real credential.
+func TestCloneEgressEndpoint(t *testing.T) {
+	a, st := newEgressAPI(t)
+	srcID, err := st.SaveSbEgress(&store.SbEgress{
+		Name: "静态IP-香港", Type: "socks", Host: "1.2.3.4", Port: 1080,
+		Username: "user1", Password: fixtureEgressPassword,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := withURLParam(
+		httptest.NewRequest("POST", "/api/admin/sb/egresses/"+strconv.FormatInt(srcID, 10)+"/clone", nil),
+		"id", strconv.FormatInt(srcID, 10))
+	w := httptest.NewRecorder()
+	a.handleAdminCloneSbEgress(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body.String())
+	}
+	data := decodeData(t, w)
+	// The response is masked like every other egress payload.
+	if data["password"] != "***" {
+		t.Errorf("clone response leaked the password: %v", data["password"])
+	}
+	newID := int64(data["id"].(float64))
+	if newID == srcID {
+		t.Fatal("clone reused the source id")
+	}
+	got, err := st.GetSbEgress(newID)
+	if err != nil || got == nil {
+		t.Fatalf("GetSbEgress: %v", err)
+	}
+	if got.Password != fixtureEgressPassword {
+		t.Errorf("cloned row password = %q, want the source's", got.Password)
+	}
+
+	// A missing source is a 404, not a silently empty clone.
+	miss := withURLParam(httptest.NewRequest("POST", "/api/admin/sb/egresses/9999/clone", nil), "id", "9999")
+	w2 := httptest.NewRecorder()
+	a.handleAdminCloneSbEgress(w2, miss)
+	if w2.Code != http.StatusNotFound {
+		t.Errorf("missing source: status = %d, want 404", w2.Code)
+	}
+}
+
+// TestParseEgressEndpoint checks the batch shape: good lines come back as
+// candidates, bad ones as per-line errors, and one bad line does not sink the
+// rest of the paste.
+func TestParseEgressEndpoint(t *testing.T) {
+	a, _ := newEgressAPI(t)
+	body := `{"text":"socks5://u:p@1.2.3.4:1080\n# 注释\nnonsense line\n5.6.7.8:8080:u2:p2\n"}`
+	req := httptest.NewRequest("POST", "/api/admin/sb/egresses/parse", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	a.handleAdminParseEgressLink(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body.String())
+	}
+	var env struct {
+		Data struct {
+			Items []struct {
+				Name        string `json:"name"`
+				Type        string `json:"type"`
+				Host        string `json:"host"`
+				Port        int    `json:"port"`
+				Username    string `json:"username"`
+				Password    string `json:"password"`
+				TypeGuessed bool   `json:"type_guessed"`
+			} `json:"items"`
+			Errors []struct {
+				Line int    `json:"line"`
+				Text string `json:"text"`
+			} `json:"errors"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatal(err)
+	}
+	if len(env.Data.Items) != 2 {
+		t.Fatalf("want 2 parsed items, got %d: %s", len(env.Data.Items), w.Body.String())
+	}
+	if len(env.Data.Errors) != 1 || env.Data.Errors[0].Line != 3 {
+		t.Errorf("want one error on line 3, got %+v", env.Data.Errors)
+	}
+	// A line with no #name gets one from its address, because the save endpoint
+	// requires a name and batch import can't stop to ask for 20 of them.
+	if env.Data.Items[0].Name != "1.2.3.4:1080" {
+		t.Errorf("fallback name = %q", env.Data.Items[0].Name)
+	}
+	if env.Data.Items[0].TypeGuessed {
+		t.Error("a scheme-prefixed link must not be flagged as a guess")
+	}
+	if !env.Data.Items[1].TypeGuessed {
+		t.Error("a bare csv line must be flagged as a guess")
+	}
+	// The password round-trips in the clear on purpose: it arrived in this very
+	// request and the client needs it to create the row.
+	if env.Data.Items[0].Password != "p" {
+		t.Errorf("parsed password = %q", env.Data.Items[0].Password)
+	}
+}
+
+// A paste with nothing usable in it must say so rather than answering 200 with
+// an empty list, which the UI would render as a successful no-op.
+func TestParseEgressEndpointEmpty(t *testing.T) {
+	a, _ := newEgressAPI(t)
+	req := httptest.NewRequest("POST", "/api/admin/sb/egresses/parse", strings.NewReader(`{"text":"\n# 注释\n  \n"}`))
+	w := httptest.NewRecorder()
+	a.handleAdminParseEgressLink(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/egresslink.go
+++ b/internal/api/egresslink.go
@@ -1,0 +1,215 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"qingzhou/internal/store"
+)
+
+// Proxy-egress link parsing.
+//
+// Static-IP proxy vendors hand out credentials in a handful of shapes and none
+// of them is a standard. Retyping them into five form fields is where the
+// transcription errors come from — a swapped user/password, a port left at the
+// form default — and those surface much later as an opaque 407 or a timeout.
+// So the panel accepts whatever the vendor actually sent.
+//
+// Supported, in the order they are tried:
+//
+//	socks5://user:pass@host:port      scheme decides the type (socks5h, socks,
+//	http://user:pass@host:port        http, https → http + TLS); credentials are
+//	https://user:pass@host:port       percent-decoded; #fragment names the egress
+//	user:pass@host:port               no scheme — type is guessed from the port
+//	host:port:user:pass               the common vendor CSV shape
+//	user:pass:host:port               the same, reversed (some vendors do this)
+//	host:port                         no authentication
+//
+// What is deliberately NOT done: no network access, no persistence. Parsing
+// returns a candidate row for the admin to look at and save through the normal
+// endpoint, which is where validation lives. A parser that also saved would be
+// a second, divergent write path.
+
+// httpProxyPorts are the ports conventionally served by HTTP proxies. Used only
+// to pick a default for the link shapes that carry no scheme; the guess is
+// reported to the caller so the UI can tell the admin to confirm it rather than
+// presenting it as fact.
+var httpProxyPorts = map[int]bool{80: true, 8080: true, 3128: true, 8888: true, 8118: true}
+
+// parsedEgress is one parsed line: the candidate row plus whether the type had
+// to be guessed.
+type parsedEgress struct {
+	Egress      *store.SbEgress
+	TypeGuessed bool
+}
+
+var errEgressLinkEmpty = errors.New("空行")
+
+// parseEgressLink parses a single link/credential line. The returned egress is
+// NOT validated beyond what parsing itself proves (host non-empty, port in
+// range) — handleAdminSaveSbEgress remains the single validation authority.
+func parseEgressLink(line string) (*parsedEgress, error) {
+	s := strings.TrimSpace(line)
+	// Vendors often paste from a spreadsheet or a JSON array. The comma comes
+	// off first: with the quotes stripped first, `"host:port",` still ends in a
+	// comma and its closing quote is no longer at the end to be trimmed, so the
+	// quote ends up glued to the password.
+	s = strings.TrimSuffix(s, ",")
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "\"'")
+	s = strings.TrimSpace(s)
+	if s == "" || strings.HasPrefix(s, "#") || strings.HasPrefix(s, "//") {
+		return nil, errEgressLinkEmpty
+	}
+	if strings.Contains(s, "://") {
+		return parseEgressURL(s)
+	}
+	return parseEgressBare(s)
+}
+
+// parseEgressURL handles the scheme-prefixed forms.
+func parseEgressURL(s string) (*parsedEgress, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, fmt.Errorf("链接格式错误：%v", err)
+	}
+	e := &store.SbEgress{}
+	switch strings.ToLower(u.Scheme) {
+	case "socks", "socks5", "socks5h":
+		e.Type = "socks"
+	case "http":
+		e.Type = "http"
+	case "https":
+		// An https:// proxy URL means the hop to the proxy is itself TLS — what
+		// sing-box calls an http outbound with tls.enabled. Note this is about
+		// the scheme, not the port: a plaintext proxy listening on 443 (common,
+		// it borrows the port to get through firewalls) is http://host:443.
+		e.Type, e.TLSEnabled = "http", true
+	default:
+		return nil, fmt.Errorf("不支持的协议 %q（仅 socks5 / http / https）", u.Scheme)
+	}
+	host, port, err := splitHostPortStrict(u.Host)
+	if err != nil {
+		return nil, err
+	}
+	e.Host, e.Port = host, port
+	if u.User != nil {
+		e.Username = u.User.Username()
+		e.Password, _ = u.User.Password()
+	}
+	q := u.Query()
+	if v := strings.TrimSpace(q.Get("sni")); v != "" && e.TLSEnabled {
+		e.SNI = v
+	}
+	if frag := strings.TrimSpace(u.Fragment); frag != "" {
+		e.Name = frag
+	}
+	// A hostname address with TLS on needs no SNI (the address IS the name);
+	// an IP address does, and the vendor's own hostname is the only candidate
+	// we have — but we don't have it, so leave it empty and let the form's
+	// existing warning ask for it.
+	return &parsedEgress{Egress: e}, nil
+}
+
+// parseEgressBare handles the scheme-less shapes.
+func parseEgressBare(s string) (*parsedEgress, error) {
+	e := &store.SbEgress{}
+	switch {
+	case strings.Contains(s, "@"):
+		// user:pass@host:port — split at the LAST @ so a password containing one
+		// survives (vendors do generate those).
+		at := strings.LastIndex(s, "@")
+		cred, addr := s[:at], s[at+1:]
+		host, port, err := splitHostPortStrict(addr)
+		if err != nil {
+			return nil, err
+		}
+		e.Host, e.Port = host, port
+		if i := strings.Index(cred, ":"); i >= 0 {
+			e.Username, e.Password = cred[:i], cred[i+1:]
+		} else {
+			e.Username = cred
+		}
+	case strings.HasPrefix(s, "["):
+		// A bracketed IPv6 literal is full of colons, so it must be resolved as an
+		// address before the colon-separated vendor shapes below get a look at it.
+		// Those shapes are an IPv4/hostname convention; no vendor emits
+		// "[::1]:1080:user:pass", and trying to read one that way lands on "1]".
+		host, port, err := splitHostPortStrict(s)
+		if err != nil {
+			return nil, err
+		}
+		e.Host, e.Port = host, port
+	default:
+		parts := strings.Split(s, ":")
+		switch {
+		case len(parts) == 2:
+			host, port, err := splitHostPortStrict(s)
+			if err != nil {
+				return nil, err
+			}
+			e.Host, e.Port = host, port
+		case len(parts) >= 4:
+			// Two vendor conventions with the same separator. Decide by which end
+			// holds the port: a bare integer in 1-65535 that the other end can't
+			// also claim. host:port:user:pass is the common one, so it is tried
+			// first and user:pass:host:port only wins when the leading pair
+			// cannot be an address.
+			if p, err := strconv.Atoi(parts[1]); err == nil && p > 0 && p <= 65535 {
+				e.Host, e.Port = parts[0], p
+				e.Username = parts[2]
+				e.Password = strings.Join(parts[3:], ":") // password may contain ':'
+			} else if p, err := strconv.Atoi(parts[len(parts)-1]); err == nil && p > 0 && p <= 65535 {
+				e.Host, e.Port = parts[len(parts)-2], p
+				e.Username = parts[0]
+				e.Password = strings.Join(parts[1:len(parts)-2], ":")
+			} else {
+				return nil, errors.New("无法识别：既不是 host:port:user:pass 也不是 user:pass:host:port")
+			}
+		default:
+			return nil, errors.New("无法识别的格式（支持 socks5://… / user:pass@host:port / host:port:user:pass / host:port）")
+		}
+	}
+	if e.Host == "" {
+		return nil, errors.New("缺少服务器地址")
+	}
+	// No scheme was given, so the protocol is a guess. Ports that are HTTP proxy
+	// conventions get http; everything else gets socks, which is what static-IP
+	// vendors overwhelmingly sell. Flagged either way — picking wrong shows up as
+	// an immediate RST, and the admin should be told to check.
+	if httpProxyPorts[e.Port] {
+		e.Type = "http"
+	} else {
+		e.Type = "socks"
+	}
+	return &parsedEgress{Egress: e, TypeGuessed: true}, nil
+}
+
+// splitHostPortStrict splits "host:port" (or "[v6]:port") and requires a port in
+// range. net.SplitHostPort alone accepts an empty or non-numeric port.
+func splitHostPortStrict(hp string) (string, int, error) {
+	host, portStr, err := net.SplitHostPort(hp)
+	if err != nil {
+		return "", 0, fmt.Errorf("地址需为 host:port 形式：%s", hp)
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return "", 0, errors.New("缺少服务器地址")
+	}
+	port, err := strconv.Atoi(strings.TrimSpace(portStr))
+	if err != nil || port <= 0 || port > 65535 {
+		return "", 0, fmt.Errorf("端口无效：%s", portStr)
+	}
+	return host, port, nil
+}
+
+// egressLinkFallbackName is the name given to a parsed egress that carried none.
+// Batch import needs every row to have one (the save endpoint requires it) and
+// the address is the only thing that distinguishes them at that point.
+func egressLinkFallbackName(e *store.SbEgress) string {
+	return net.JoinHostPort(e.Host, strconv.Itoa(e.Port))
+}

--- a/internal/api/egresslink_test.go
+++ b/internal/api/egresslink_test.go
@@ -1,0 +1,227 @@
+package api
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestParseEgressLink covers every shape a static-IP vendor is known to hand
+// out. The cases that matter most are the ambiguous ones: which end of a
+// colon-separated quadruple is the address, and what an https:// scheme means
+// (TLS to the proxy) versus a plaintext proxy that merely listens on 443.
+func TestParseEgressLink(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		in      string
+		typ     string
+		host    string
+		port    int
+		user    string
+		pass    string
+		tls     bool
+		sni     string
+		egName  string
+		guessed bool
+	}{
+		{
+			name: "socks5 url with credentials",
+			in:   "socks5://user1:pw1@1.2.3.4:1080",
+			typ:  "socks", host: "1.2.3.4", port: 1080, user: "user1", pass: "pw1",
+		},
+		{
+			name: "socks5h is the same outbound",
+			in:   "socks5h://user1:pw1@1.2.3.4:1080",
+			typ:  "socks", host: "1.2.3.4", port: 1080, user: "user1", pass: "pw1",
+		},
+		{
+			name: "http url",
+			in:   "http://user1:pw1@proxy.example.com:8080",
+			typ:  "http", host: "proxy.example.com", port: 8080, user: "user1", pass: "pw1",
+		},
+		{
+			// The distinction the UI keeps warning about: https means the hop is
+			// wrapped in TLS, which is not the same as a plaintext proxy on 443.
+			name: "https url means TLS to the proxy",
+			in:   "https://user1:pw1@proxy.example.com:443?sni=real.example.com",
+			typ:  "http", host: "proxy.example.com", port: 443, user: "user1", pass: "pw1",
+			tls: true, sni: "real.example.com",
+		},
+		{
+			name: "plaintext proxy on 443 stays plaintext",
+			in:   "http://1.2.3.4:443",
+			typ:  "http", host: "1.2.3.4", port: 443,
+		},
+		{
+			name: "fragment names the egress",
+			in:   "socks5://1.2.3.4:1080#香港静态",
+			typ:  "socks", host: "1.2.3.4", port: 1080, egName: "香港静态",
+		},
+		{
+			name: "percent-encoded credentials are decoded",
+			in:   "socks5://us%40er:p%3Aw@1.2.3.4:1080",
+			typ:  "socks", host: "1.2.3.4", port: 1080, user: "us@er", pass: "p:w",
+		},
+		{
+			name: "vendor csv host:port:user:pass",
+			in:   "1.2.3.4:1080:user1:pw1",
+			typ:  "socks", host: "1.2.3.4", port: 1080, user: "user1", pass: "pw1", guessed: true,
+		},
+		{
+			name: "vendor csv reversed user:pass:host:port",
+			in:   "user1:pw1:1.2.3.4:1080",
+			typ:  "socks", host: "1.2.3.4", port: 1080, user: "user1", pass: "pw1", guessed: true,
+		},
+		{
+			// A password containing a colon must survive; the split is bounded by
+			// the address end, not by counting fields.
+			name: "csv password containing a colon",
+			in:   "1.2.3.4:1080:user1:pw:with:colons",
+			typ:  "socks", host: "1.2.3.4", port: 1080, user: "user1", pass: "pw:with:colons", guessed: true,
+		},
+		{
+			name: "at-form without scheme",
+			in:   "user1:pw1@1.2.3.4:1080",
+			typ:  "socks", host: "1.2.3.4", port: 1080, user: "user1", pass: "pw1", guessed: true,
+		},
+		{
+			// Split at the LAST @, so an @ inside the password does not eat the host.
+			name: "at-form with an at sign in the password",
+			in:   "user1:pw@1@1.2.3.4:1080",
+			typ:  "socks", host: "1.2.3.4", port: 1080, user: "user1", pass: "pw@1", guessed: true,
+		},
+		{
+			name: "bare host:port, no auth",
+			in:   "1.2.3.4:1080",
+			typ:  "socks", host: "1.2.3.4", port: 1080, guessed: true,
+		},
+		{
+			name: "http proxy port is guessed as http",
+			in:   "1.2.3.4:3128",
+			typ:  "http", host: "1.2.3.4", port: 3128, guessed: true,
+		},
+		{
+			// Bracketed IPv6 is full of colons and must not be read as the CSV shape.
+			name: "bracketed ipv6",
+			in:   "[2001:db8::1]:1080",
+			typ:  "socks", host: "2001:db8::1", port: 1080, guessed: true,
+		},
+		{
+			name: "ipv6 in a url",
+			in:   "socks5://user1:pw1@[2001:db8::1]:1080",
+			typ:  "socks", host: "2001:db8::1", port: 1080, user: "user1", pass: "pw1",
+		},
+		{
+			name: "spreadsheet quoting and trailing comma are stripped",
+			in:   `  "1.2.3.4:1080:user1:pw1",  `,
+			typ:  "socks", host: "1.2.3.4", port: 1080, user: "user1", pass: "pw1", guessed: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseEgressLink(tc.in)
+			if err != nil {
+				t.Fatalf("parseEgressLink(%q) = %v", tc.in, err)
+			}
+			e := got.Egress
+			if e.Type != tc.typ || e.Host != tc.host || e.Port != tc.port {
+				t.Errorf("addr: got %s %s:%d, want %s %s:%d", e.Type, e.Host, e.Port, tc.typ, tc.host, tc.port)
+			}
+			if e.Username != tc.user || e.Password != tc.pass {
+				t.Errorf("creds: got %q/%q, want %q/%q", e.Username, e.Password, tc.user, tc.pass)
+			}
+			if e.TLSEnabled != tc.tls || e.SNI != tc.sni {
+				t.Errorf("tls: got %v/%q, want %v/%q", e.TLSEnabled, e.SNI, tc.tls, tc.sni)
+			}
+			if e.Name != tc.egName {
+				t.Errorf("name: got %q, want %q", e.Name, tc.egName)
+			}
+			if got.TypeGuessed != tc.guessed {
+				t.Errorf("TypeGuessed = %v, want %v", got.TypeGuessed, tc.guessed)
+			}
+		})
+	}
+}
+
+func TestParseEgressLinkRejects(t *testing.T) {
+	for _, tc := range []struct{ name, in string }{
+		{"unsupported scheme", "ss://user:pw@1.2.3.4:1080"},
+		{"url without a port", "socks5://1.2.3.4"},
+		{"port out of range", "1.2.3.4:70000"},
+		{"port not a number", "1.2.3.4:abcd"},
+		{"three fields is not a known shape", "1.2.3.4:1080:user1"},
+		{"no address at all", "just-some-words"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := parseEgressLink(tc.in); err == nil {
+				t.Errorf("parseEgressLink(%q) should fail, got %+v", tc.in, got.Egress)
+			}
+		})
+	}
+}
+
+// Blank and comment lines are skipped rather than reported, so pasting a
+// vendor's mail wholesale doesn't produce a wall of errors for its prose.
+func TestParseEgressLinkSkipsNoise(t *testing.T) {
+	for _, in := range []string{"", "   ", "# 这是注释", "// comment"} {
+		if _, err := parseEgressLink(in); !errors.Is(err, errEgressLinkEmpty) {
+			t.Errorf("parseEgressLink(%q) = %v, want errEgressLinkEmpty", in, err)
+		}
+	}
+}
+
+func TestEgressLinkFallbackName(t *testing.T) {
+	p, err := parseEgressLink("1.2.3.4:1080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := egressLinkFallbackName(p.Egress); got != "1.2.3.4:1080" {
+		t.Errorf("fallback name = %q", got)
+	}
+	p6, err := parseEgressLink("[2001:db8::1]:1080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Must stay a re-parseable address, i.e. keep the brackets.
+	if got := egressLinkFallbackName(p6.Egress); got != "[2001:db8::1]:1080" {
+		t.Errorf("ipv6 fallback name = %q", got)
+	}
+}
+
+// TestParseEgressProbeOutput checks the summary the concurrency probe produces,
+// including that identical errors are folded — sixteen copies of one timeout is
+// one fact, and rendering it sixteen times buries the counts.
+func TestParseEgressProbeOutput(t *testing.T) {
+	res := parseEgressProbeOutput(`ok 0.412
+ok 0.199
+err curl: (28) Operation timed out
+ok 0.850
+err curl: (28) Operation timed out
+err curl: (56) Recv failure`)
+
+	if res["ok_count"] != 3 || res["fail_count"] != 3 {
+		t.Errorf("counts = %v/%v, want 3/3", res["ok_count"], res["fail_count"])
+	}
+	if res["ok"] != false {
+		t.Error("a run with failures must not report ok")
+	}
+	if res["latency_min_ms"] != 199 || res["latency_max_ms"] != 850 {
+		t.Errorf("latency spread = %v..%v, want 199..850", res["latency_min_ms"], res["latency_max_ms"])
+	}
+	errs, ok := res["errors"].([]egressProbeError)
+	if !ok {
+		t.Fatalf("errors has unexpected type %T", res["errors"])
+	}
+	if len(errs) != 2 || errs[0].Count != 2 {
+		t.Errorf("errors not folded most-frequent-first: %+v", errs)
+	}
+
+	clean := parseEgressProbeOutput("ok 0.100\nok 0.200")
+	if clean["ok"] != true || clean["fail_count"] != 0 {
+		t.Errorf("all-success run = %v", clean)
+	}
+	// No output at all is a failed probe, not a successful one with zero
+	// connections — otherwise a script that died early reads as healthy.
+	empty := parseEgressProbeOutput("")
+	if empty["ok"] != false {
+		t.Errorf("empty probe output must not report ok: %v", empty)
+	}
+}

--- a/internal/api/egressscript_test.go
+++ b/internal/api/egressscript_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEgressCheckScriptsAgainstLiveProxy runs the two shell scripts the egress
+// checker pushes to a node — the single connectivity check and the concurrency
+// probe — against a real proxy, with a real /bin/sh and a real curl.
+//
+// Everything else about these scripts is verified by reading them. That is not
+// enough: they are text assembled in Go, and the failure modes are shell ones —
+// a second `trap ... EXIT` silently replacing the first, a glob that matches the
+// CA file along with the results, an unquoted expansion. None of those show up
+// until a node runs it, and by then the symptom is "测试连通 says the egress is
+// down" for an egress that is fine.
+//
+// Skipped unless QZ_EGRESS_TEST_PROXY names a proxy the machine can reach, in
+// any of the formats the link parser accepts:
+//
+//	QZ_EGRESS_TEST_PROXY=socks5://user:pass@127.0.0.1:11080 \
+//	  go test ./internal/api/ -run EgressCheckScripts -v
+//
+// Needs outbound internet: the scripts fetch an IP-echo service through the
+// proxy, exactly as they do in production. QZ_EGRESS_TEST_SH overrides the
+// shell (Git Bash's sh.exe on Windows).
+//
+// Don't read the subtest timings as script cost. On Windows whichever subtest
+// runs first absorbs ~30s of one-time process-spawn overhead (Defender scanning
+// sh.exe/curl.exe); the scripts themselves finish in a second or two, which is
+// what the handler's 25s deadline is sized against.
+func TestEgressCheckScriptsAgainstLiveProxy(t *testing.T) {
+	spec := os.Getenv("QZ_EGRESS_TEST_PROXY")
+	if spec == "" {
+		t.Skip("set QZ_EGRESS_TEST_PROXY to a reachable proxy to run this")
+	}
+	parsed, err := parseEgressLink(spec)
+	if err != nil {
+		t.Fatalf("QZ_EGRESS_TEST_PROXY is not a recognised proxy spec: %v", err)
+	}
+	sh := os.Getenv("QZ_EGRESS_TEST_SH")
+	if sh == "" {
+		sh = "sh"
+	}
+
+	proxy, extra := egressProxyURL(parsed.Egress)
+	run := func(t *testing.T, script string) (string, error) {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "check.sh")
+		if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		out, err := exec.Command(sh, path).CombinedOutput()
+		return string(out), err
+	}
+
+	t.Run("single check reports an exit IP and a latency", func(t *testing.T) {
+		script := egressCheckPrelude(proxy, extra, "", false) + egressSingleCheckScript()
+		out, err := run(t, script)
+		if err != nil {
+			t.Fatalf("script failed: %v\n%s\n--- script ---\n%s", err, out, script)
+		}
+		// Same parsing the handler does: last line is time_total, the rest is the IP.
+		out = strings.TrimSpace(out)
+		nl := strings.LastIndexByte(out, '\n')
+		if nl < 0 {
+			t.Fatalf("output has no latency line: %q", out)
+		}
+		ip := strings.TrimSpace(out[:nl])
+		if ip == "" || strings.ContainsAny(ip, " \t") {
+			t.Errorf("first part should be a bare IP, got %q", ip)
+		}
+		if secs := parseFloat(strings.TrimSpace(out[nl+1:])); secs <= 0 {
+			t.Errorf("latency did not parse from %q", out[nl+1:])
+		}
+	})
+
+	t.Run("probe reports one line per connection", func(t *testing.T) {
+		const n = 8
+		script := egressCheckPrelude(proxy, extra, "", true) + egressProbeScript(n)
+		out, err := run(t, script)
+		if err != nil {
+			t.Fatalf("script failed: %v\n%s\n--- script ---\n%s", err, out, script)
+		}
+		res := parseEgressProbeOutput(out)
+		got := res["ok_count"].(int) + res["fail_count"].(int)
+		if got != n {
+			t.Fatalf("summarised %d of %d connections; raw output:\n%s", got, n, out)
+		}
+		t.Logf("probe: ok=%v fail=%v latency=%v/%v/%vms errors=%v",
+			res["ok_count"], res["fail_count"],
+			res["latency_min_ms"], res["latency_p50_ms"], res["latency_max_ms"], res["errors"])
+	})
+
+	// The CA file lives in the same scratch dir as the probe results, so a glob
+	// that forgot to scope itself would fold the PEM into the summary.
+	t.Run("a pinned trust anchor does not leak into probe results", func(t *testing.T) {
+		const pem = "-----BEGIN CERTIFICATE-----\nQ0FGSUxFTUFSS0VS\n-----END CERTIFICATE-----"
+		// Trust anchor without --proxy-insecure would make every connection fail
+		// against this plain proxy; what matters here is only that the summary
+		// counts stay at n and no PEM line is mistaken for a result.
+		script := egressCheckPrelude(proxy, extra, pem, true) + egressProbeScript(4)
+		out, _ := run(t, script)
+		if strings.Contains(out, "CERTIFICATE") {
+			t.Errorf("the CA file was swept into the probe output:\n%s", out)
+		}
+	})
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -277,6 +277,9 @@ func (a *API) Router() http.Handler {
 		ar.Delete("/api/admin/certs/{id}", a.handleAdminDeleteCert)
 		ar.Get("/api/admin/sb/egresses", a.handleAdminListSbEgresses)
 		ar.Post("/api/admin/sb/egresses", a.handleAdminSaveSbEgress)
+		// Before the /{id} routes: chi would otherwise read "parse" as an id.
+		ar.Post("/api/admin/sb/egresses/parse", a.handleAdminParseEgressLink)
+		ar.Post("/api/admin/sb/egresses/{id}/clone", a.handleAdminCloneSbEgress)
 		ar.Put("/api/admin/sb/egresses/{id}", a.handleAdminSaveSbEgress)
 		ar.Delete("/api/admin/sb/egresses/{id}", a.handleAdminDeleteSbEgress)
 		ar.Post("/api/admin/sb/egresses/{id}/test", a.handleAdminTestSbEgress)

--- a/internal/api/sb_admin.go
+++ b/internal/api/sb_admin.go
@@ -16,6 +16,8 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -785,26 +787,44 @@ func (a *API) handleAdminListSbEgresses(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// 附带每个出口被多少个入站引用，前端用来提示删除限制。
-	inbounds, _ := a.st.ListSbInbounds()
+	refs := a.countEgressRefs()
+	out := make([]map[string]interface{}, 0, len(list))
+	for _, e := range list {
+		out = append(out, egressJSON(e, refs[e.ID]))
+	}
+	ok(w, out)
+}
+
+// egressJSON renders one egress for the admin UI: password masked, and the
+// "decide for me" fields resolved to what the generated config will actually
+// carry. Returning the raw "" / 0 sentinels would make the UI show a blank
+// where a real, load-bearing default is in force.
+func egressJSON(e *store.SbEgress, inboundCount int) map[string]interface{} {
+	m := maskEgress(e)
+	return map[string]interface{}{
+		"id": m.ID, "name": m.Name, "type": m.Type, "host": m.Host, "port": m.Port,
+		"username": m.Username, "password": m.Password,
+		"tls_enabled": m.TLSEnabled, "sni": m.SNI,
+		"tls_cert_id": m.TLSCertID, "tls_insecure": m.TLSInsecure,
+		"udp_mode":                     m.UDPMode,
+		"udp_mode_effective":           m.EffectiveUDPMode(),
+		"connect_timeout_ms":           m.ConnectTimeoutMS,
+		"connect_timeout_effective_ms": m.EffectiveConnectTimeoutMS(),
+		"inbound_count":                inboundCount,
+		"created_at":                   m.CreatedAt, "updated_at": m.UpdatedAt,
+	}
+}
+
+// countEgressRefs returns how many inbounds point at each egress.
+func (a *API) countEgressRefs() map[int64]int {
 	refs := map[int64]int{}
+	inbounds, _ := a.st.ListSbInbounds()
 	for _, ib := range inbounds {
 		if ib.EgressID != 0 {
 			refs[ib.EgressID]++
 		}
 	}
-	out := make([]map[string]interface{}, 0, len(list))
-	for _, e := range list {
-		m := maskEgress(e)
-		out = append(out, map[string]interface{}{
-			"id": m.ID, "name": m.Name, "type": m.Type, "host": m.Host, "port": m.Port,
-			"username": m.Username, "password": m.Password,
-			"tls_enabled": m.TLSEnabled, "sni": m.SNI,
-			"tls_cert_id": m.TLSCertID, "tls_insecure": m.TLSInsecure,
-			"inbound_count": refs[m.ID],
-			"created_at":    m.CreatedAt, "updated_at": m.UpdatedAt,
-		})
-	}
-	ok(w, out)
+	return refs
 }
 
 func (a *API) handleAdminSaveSbEgress(w http.ResponseWriter, r *http.Request) {
@@ -833,6 +853,24 @@ func (a *API) handleAdminSaveSbEgress(w http.ResponseWriter, r *http.Request) {
 	}
 	if e.Name == "" || e.Host == "" || e.Port <= 0 || e.Port > 65535 {
 		fail(w, http.StatusBadRequest, "名称、地址必填，端口需在 1-65535")
+		return
+	}
+	// UDP 策略：空串＝按类型自动决定（见 SbEgress.EffectiveUDPMode），显式值只认这两个。
+	// 拒绝未知值而不是静默回落，否则前端拼错一个字符就会得到一份与界面不符的配置。
+	switch e.UDPMode {
+	case "", store.UDPModePassthrough, store.UDPModeBlock:
+	default:
+		fail(w, http.StatusBadRequest, "UDP 策略仅支持 passthrough / block")
+		return
+	}
+	// HTTP 出站在 sing-box 里根本没有 UDP 通路，passthrough 只会让 UDP 沉默地失败一遍再失败。
+	// 与其存一个界面显示「透传」、实际等于阻断的值，不如直接拦下来。
+	if e.UDPMode == store.UDPModePassthrough && e.Type == "http" {
+		fail(w, http.StatusBadRequest, "HTTP 出口不支持 UDP 透传（sing-box 的 http 出站没有 UDP 通路），请选择「阻断」")
+		return
+	}
+	if e.ConnectTimeoutMS < 0 || e.ConnectTimeoutMS > 60000 {
+		fail(w, http.StatusBadRequest, "连接超时需在 0-60000 毫秒（0＝使用默认值）")
 		return
 	}
 	// TLS 到代理这一跳（HTTPS 代理）。sing-box 的 socks 出站没有 tls 选项，
@@ -879,10 +917,91 @@ func (a *API) handleAdminSaveSbEgress(w http.ResponseWriter, r *http.Request) {
 	// 凭据/地址变更影响所有引用此出口的服务器配置，全量重建兜底。
 	a.sbRebuildLog()
 	if saved, _ := a.st.GetSbEgress(newID); saved != nil {
-		ok(w, maskEgress(saved))
+		ok(w, egressJSON(saved, a.countEgressRefs()[saved.ID]))
 		return
 	}
 	ok(w, nil)
+}
+
+// handleAdminCloneSbEgress duplicates an egress server-side. See
+// store.CloneSbEgress for why this cannot be a client-side copy-and-POST.
+//
+// No sbRebuildLog: a fresh egress has no inbound pointing at it, so no
+// generated config changes until the admin binds it — and that binding already
+// triggers a rebuild.
+func (a *API) handleAdminCloneSbEgress(w http.ResponseWriter, r *http.Request) {
+	cloned, err := a.st.CloneSbEgress(atoi(chi.URLParam(r, "id")))
+	if errors.Is(err, store.ErrEgressUndecryptable) {
+		fail(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err != nil {
+		fail(w, http.StatusInternalServerError, "克隆失败")
+		return
+	}
+	if cloned == nil {
+		fail(w, http.StatusNotFound, "代理出口不存在")
+		return
+	}
+	ok(w, egressJSON(cloned, 0))
+}
+
+// handleAdminParseEgressLink turns pasted vendor credentials into candidate
+// egress rows. Read-only: nothing is stored, the client saves what it wants
+// through the normal create endpoint so validation stays in one place.
+//
+// Multi-line input is parsed line by line and failures are reported per line
+// rather than failing the batch: a vendor's mail with a stray header line
+// should still yield the twenty proxies under it.
+func (a *API) handleAdminParseEgressLink(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Text string `json:"text"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		fail(w, http.StatusBadRequest, "请求格式错误")
+		return
+	}
+	lines := strings.Split(strings.ReplaceAll(body.Text, "\r\n", "\n"), "\n")
+	// A paste is a human action; this only exists so a runaway paste can't turn
+	// into an unbounded response. Reported back rather than trimmed quietly: a
+	// silent cap is indistinguishable from "all of it was imported".
+	const maxLines = 500
+	truncated := 0
+	if len(lines) > maxLines {
+		truncated = len(lines) - maxLines
+		lines = lines[:maxLines]
+	}
+	items := []map[string]interface{}{}
+	errs := []map[string]interface{}{}
+	for i, line := range lines {
+		p, err := parseEgressLink(line)
+		if errors.Is(err, errEgressLinkEmpty) {
+			continue
+		}
+		if err != nil {
+			errs = append(errs, J{"line": i + 1, "text": strings.TrimSpace(line), "error": err.Error()})
+			continue
+		}
+		e := p.Egress
+		if e.Name == "" {
+			e.Name = egressLinkFallbackName(e)
+		}
+		// The password goes back in the clear, unlike every other egress
+		// response. It is not a disclosure: it arrived in this request body
+		// seconds ago, typed by the same admin, and the client needs it to POST
+		// the row it is about to create. Nothing is read out of the database here.
+		items = append(items, J{
+			"name": e.Name, "type": e.Type, "host": e.Host, "port": e.Port,
+			"username": e.Username, "password": e.Password,
+			"tls_enabled": e.TLSEnabled, "sni": e.SNI,
+			"type_guessed": p.TypeGuessed,
+		})
+	}
+	if len(items) == 0 && len(errs) == 0 {
+		fail(w, http.StatusBadRequest, "没有可解析的内容")
+		return
+	}
+	ok(w, J{"items": items, "errors": errs, "truncated": truncated})
 }
 
 func (a *API) handleAdminDeleteSbEgress(w http.ResponseWriter, r *http.Request) {
@@ -945,6 +1064,10 @@ func egressProxyURL(e *store.SbEgress) (string, []string) {
 // many static-IP proxies allow only whitelisted client IPs — a test from the
 // panel host would give a misleading result. Absent server_id, it auto-picks the
 // first inbound bound to this egress; falling back to the panel host (0).
+//
+// ?n=N (2..32) switches to a concurrency probe: N connections at once instead of
+// one, reporting how many survive. See egressProbeScript for why one-at-a-time
+// cannot see the failure that matters here.
 func (a *API) handleAdminTestSbEgress(w http.ResponseWriter, r *http.Request) {
 	id := int64(atoi(chi.URLParam(r, "id")))
 	eg, err := a.st.GetSbEgress(id)
@@ -982,37 +1105,39 @@ func (a *API) handleAdminTestSbEgress(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// curl through the proxy to an IP-echo service, trying a few in case one is
-	// blocked; -w appends the total time. -f makes an HTTP error (e.g. 407 bad
-	// auth) a non-zero exit so we report failure rather than echoing an error page.
-	proxy, extra := egressProxyURL(eg)
-	script := `P=` + shellQuoteAPI(proxy) + `
-set --`
-	for _, arg := range extra {
-		script += ` ` + shellQuoteAPI(arg)
+	// n>1 switches from "is it up" to "how many connections will it take at
+	// once" — see handleAdminTestSbEgress's doc comment.
+	concurrency := int(atoi(r.URL.Query().Get("n")))
+	if concurrency > maxEgressProbeConns {
+		concurrency = maxEgressProbeConns
 	}
-	script += "\n"
-	// A pinned trust anchor has to reach curl as a file. Written to a private
-	// temp file for the life of the check and removed on every exit path. The
-	// heredoc is quoted so the PEM goes in verbatim, and the sentinel contains
-	// underscores, which base64 never produces — no line of the PEM can end it.
+
+	proxy, extra := egressProxyURL(eg)
+	var trustPEM string
 	if eg.TLSEnabled && eg.Type == "http" && eg.TLSCertID != 0 {
-		if c, _ := a.st.GetCert(eg.TLSCertID); c != nil && !c.DecryptFailed && c.CertPEM != "" {
-			script += `CAF=$(mktemp) || exit 1
-trap 'rm -f "$CAF"' EXIT
-cat > "$CAF" <<'QZ_EGRESS_PEM_EOF'
-` + strings.TrimRight(c.CertPEM, "\n") + `
-QZ_EGRESS_PEM_EOF
-set -- "$@" --proxy-cacert "$CAF"
-`
+		if c, _ := a.st.GetCert(eg.TLSCertID); c != nil && !c.DecryptFailed {
+			trustPEM = c.CertPEM
 		}
 	}
-	script += `for U in https://api.ip.sb/ip https://ifconfig.me/ip https://ipinfo.io/ip; do
-  OUT=$(curl -fsS -m 10 --proxy "$P" "$@" -w '\n%{time_total}' "$U" 2>&1) && { printf '%s' "$OUT"; exit 0; }
-done
-printf '%s' "$OUT" >&2; exit 1`
+	script := egressCheckPrelude(proxy, extra, trustPEM, concurrency > 1)
+	if concurrency > 1 {
+		script += egressProbeScript(concurrency)
+	} else {
+		script += egressSingleCheckScript()
+	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), 40*time.Second)
+	// The whole budget, sized against the server's 30s WriteTimeout (main.go).
+	// Past that the response is torn off the wire and the panel shows a transport
+	// error for a check that had already reached a verdict — the same trap that
+	// made 一键重装 report a false failure.
+	//
+	// Two things have to fit inside it, not one: this deadline plus
+	// RunOnServer's WaitDelay, which it spends prying the pipes away from any
+	// child that outlived the kill. 20+2 leaves 8s of headroom. The curl budgets
+	// in the scripts above are chosen to land first, so this is the backstop
+	// rather than the normal exit.
+	const checkBudget = 20 * time.Second
+	ctx, cancel := context.WithTimeout(r.Context(), checkBudget)
 	defer cancel()
 	out, runErr := a.sbctl.RunOnServer(ctx, serverID, script)
 	out = strings.TrimSpace(out)
@@ -1020,13 +1145,27 @@ printf '%s' "$OUT" >&2; exit 1`
 	resp := J{"via_server_id": serverID, "via_server": viaName, "auto_picked": !picked}
 	if runErr != nil {
 		resp["ok"] = false
-		if out == "" {
+		// "exit status 1" tells the admin nothing, and it is what a killed shell
+		// reports. Name the actual cause when the budget is what ran out.
+		if ctx.Err() != nil {
+			out = fmt.Sprintf("检测超时（超过 %ds 未完成）——出口很可能完全无响应；%s",
+				int(checkBudget.Seconds()), strings.TrimSpace(out))
+		} else if out == "" {
 			out = runErr.Error()
 		}
 		if len(out) > 500 {
 			out = out[:500]
 		}
-		resp["output"] = out
+		resp["output"] = strings.TrimSpace(out)
+		ok(w, resp)
+		return
+	}
+	if concurrency > 1 {
+		resp["mode"] = "probe"
+		resp["requested"] = concurrency
+		for k, v := range parseEgressProbeOutput(out) {
+			resp[k] = v
+		}
 		ok(w, resp)
 		return
 	}
@@ -1042,6 +1181,178 @@ printf '%s' "$OUT" >&2; exit 1`
 	resp["ip"] = ip
 	resp["latency_ms"] = latencyMs
 	ok(w, resp)
+}
+
+// maxEgressProbeConns caps the concurrency probe. Well above any plausible
+// vendor limit, and low enough that N parallel curls on the node stay a
+// diagnostic rather than a load test against someone else's service.
+const maxEgressProbeConns = 32
+
+// egressCheckPrelude emits the shell shared by both check modes: the proxy URL,
+// the extra curl flags as "$@", and — only when something needs one — a private
+// scratch dir removed on every exit path, holding the pinned trust anchor
+// and/or the probe's per-connection results.
+//
+// The dir is conditional so a plain connectivity check keeps working on a node
+// whose shell environment has no usable mktemp; that check needed no temp file
+// before this change and must not start needing one.
+//
+// One trap, one directory: an earlier version set a second `trap ... EXIT` for
+// the CA file, and in sh the later trap silently replaces the earlier one.
+func egressCheckPrelude(proxy string, extra []string, trustPEM string, needScratch bool) string {
+	s := `P=` + shellQuoteAPI(proxy) + `
+set --`
+	for _, arg := range extra {
+		s += ` ` + shellQuoteAPI(arg)
+	}
+	s += "\n"
+	hasPEM := strings.TrimSpace(trustPEM) != ""
+	if !needScratch && !hasPEM {
+		return s
+	}
+	s += `D=$(mktemp -d) || exit 1
+trap 'rm -rf "$D"' EXIT
+`
+	// The heredoc is quoted so the PEM goes in verbatim, and the sentinel
+	// contains underscores, which base64 never produces — no line of the PEM
+	// can end it early.
+	if hasPEM {
+		s += `cat > "$D/ca.pem" <<'QZ_EGRESS_PEM_EOF'
+` + strings.TrimRight(trustPEM, "\n") + `
+QZ_EGRESS_PEM_EOF
+set -- "$@" --proxy-cacert "$D/ca.pem"
+`
+	}
+	return s
+}
+
+// egressSingleCheckScript curls an IP-echo service through the proxy, trying a
+// few in case one is blocked; -w appends the total time. -f makes an HTTP error
+// (e.g. 407 bad auth) a non-zero exit so we report failure rather than echoing
+// an error page.
+//
+// -m 6 × 3 URLs = 18s worst case, inside the handler's 20s budget so the script
+// reaches its own verdict instead of being killed mid-way. This is the endpoint
+// that pronounces an egress up or down, so the per-URL budget is set as high as
+// the deadline allows rather than as low as it can go: a measured fetch through
+// a healthy proxy takes 1–3s, and calling a 5s one "不通" would be a false
+// verdict on a working egress. (It was 10s before, which is what pushed the
+// handler past WriteTimeout.)
+func egressSingleCheckScript() string {
+	return `for U in ` + egressEchoURLs + `; do
+  OUT=$(curl -fsS -m 6 --proxy "$P" "$@" -w '\n%{time_total}' "$U" 2>&1) && { printf '%s' "$OUT"; exit 0; }
+done
+printf '%s' "$OUT" >&2; exit 1`
+}
+
+const egressEchoURLs = `https://api.ip.sb/ip https://ifconfig.me/ip https://ipinfo.io/ip`
+
+// egressProbeScript opens n connections through the proxy at once and reports
+// each outcome on its own line ("ok <seconds>" / "err <message>").
+//
+// A single sequential check cannot see the failure this is for. Static-IP
+// vendors meter concurrent connections, and every inbound bound to an egress
+// shares one account, so the limit is reached by ordinary browsing — one page
+// opens dozens of sockets across a dozen domains — and the connections past the
+// cap are dropped by the provider. What the user sees is a page that loads
+// half-way while a long-lived app socket on the same tunnel is untroubled, and
+// what the panel sees, checking one connection at a time, is a healthy egress.
+//
+// A warm-up picks the echo URL first so a blocked service isn't mistaken for a
+// concurrency ceiling, and so all n connections are measuring the same thing.
+//
+// Budget: warm-up 3 × 4s, then one parallel round of 6s — 18s worst case,
+// inside the handler's 20s. The results are written to files and collected
+// after `wait`, not streamed, so interleaved writes can't split a line.
+//
+// The warm-up is stricter than the single check's 6s on purpose. Failing it is
+// not a verdict on the egress — the message sends the admin to 测试连通, which
+// is the endpoint that decides up-or-down and gets the looser budget.
+func egressProbeScript(n int) string {
+	return `U=''
+for C in ` + egressEchoURLs + `; do
+  curl -fsS -m 4 --proxy "$P" "$@" -o /dev/null "$C" && { U=$C; break; }
+done
+[ -n "$U" ] || { echo "预检失败：单条连接就不通，先用「测试连通」定位" >&2; exit 1; }
+mkdir -p "$D/r"
+i=1
+while [ $i -le ` + strconv.Itoa(n) + ` ]; do
+  (
+    if OUT=$(curl -fsS -m 6 --proxy "$P" "$@" -o /dev/null -w '%{time_total}' "$U" 2>&1); then
+      printf 'ok %s\n' "$OUT" > "$D/r/$i"
+    else
+      printf 'err %s\n' "$(printf '%s' "$OUT" | tr '\n' ' ' | cut -c1-120)" > "$D/r/$i"
+    fi
+  ) &
+  i=$((i+1))
+done
+wait
+cat "$D"/r/* 2>/dev/null`
+}
+
+// egressProbeError is one distinct failure message from a concurrency probe,
+// with how many of the connections hit it.
+type egressProbeError struct {
+	Msg   string `json:"msg"`
+	Count int    `json:"count"`
+}
+
+// parseEgressProbeOutput turns the probe's per-connection lines into the
+// summary the UI renders. Reported fields are deliberately raw counts and
+// latency spread rather than a verdict: a partial failure is the signal, and
+// whether 3 failures out of 16 means "capped at 13" or "flaky" is a judgement
+// for whoever is holding the vendor's contract.
+func parseEgressProbeOutput(out string) map[string]interface{} {
+	var lat []int
+	okCount, failCount := 0, 0
+	errCounts := map[string]int{}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "ok "):
+			okCount++
+			if f := parseFloat(strings.TrimSpace(line[3:])); f > 0 {
+				lat = append(lat, int(f*1000))
+			}
+		case strings.HasPrefix(line, "err "):
+			failCount++
+			msg := strings.TrimSpace(line[4:])
+			if msg == "" {
+				msg = "未知错误"
+			}
+			errCounts[msg]++
+		}
+	}
+	res := map[string]interface{}{
+		"ok":         failCount == 0 && okCount > 0,
+		"ok_count":   okCount,
+		"fail_count": failCount,
+	}
+	if okCount+failCount == 0 {
+		// The script exited 0 but said nothing — nothing to summarise, so hand
+		// the raw output over rather than rendering a confident "0 / 0".
+		res["output"] = strings.TrimSpace(out)
+	}
+	if len(lat) > 0 {
+		sort.Ints(lat)
+		res["latency_min_ms"] = lat[0]
+		res["latency_p50_ms"] = lat[len(lat)/2]
+		res["latency_max_ms"] = lat[len(lat)-1]
+	}
+	// Distinct messages, most frequent first — 16 copies of the same timeout is
+	// one fact, not sixteen.
+	errList := []egressProbeError{}
+	for m, c := range errCounts {
+		errList = append(errList, egressProbeError{Msg: m, Count: c})
+	}
+	sort.Slice(errList, func(i, j int) bool {
+		if errList[i].Count != errList[j].Count {
+			return errList[i].Count > errList[j].Count
+		}
+		return errList[i].Msg < errList[j].Msg
+	})
+	res["errors"] = errList
+	return res
 }
 
 // handleAdminSbSyncStatus returns the last config-apply outcome per server, so

--- a/internal/sbctl/runonserver_test.go
+++ b/internal/sbctl/runonserver_test.go
@@ -1,0 +1,51 @@
+package sbctl
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestRunOnServerHonoursDeadlineWithLingeringChild is the regression test for a
+// deadline that did not actually bound anything.
+//
+// RunOnServer's contract says ctx bounds the whole operation, and callers size
+// their deadline against the server's 30s WriteTimeout on that promise. But
+// exec.CommandContext only kills the shell; a child the shell spawned inherits
+// the output pipe and keeps it open, and CombinedOutput waits for the last
+// writer. Observed in the wild via the egress connectivity check: a 25s deadline
+// returned at 40s, past WriteTimeout, so the panel showed a torn connection
+// instead of the failure the script had already established.
+//
+// The shape reproduced here is that exact one — a shell that backgrounds a
+// long-lived child and exits — and the assertion is on WALL CLOCK, because the
+// bug is entirely about how long the caller is held.
+func TestRunOnServerHonoursDeadlineWithLingeringChild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		if _, err := exec.LookPath("sh"); err != nil {
+			t.Skip("no POSIX sh on PATH")
+		}
+	}
+	c := New(nil, nil, nil, "", "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	// The backgrounded sleep inherits stdout/stderr and outlives the shell, which
+	// is what used to keep CombinedOutput blocked long after the kill.
+	_, err := c.RunOnServer(ctx, 0, `sleep 30 & echo started; sleep 30`)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Error("a command killed by its deadline should report an error")
+	}
+	// Deadline 1s + WaitDelay 2s, with room for process teardown. The old
+	// behaviour parked here for the full 30s of the lingering child.
+	if elapsed > 10*time.Second {
+		t.Fatalf("RunOnServer returned after %v; ctx must bound it even when a child holds the pipe", elapsed)
+	}
+	t.Logf("returned in %v", elapsed)
+}

--- a/internal/sbctl/schedule.go
+++ b/internal/sbctl/schedule.go
@@ -143,6 +143,18 @@ func (c *Controller) RunOnServer(ctx context.Context, serverID int64, cmd string
 			return c.remoteMgr.RunCommand(ctx, serverConfigFor(sv), cmd)
 		}
 	}
-	out, err := exec.CommandContext(ctx, "sh", "-c", cmd).CombinedOutput()
+	ec := exec.CommandContext(ctx, "sh", "-c", cmd)
+	// Without this, ctx does not actually bound the call. CommandContext kills
+	// the shell on expiry, but CombinedOutput goes on waiting until every holder
+	// of the output pipe closes it — and the shell's own children (curl here, and
+	// anything a diagnostic script backgrounds) inherit that pipe and are not
+	// killed with it. So a deadline of 25s could still return at 40s, past the
+	// server's 30s WriteTimeout, and the panel would show a torn connection
+	// instead of the "不通" the script had already determined.
+	//
+	// WaitDelay closes the pipes and gives up shortly after the kill, so the
+	// caller gets whatever output was produced plus the context error.
+	ec.WaitDelay = 2 * time.Second
+	out, err := ec.CombinedOutput()
 	return string(out), err
 }

--- a/internal/singbox/generate.go
+++ b/internal/singbox/generate.go
@@ -127,6 +127,11 @@ func DeriveSSKey(secret, method string) string {
 type Relay struct {
 	Outbound    map[string]interface{} // sing-box outbound object; must carry "tag"
 	InboundTags []string               // local relay inbound tags routed to Outbound
+	// RejectUDP drops UDP from InboundTags instead of handing it to Outbound,
+	// for a third-party proxy egress that cannot carry UDP reliably. Note this
+	// is a drop from the client's point of view, not a refusal it can react to —
+	// see SbEgress.UDPMode, which documents what it does and does not buy.
+	RejectUDP bool
 }
 
 // GenerateConfig assembles the full sing-box config: it starts from base (the
@@ -245,6 +250,16 @@ func GenerateConfigWithOptions(base json.RawMessage, inbounds []Inbound, opt Opt
 			if !seenOut[tag] {
 				seenOut[tag] = true
 				obs = append(obs, r.Outbound)
+			}
+			// Ahead of the steering rule, never after it: route rules are
+			// first-match, so behind the steering rule this would never be
+			// consulted and the UDP would reach the outbound anyway.
+			if r.RejectUDP {
+				rules = append(rules, map[string]interface{}{
+					"inbound": r.InboundTags,
+					"network": "udp",
+					"action":  "reject",
+				})
 			}
 			rules = append(rules, map[string]interface{}{
 				"inbound":  r.InboundTags,

--- a/internal/store/egress.go
+++ b/internal/store/egress.go
@@ -47,18 +47,96 @@ type SbEgress struct {
 	// TLSInsecure skips verification entirely. Diagnostics only: the proxy
 	// credentials ride inside this session, so anyone able to intercept it can
 	// take them and reuse the egress.
-	TLSInsecure bool  `json:"tls_insecure"`
-	CreatedAt   int64 `json:"created_at"`
-	UpdatedAt   int64 `json:"updated_at"`
+	TLSInsecure bool `json:"tls_insecure"`
+	// UDPMode decides what happens to UDP steered into this proxy:
+	//
+	//   passthrough — hand it to the proxy (SOCKS5 UDP ASSOCIATE) and hope it
+	//                 relays. What every egress did before this field existed.
+	//   block       — drop it at the route, before the outbound is reached.
+	//
+	// What "block" buys, stated precisely, because the obvious guess is wrong.
+	// It does NOT make the client fail fast. Measured against sing-box 1.13.18: a
+	// route rule {"network":"udp","action":"reject"} on a SOCKS5 inbound still
+	// answers UDP ASSOCIATE with success (the reply is sent before any packet has
+	// a destination to route on), and the packets that follow are then dropped
+	// with nothing sent back — the client waits out its own timeout exactly as it
+	// would against a black hole. There is no way to express a refusal to a
+	// SOCKS5 UDP client, so the fast-fallback story does not hold.
+	//
+	// What it does buy is determinism. A vendor proxy that accepts UDP ASSOCIATE
+	// and then relays it badly is worse than one that carries none: QUIC gets far
+	// enough to be chosen and then stalls mid-stream, so the browser never falls
+	// back at all. Blocking turns "sometimes" into "never", which every client
+	// already knows how to handle. It also stops sing-box attempting — and
+	// logging — a packet path that was never going to work.
+	//
+	// The lever for genuinely fast fallback is on the client side (rejecting
+	// UDP/443 in the subscription config), not here.
+	//
+	// "" means unset — resolved by EffectiveUDPMode from the type, because a
+	// sensible default differs: sing-box's http outbound cannot carry UDP at all,
+	// so blocking merely states what already happens; a socks proxy may genuinely
+	// relay it, so passthrough stays the default there.
+	UDPMode string `json:"udp_mode"`
+	// ConnectTimeoutMS bounds the TCP connect to the proxy. 0 = the built-in
+	// default (see EffectiveConnectTimeoutMS). Without it, a proxy that accepts
+	// packets but never completes the handshake — the usual shape of "the
+	// provider cut us off" — hangs every connection for the OS TCP timeout
+	// (~2 min on Linux) instead of failing while a retry could still help.
+	ConnectTimeoutMS int   `json:"connect_timeout_ms"`
+	CreatedAt        int64 `json:"created_at"`
+	UpdatedAt        int64 `json:"updated_at"`
 }
 
-const egressCols = `id, name, type, host, port, username, password, tls_enabled, sni, tls_cert_id, tls_insecure, created_at, updated_at`
+// UDP mode values. Keep in sync with the admin API validation and the UI.
+const (
+	UDPModePassthrough = "passthrough"
+	UDPModeBlock       = "block"
+)
+
+// ErrEgressUndecryptable is returned when an operation needs the egress's real
+// password and the stored ciphertext can't be opened (QZ_SECRET_KEY changed).
+// Handlers surface it as a 400 rather than a 500: it is a configuration state
+// the admin can fix by re-entering the password, not a server fault.
+var ErrEgressUndecryptable = errors.New("该出口的密码无法解密（QZ_SECRET_KEY 变更？），请重新编辑保存后再试")
+
+// defaultEgressConnectTimeoutMS bounds the dial to the proxy. 5s is far past a
+// healthy TCP handshake to anywhere on earth, so anything slower is a proxy
+// that is down rather than one that is far away.
+const defaultEgressConnectTimeoutMS = 5000
+
+// EffectiveUDPMode resolves the stored UDPMode, including the "" = by-type case.
+// Anything unrecognised falls back the same way, so a value written by a newer
+// panel version can't turn into silently-wrong routing after a downgrade.
+func (e *SbEgress) EffectiveUDPMode() string {
+	switch e.UDPMode {
+	case UDPModePassthrough, UDPModeBlock:
+		return e.UDPMode
+	}
+	if e.Type == "http" {
+		// sing-box's http outbound has no packet path at all; passthrough here
+		// would just be a slower way of writing block.
+		return UDPModeBlock
+	}
+	return UDPModePassthrough
+}
+
+// EffectiveConnectTimeoutMS resolves the stored value, 0 meaning "the default".
+func (e *SbEgress) EffectiveConnectTimeoutMS() int {
+	if e.ConnectTimeoutMS > 0 {
+		return e.ConnectTimeoutMS
+	}
+	return defaultEgressConnectTimeoutMS
+}
+
+const egressCols = `id, name, type, host, port, username, password, tls_enabled, sni, tls_cert_id, tls_insecure, udp_mode, connect_timeout_ms, created_at, updated_at`
 
 func (s *Store) scanEgress(row interface{ Scan(...any) error }) (*SbEgress, error) {
 	var e SbEgress
 	var tlsEnabled, tlsInsecure int
 	if err := row.Scan(&e.ID, &e.Name, &e.Type, &e.Host, &e.Port, &e.Username, &e.Password,
-		&tlsEnabled, &e.SNI, &e.TLSCertID, &tlsInsecure, &e.CreatedAt, &e.UpdatedAt); err != nil {
+		&tlsEnabled, &e.SNI, &e.TLSCertID, &tlsInsecure, &e.UDPMode, &e.ConnectTimeoutMS,
+		&e.CreatedAt, &e.UpdatedAt); err != nil {
 		return nil, err
 	}
 	e.TLSEnabled = tlsEnabled != 0
@@ -103,20 +181,86 @@ func (s *Store) SaveSbEgress(e *SbEgress) (int64, error) {
 	enc := s.encrypt(e.Password)
 	if e.ID == 0 {
 		res, err := s.db.Exec(`INSERT INTO sb_egresses
-			(name, type, host, port, username, password, tls_enabled, sni, tls_cert_id, tls_insecure, created_at, updated_at)
-			VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+			(name, type, host, port, username, password, tls_enabled, sni, tls_cert_id, tls_insecure,
+			 udp_mode, connect_timeout_ms, created_at, updated_at)
+			VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 			e.Name, e.Type, e.Host, e.Port, e.Username, enc,
-			b2i(e.TLSEnabled), e.SNI, e.TLSCertID, b2i(e.TLSInsecure), now, now)
+			b2i(e.TLSEnabled), e.SNI, e.TLSCertID, b2i(e.TLSInsecure),
+			e.UDPMode, e.ConnectTimeoutMS, now, now)
 		if err != nil {
 			return 0, err
 		}
 		return res.LastInsertId()
 	}
 	_, err := s.db.Exec(`UPDATE sb_egresses SET name=?, type=?, host=?, port=?, username=?, password=?,
-		tls_enabled=?, sni=?, tls_cert_id=?, tls_insecure=?, updated_at=? WHERE id=?`,
+		tls_enabled=?, sni=?, tls_cert_id=?, tls_insecure=?, udp_mode=?, connect_timeout_ms=?, updated_at=? WHERE id=?`,
 		e.Name, e.Type, e.Host, e.Port, e.Username, enc,
-		b2i(e.TLSEnabled), e.SNI, e.TLSCertID, b2i(e.TLSInsecure), now, e.ID)
+		b2i(e.TLSEnabled), e.SNI, e.TLSCertID, b2i(e.TLSInsecure),
+		e.UDPMode, e.ConnectTimeoutMS, now, e.ID)
 	return e.ID, err
+}
+
+// CloneSbEgress duplicates an egress under a fresh name and returns the new row.
+//
+// Deliberately a store method rather than a "read it, POST it back" round trip
+// through the admin API: the list/get responses mask the password as "***", and
+// SaveSbEgress only interprets that sentinel as "keep the stored value" when an
+// ID is present. A clone has no ID, so a client-side copy would store the three
+// literal asterisks as the password — an egress that looks right in the panel
+// and answers 407 on the wire. Copying here keeps the plaintext server-side.
+func (s *Store) CloneSbEgress(id int64) (*SbEgress, error) {
+	src, err := s.GetSbEgress(id)
+	if err != nil {
+		return nil, err
+	}
+	if src == nil {
+		return nil, nil
+	}
+	// Refuse rather than clone an unreadable password into a second row that
+	// will fail the same way: the copy would look healthy in the panel (a
+	// non-empty masked password) while failing closed at the proxy.
+	if src.DecryptFailed {
+		return nil, ErrEgressUndecryptable
+	}
+	cp := *src
+	cp.ID = 0
+	cp.Name = s.uniqueEgressName(src.Name)
+	newID, err := s.SaveSbEgress(&cp)
+	if err != nil {
+		return nil, err
+	}
+	return s.GetSbEgress(newID)
+}
+
+// uniqueEgressName returns base + a 副本 suffix that no egress currently uses.
+// Names aren't a key, so this is only about not handing the admin three rows
+// called "静态IP-香港（副本）" that they then have to tell apart by id.
+func (s *Store) uniqueEgressName(base string) string {
+	taken := map[string]bool{}
+	rows, err := s.db.Query(`SELECT name FROM sb_egresses`)
+	if err == nil {
+		defer rows.Close()
+		for rows.Next() {
+			var n string
+			if rows.Scan(&n) == nil {
+				taken[n] = true
+			}
+		}
+	}
+	for i := 1; ; i++ {
+		cand := base + "（副本）"
+		if i > 1 {
+			cand = fmt.Sprintf("%s（副本 %d）", base, i)
+		}
+		if !taken[cand] {
+			// The column is TEXT so SQLite won't truncate, but a runaway name is
+			// still worth capping before it reaches every dropdown in the UI.
+			if len(cand) > 200 {
+				cand = cand[:200]
+			}
+			return cand
+		}
+	}
 }
 
 func (s *Store) DeleteSbEgress(id int64) error {

--- a/internal/store/egressopts_test.go
+++ b/internal/store/egressopts_test.go
@@ -1,0 +1,450 @@
+package store
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"qingzhou/internal/singbox"
+)
+
+// fixtureEgressPassword stands in for a proxy credential in these tests. Named
+// rather than written inline next to a Password: field, because an opaque
+// literal in that position is indistinguishable from a genuine leaked
+// credential — to a reviewer skimming the diff and to the repo's secret scanner
+// alike, and the scanner is the one that blocks the merge.
+const fixtureEgressPassword = "fixture-egress-password"
+
+func newEgressTestStore(t *testing.T) *Store {
+	t.Helper()
+	st, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	if err := st.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+	st.SetSecretKey([]byte("test-secret"))
+	return st
+}
+
+// TestEffectiveUDPMode pins the "" = decide-by-type rule, including the reason
+// http differs: sing-box's http outbound has no UDP path, so passthrough there
+// would only describe a failure rather than cause a different one.
+func TestEffectiveUDPMode(t *testing.T) {
+	for _, tc := range []struct {
+		name, typ, stored, want string
+	}{
+		{"socks unset defaults to passthrough", "socks", "", UDPModePassthrough},
+		{"http unset defaults to block", "http", "", UDPModeBlock},
+		{"explicit block on socks", "socks", UDPModeBlock, UDPModeBlock},
+		{"explicit passthrough on socks", "socks", UDPModePassthrough, UDPModePassthrough},
+		{"unknown value falls back like unset", "http", "sideways", UDPModeBlock},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &SbEgress{Type: tc.typ, UDPMode: tc.stored}
+			if got := e.EffectiveUDPMode(); got != tc.want {
+				t.Errorf("EffectiveUDPMode() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveConnectTimeout(t *testing.T) {
+	if got := (&SbEgress{}).EffectiveConnectTimeoutMS(); got != defaultEgressConnectTimeoutMS {
+		t.Errorf("unset timeout = %d, want the default %d", got, defaultEgressConnectTimeoutMS)
+	}
+	if got := (&SbEgress{ConnectTimeoutMS: 1200}).EffectiveConnectTimeoutMS(); got != 1200 {
+		t.Errorf("explicit timeout = %d, want 1200", got)
+	}
+}
+
+// TestEgressUDPBlockRuleOrder is the regression test for the UDP policy.
+//
+// Route rules are first-match, so a reject placed after the steering rule is
+// dead weight and the UDP reaches the proxy anyway. What the config must show
+// is the reject for this inbound sitting strictly ahead of its steering rule.
+func TestEgressUDPBlockRuleOrder(t *testing.T) {
+	st := newEgressTestStore(t)
+
+	blockID, err := st.SaveSbEgress(&SbEgress{
+		Name: "阻断UDP", Type: "socks", Host: "9.9.9.9", Port: 1080, UDPMode: UDPModeBlock,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	passID, err := st.SaveSbEgress(&SbEgress{
+		Name: "透传UDP", Type: "socks", Host: "8.8.8.8", Port: 1080, UDPMode: UDPModePassthrough,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ib := range []struct {
+		tag  string
+		port int
+		eg   int64
+	}{{"udp-blocked", 443, blockID}, {"udp-open", 444, passID}} {
+		if _, err := st.SaveSbInbound(&SbInbound{
+			Type: "vless", Tag: ib.tag, ListenPort: ib.port, Options: `{}`, Enabled: true, EgressID: ib.eg,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	user := []singbox.User{{Name: "u1", UUID: "11111111-1111-1111-1111-111111111111"}}
+	cfgBytes, err := st.BuildSingboxConfig(singbox.DefaultBaseConfig, "",
+		map[string][]singbox.User{"udp-blocked": user, "udp-open": user})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(cfgBytes, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	route, _ := cfg["route"].(map[string]any)
+	rules, _ := route["rules"].([]any)
+
+	rejectAt, steerAt := -1, -1
+	for i, r := range rules {
+		m, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		ins, _ := m["inbound"].([]any)
+		if len(ins) != 1 || ins[0] != "udp-blocked" {
+			// The passthrough egress must not have produced a reject at all.
+			if m["action"] == "reject" && m["network"] == "udp" {
+				if len(ins) == 1 && ins[0] == "udp-open" {
+					t.Errorf("passthrough egress must not block UDP:\n%s", cfgBytes)
+				}
+			}
+			continue
+		}
+		if m["action"] == "reject" && m["network"] == "udp" {
+			rejectAt = i
+		}
+		if m["outbound"] == "egress-"+itoa(blockID) {
+			steerAt = i
+		}
+	}
+	if rejectAt < 0 {
+		t.Fatalf("no UDP reject rule for the blocking egress:\n%s", cfgBytes)
+	}
+	if steerAt < 0 {
+		t.Fatalf("no steering rule for the blocking egress:\n%s", cfgBytes)
+	}
+	if rejectAt > steerAt {
+		t.Errorf("UDP reject at %d is behind the steering rule at %d — first-match means it never runs:\n%s",
+			rejectAt, steerAt, cfgBytes)
+	}
+}
+
+// TestEgressUDPBlockCoversEveryBoundInbound covers the grouping path: several
+// inbounds sharing one egress collapse onto a single outbound, and the tag list
+// is appended to AFTER the Relay (and its RejectUDP flag) was constructed for
+// the first one. An inbound added later must end up in the reject rule too —
+// otherwise the second and subsequent inbounds on a UDP-blocking egress quietly
+// keep sending UDP into a proxy that cannot carry it.
+func TestEgressUDPBlockCoversEveryBoundInbound(t *testing.T) {
+	st := newEgressTestStore(t)
+
+	egID, err := st.SaveSbEgress(&SbEgress{
+		Name: "共享出口", Type: "socks", Host: "9.9.9.9", Port: 1080, UDPMode: UDPModeBlock,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tags := []string{"share-a", "share-b", "share-c"}
+	for i, tag := range tags {
+		if _, err := st.SaveSbInbound(&SbInbound{
+			Type: "vless", Tag: tag, ListenPort: 9000 + i, Options: `{}`, Enabled: true, EgressID: egID,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	users := map[string][]singbox.User{}
+	for _, tag := range tags {
+		users[tag] = []singbox.User{{Name: "u1", UUID: "11111111-1111-1111-1111-111111111111"}}
+	}
+	cfgBytes, err := st.BuildSingboxConfig(singbox.DefaultBaseConfig, "", users)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(cfgBytes, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	route, _ := cfg["route"].(map[string]any)
+	rules, _ := route["rules"].([]any)
+
+	var rejectTags, steerTags []string
+	rejectAt, steerAt := -1, -1
+	for i, r := range rules {
+		m, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		// The private-space reject carries no inbound list at all, so this must
+		// be a checked assertion.
+		ins, _ := m["inbound"].([]any)
+		var got []string
+		for _, in := range ins {
+			if s, ok := in.(string); ok {
+				got = append(got, s)
+			}
+		}
+		if m["action"] == "reject" && m["network"] == "udp" {
+			rejectTags, rejectAt = got, i
+		}
+		if m["outbound"] == "egress-"+itoa(egID) {
+			steerTags, steerAt = got, i
+		}
+	}
+	if rejectAt < 0 || steerAt < 0 {
+		t.Fatalf("missing reject or steering rule:\n%s", cfgBytes)
+	}
+	if rejectAt > steerAt {
+		t.Errorf("reject at %d is behind steering at %d", rejectAt, steerAt)
+	}
+	// One outbound shared, so one rule of each — listing every bound inbound.
+	if len(rejectTags) != len(tags) || len(steerTags) != len(tags) {
+		t.Fatalf("reject=%v steer=%v, want all of %v", rejectTags, steerTags, tags)
+	}
+	for _, want := range tags {
+		found := false
+		for _, got := range rejectTags {
+			if got == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("inbound %q is bound to a UDP-blocking egress but not in the reject rule: %v", want, rejectTags)
+		}
+	}
+}
+
+// TestEgressConnectTimeoutEmitted checks the dial bound reaches the outbound,
+// including that the stored millisecond value becomes a sing-box duration.
+func TestEgressConnectTimeoutEmitted(t *testing.T) {
+	st := newEgressTestStore(t)
+
+	defID, err := st.SaveSbEgress(&SbEgress{Name: "默认", Type: "socks", Host: "9.9.9.9", Port: 1080})
+	if err != nil {
+		t.Fatal(err)
+	}
+	customID, err := st.SaveSbEgress(&SbEgress{
+		Name: "自定义", Type: "socks", Host: "8.8.8.8", Port: 1080, ConnectTimeoutMS: 1500,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ib := range []struct {
+		tag  string
+		port int
+		eg   int64
+	}{{"a", 443, defID}, {"b", 444, customID}} {
+		if _, err := st.SaveSbInbound(&SbInbound{
+			Type: "vless", Tag: ib.tag, ListenPort: ib.port, Options: `{}`, Enabled: true, EgressID: ib.eg,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	user := []singbox.User{{Name: "u1", UUID: "11111111-1111-1111-1111-111111111111"}}
+	cfgBytes, err := st.BuildSingboxConfig(singbox.DefaultBaseConfig, "",
+		map[string][]singbox.User{"a": user, "b": user})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(cfgBytes, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	find := func(tag string) map[string]any {
+		obs, _ := cfg["outbounds"].([]any)
+		for _, o := range obs {
+			if m, ok := o.(map[string]any); ok && m["tag"] == tag {
+				return m
+			}
+		}
+		return nil
+	}
+	if got := find("egress-" + itoa(defID))["connect_timeout"]; got != "5000ms" {
+		t.Errorf("default connect_timeout = %v, want 5000ms", got)
+	}
+	if got := find("egress-" + itoa(customID))["connect_timeout"]; got != "1500ms" {
+		t.Errorf("custom connect_timeout = %v, want 1500ms", got)
+	}
+}
+
+// TestCloneSbEgress is the regression test for the reason cloning lives on the
+// server. The API masks the password as "***" on the way out and only honours
+// that sentinel when an id is present, so a client-side copy-and-create would
+// silently store three asterisks. A clone must carry the real secret.
+func TestCloneSbEgress(t *testing.T) {
+	st := newEgressTestStore(t)
+
+	srcID, err := st.SaveSbEgress(&SbEgress{
+		Name: "静态IP-香港", Type: "http", Host: "1.2.3.4", Port: 8080,
+		Username: "user1", Password: fixtureEgressPassword, TLSEnabled: true, SNI: "proxy.example.com",
+		UDPMode: UDPModeBlock, ConnectTimeoutMS: 2500,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cloned, err := st.CloneSbEgress(srcID)
+	if err != nil || cloned == nil {
+		t.Fatalf("CloneSbEgress: %+v, %v", cloned, err)
+	}
+	if cloned.ID == srcID {
+		t.Fatal("clone reused the source id")
+	}
+	if cloned.Password != fixtureEgressPassword {
+		t.Errorf("clone password = %q, want the source's plaintext", cloned.Password)
+	}
+	if cloned.Name != "静态IP-香港（副本）" {
+		t.Errorf("clone name = %q", cloned.Name)
+	}
+	if cloned.Type != "http" || cloned.Host != "1.2.3.4" || cloned.Port != 8080 ||
+		cloned.Username != "user1" || !cloned.TLSEnabled || cloned.SNI != "proxy.example.com" ||
+		cloned.UDPMode != UDPModeBlock || cloned.ConnectTimeoutMS != 2500 {
+		t.Errorf("clone did not copy every field: %+v", cloned)
+	}
+	// The copy must be encrypted at rest like any other row, not written back
+	// as the plaintext the clone path had in hand.
+	var raw string
+	if err := st.db.QueryRow(`SELECT password FROM sb_egresses WHERE id=?`, cloned.ID).Scan(&raw); err != nil {
+		t.Fatal(err)
+	}
+	if raw == fixtureEgressPassword {
+		t.Error("cloned password stored in cleartext")
+	}
+
+	// Cloning twice must not produce two rows with the same name.
+	second, err := st.CloneSbEgress(srcID)
+	if err != nil || second == nil {
+		t.Fatalf("second CloneSbEgress: %v", err)
+	}
+	if second.Name == cloned.Name {
+		t.Errorf("two clones share the name %q", second.Name)
+	}
+
+	// A source whose password cannot be decrypted must be refused rather than
+	// duplicated into a second row that fails the same way.
+	st.SetSecretKey([]byte("different-key"))
+	if _, err := st.CloneSbEgress(srcID); err == nil {
+		t.Error("cloning an undecryptable egress should fail")
+	}
+}
+
+// TestRelayHopCarriesMultiplex covers fix A: the relay→landing hop used to be
+// the one dial that never mirrored the landing inbound's multiplex setting, so
+// every short connection through a chain paid a full extra handshake.
+func TestRelayHopCarriesMultiplex(t *testing.T) {
+	st := newEgressTestStore(t)
+
+	// A landing that a relay can actually dial: vless over plain TLS, no vision
+	// (sing-box rejects multiplex together with the vision flow).
+	tlsID, err := st.SaveSbTls(&SbTls{
+		Name:       "landing-tls",
+		ServerJSON: `{"enabled":true,"server_name":"landing.example.com"}`,
+		ClientJSON: `{"insecure":true}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	landingID, err := st.SaveSbInbound(&SbInbound{
+		Type: "vless", Tag: "landing", ListenPort: 443, TlsID: tlsID, ServerID: 0,
+		Options: `{"multiplex":{"enabled":true,"brutal":{"enabled":true,"up_mbps":100,"down_mbps":200}}}`,
+		Enabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.SaveSbInbound(&SbInbound{
+		Type: "vless", Tag: "relay", ListenPort: 8443, TlsID: tlsID, ServerID: 0,
+		Options: `{}`, Enabled: true, UpstreamInboundID: landingID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	user := []singbox.User{{Name: "u1", UUID: "11111111-1111-1111-1111-111111111111"}}
+	cfgBytes, err := st.BuildSingboxConfig(singbox.DefaultBaseConfig, "",
+		map[string][]singbox.User{"landing": user, "relay": user})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(cfgBytes, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	var ob map[string]any
+	obs, _ := cfg["outbounds"].([]any)
+	for _, o := range obs {
+		if m, ok := o.(map[string]any); ok && m["tag"] == "relay-to-"+itoa(landingID) {
+			ob = m
+		}
+	}
+	if ob == nil {
+		t.Fatalf("no relay outbound in config:\n%s", cfgBytes)
+	}
+	mx, _ := ob["multiplex"].(map[string]any)
+	if mx == nil || mx["enabled"] != true {
+		t.Fatalf("relay hop did not mirror the landing's multiplex: %v", ob)
+	}
+	// Brutal is deliberately not mirrored: its bandwidths describe a subscriber's
+	// line, and pacing a relay machine to those numbers is worse than not pacing.
+	if _, ok := mx["brutal"]; ok {
+		t.Errorf("relay hop must not carry brutal: %v", mx)
+	}
+}
+
+// TestRelayHopWithoutMultiplexStaysPlain guards the other direction: enabling
+// multiplex must remain the landing inbound's decision, not something the relay
+// wiring turns on for everyone.
+func TestRelayHopWithoutMultiplexStaysPlain(t *testing.T) {
+	st := newEgressTestStore(t)
+
+	tlsID, err := st.SaveSbTls(&SbTls{
+		Name:       "landing-tls",
+		ServerJSON: `{"enabled":true,"server_name":"landing.example.com"}`,
+		ClientJSON: `{"insecure":true}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	landingID, err := st.SaveSbInbound(&SbInbound{
+		Type: "vless", Tag: "landing", ListenPort: 443, TlsID: tlsID,
+		Options: `{}`, Enabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.SaveSbInbound(&SbInbound{
+		Type: "vless", Tag: "relay", ListenPort: 8443, TlsID: tlsID,
+		Options: `{}`, Enabled: true, UpstreamInboundID: landingID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	user := []singbox.User{{Name: "u1", UUID: "11111111-1111-1111-1111-111111111111"}}
+	cfgBytes, err := st.BuildSingboxConfig(singbox.DefaultBaseConfig, "",
+		map[string][]singbox.User{"landing": user, "relay": user})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(cfgBytes, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	obs, _ := cfg["outbounds"].([]any)
+	for _, o := range obs {
+		m, ok := o.(map[string]any)
+		if !ok || m["tag"] != "relay-to-"+itoa(landingID) {
+			continue
+		}
+		if _, has := m["multiplex"]; has {
+			t.Errorf("relay hop enabled multiplex the landing never asked for: %v", m)
+		}
+	}
+}

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -334,6 +334,8 @@ CREATE TABLE IF NOT EXISTS sb_egresses (
   sni          TEXT    NOT NULL DEFAULT '',
   tls_cert_id  INTEGER NOT NULL DEFAULT 0,          -- -> certificates.id (0 = system roots)
   tls_insecure INTEGER NOT NULL DEFAULT 0,
+  udp_mode     TEXT    NOT NULL DEFAULT '',         -- '' = by type | passthrough | block
+  connect_timeout_ms INTEGER NOT NULL DEFAULT 0,    -- 0 = built-in default
   created_at   INTEGER NOT NULL,
   updated_at   INTEGER NOT NULL
 );
@@ -573,6 +575,15 @@ func (s *Store) Migrate() error {
 		`ALTER TABLE sb_egresses ADD COLUMN sni TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sb_egresses ADD COLUMN tls_cert_id INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sb_egresses ADD COLUMN tls_insecure INTEGER NOT NULL DEFAULT 0`,
+		// How UDP behaves on the hop through this proxy, and how long to wait for
+		// the TCP connect to it. Both default to '' / 0, which mean "decide by
+		// type" and "use the built-in default" respectively — see
+		// SbEgress.EffectiveUDPMode / EffectiveConnectTimeoutMS. Storing the
+		// sentinel instead of backfilling a concrete value keeps an existing row
+		// tracking the panel's default as it improves, rather than freezing
+		// whatever the default happened to be on the upgrade day.
+		`ALTER TABLE sb_egresses ADD COLUMN udp_mode TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sb_egresses ADD COLUMN connect_timeout_ms INTEGER NOT NULL DEFAULT 0`,
 		// Alerts became episode-based (see server_alerts above). Legacy DBs hold one
 		// row per hourly observation, so a single server that stayed offline for a
 		// week shows ~170 identical unread lines. Fold each unread (server, type)

--- a/internal/store/relay.go
+++ b/internal/store/relay.go
@@ -163,7 +163,11 @@ func (s *Store) buildRelayWiring(serverInbounds, allInbounds []*SbInbound) ([]si
 				trustPEM = c.CertPEM
 			}
 		}
-		byEgress[r.EgressID] = &singbox.Relay{Outbound: egressOutbound(eg, trustPEM), InboundTags: []string{r.Tag}}
+		byEgress[r.EgressID] = &singbox.Relay{
+			Outbound:    egressOutbound(eg, trustPEM),
+			InboundTags: []string{r.Tag},
+			RejectUDP:   eg.EffectiveUDPMode() == UDPModeBlock,
+		}
 		egOrder = append(egOrder, r.EgressID)
 	}
 	for _, id := range egOrder {
@@ -188,6 +192,18 @@ func egressOutbound(e *SbEgress, trustPEM string) map[string]interface{} {
 		"tag":         fmt.Sprintf("egress-%d", e.ID),
 		"server":      e.Host,
 		"server_port": e.Port,
+		// Bound the TCP connect to the proxy. When a provider drops an account
+		// (quota spent, IP no longer whitelisted) the port usually goes silent
+		// rather than refusing, and with no timeout every connection then sits on
+		// the OS retry schedule — minutes, during which the user's tab neither
+		// loads nor errors. Seconds instead at least lets the client retry and
+		// makes the outage legible.
+		//
+		// Scope, precisely: this is a DialerOptions field, so it covers reaching
+		// the proxy's port. A proxy that completes the TCP handshake and then
+		// stalls mid-SOCKS5/CONNECT is not covered by it — nothing in a sing-box
+		// outbound bounds that, and the concurrency probe is what surfaces it.
+		"connect_timeout": fmt.Sprintf("%dms", e.EffectiveConnectTimeoutMS()),
 	}
 	if e.Type == "socks" {
 		ob["version"] = "5"
@@ -269,6 +285,28 @@ func (s *Store) relayOutbound(landing *SbInbound, serverCache map[int64]*Server,
 		ServerKey:   mapStr(opts, "password"),
 		TCPFastOpen: mapBool(opts, "tcp_fast_open"),
 		MPTCP:       mapBool(opts, "tcp_multi_path"),
+	}
+	// Multiplex on the relay→landing hop, mirroring the landing inbound's own
+	// setting exactly as BuildSelfBuiltLinks does for client links.
+	//
+	// This hop is the one place where the omission really hurts. A client makes a
+	// handful of connections; a relay carries every connection of every user
+	// behind it, and without multiplexing each one pays a full protocol handshake
+	// to the landing on top of the client's own. Loading one web page opens
+	// dozens of short connections across a dozen domains, so the round trips
+	// stack up into "images load half-way" while a long-lived app socket over the
+	// same relay feels perfectly fine.
+	//
+	// BuildShareLink drops mux by itself when vless xtls-rprx-vision is active
+	// (sing-box rejects the pair), so no gate is needed here.
+	//
+	// Brutal is deliberately NOT mirrored. Its up/down are per-endpoint physical
+	// bandwidths; the values configured for client links describe a subscriber's
+	// line, and a relay machine's is nothing like it. Brutal ignores congestion
+	// signals and paces to the number it is given, so a wrong one doesn't degrade
+	// gracefully — it floods the landing or throttles the relay to a crawl.
+	if mx, ok := opts["multiplex"].(map[string]interface{}); ok && mapBool(mx, "enabled") {
+		lp.Mux = true
 	}
 	if obfs, ok := opts["obfs"].(map[string]interface{}); ok {
 		lp.Obfs = mapStr(obfs, "type")

--- a/internal/store/singboxcheck_test.go
+++ b/internal/store/singboxcheck_test.go
@@ -1,0 +1,154 @@
+package store
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"qingzhou/internal/singbox"
+)
+
+// TestServerConfigPassesSingboxCheck runs the real `sing-box check` over the
+// SERVER config 轻舟 pushes to a node, with every wiring shape at once: a plain
+// direct-exit inbound, a relay hop into a landing (which now carries
+// multiplex), and two third-party egresses — one blocking UDP, one passing it
+// through — with their connect_timeout.
+//
+// Unit tests assert what we thought we emitted; only the binary says whether
+// sing-box will start. That gap has bitten this repo before: a config that
+// passed every assertion was rejected outright by 1.13 for an option removal
+// nobody had noticed. Every knob added here (connect_timeout, a
+// network+action rule, multiplex on a server-side outbound) is a new chance to
+// emit something that parses as JSON and is not valid sing-box.
+//
+// Skipped unless QZ_SINGBOX_TEST_BIN points at a sing-box binary:
+//
+//	QZ_SINGBOX_TEST_BIN=/path/to/sing-box go test ./internal/store/ -run SingboxCheck
+//
+// Worth re-running against each new sing-box release — a deprecation whose
+// removal has landed turns from a warning into a hard failure here first.
+func TestServerConfigPassesSingboxCheck(t *testing.T) {
+	bin := os.Getenv("QZ_SINGBOX_TEST_BIN")
+	if bin == "" {
+		t.Skip("set QZ_SINGBOX_TEST_BIN to a sing-box binary to run this")
+	}
+	st := newEgressTestStore(t)
+
+	// A Reality profile, because that is what a real landing inbound uses and it
+	// is the case where multiplex must be suppressed (vision) or emitted.
+	//
+	// The keypair is generated rather than pasted. sing-box parses the private
+	// key during `check`, so it has to be a genuine x25519 key — and a genuine
+	// key checked into the repo is a high-entropy blob that secret scanners
+	// (rightly) cannot tell apart from a real one.
+	priv, pub, err := singbox.GenerateRealityKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsID, err := st.SaveSbTls(&SbTls{
+		Name: "landing-tls",
+		ServerJSON: `{"enabled":true,"server_name":"www.microsoft.com","reality":{"enabled":true,
+			"handshake":{"server":"www.microsoft.com","server_port":443},
+			"private_key":"` + priv + `","short_id":["0123456789abcdef"]}}`,
+		ClientJSON: `{"reality":{"enabled":true,"public_key":"` + pub + `","short_id":"0123456789abcdef"},
+			"utls":{"enabled":true,"fingerprint":"chrome"}}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockID, err := st.SaveSbEgress(&SbEgress{
+		Name: "阻断UDP", Type: "http", Host: "proxy.example.com", Port: 8080,
+		Username: "u", Password: "p", ConnectTimeoutMS: 3000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	passID, err := st.SaveSbEgress(&SbEgress{
+		Name: "透传UDP", Type: "socks", Host: "203.0.113.9", Port: 1080,
+		Username: "u", Password: "p", UDPMode: UDPModePassthrough,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Landing: multiplex on, no vision flow (sing-box rejects the pair), so the
+	// relay hop below actually emits a multiplex block.
+	landingID, err := st.SaveSbInbound(&SbInbound{
+		Type: "vless", Tag: "landing", ListenPort: 443, TlsID: tlsID,
+		Options: `{"flow":"none","multiplex":{"enabled":true}}`, Enabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ib := range []struct {
+		tag      string
+		port     int
+		upstream int64
+		egress   int64
+	}{
+		{"relay", 8443, landingID, 0},
+		{"via-http-egress", 8444, 0, blockID},
+		{"via-socks-egress", 8445, 0, passID},
+		{"direct", 8446, 0, 0},
+	} {
+		if _, err := st.SaveSbInbound(&SbInbound{
+			Type: "vless", Tag: ib.tag, ListenPort: ib.port, TlsID: tlsID,
+			Options: `{"flow":"none"}`, Enabled: true,
+			UpstreamInboundID: ib.upstream, EgressID: ib.egress,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	user := []singbox.User{{Name: "u1", UUID: "11111111-1111-1111-1111-111111111111", Password: "pw"}}
+	users := map[string][]singbox.User{}
+	for _, tag := range []string{"landing", "relay", "via-http-egress", "via-socks-egress", "direct"} {
+		users[tag] = user
+	}
+
+	// Both shapes the panel actually pushes: a node whose sing-box carries the
+	// v2ray_api plugin (per-user stats) and one without it, where the block is
+	// omitted entirely.
+	for _, tc := range []struct{ name, v2ray string }{
+		{"with v2ray_api", "127.0.0.1:18080"},
+		{"without v2ray_api", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := st.BuildSingboxConfig(singbox.DefaultBaseConfig, tc.v2ray, users)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Sanity: the things this test exists to validate must actually be
+			// present, or a passing `check` would only prove an empty config is valid.
+			for _, want := range []string{`"connect_timeout": "3000ms"`, `"network": "udp"`, `"action": "reject"`, `"multiplex"`} {
+				if !strings.Contains(string(cfg), want) {
+					t.Fatalf("generated config is missing %s — the check below would prove nothing:\n%s", want, cfg)
+				}
+			}
+
+			path := filepath.Join(t.TempDir(), "config.json")
+			if err := os.WriteFile(path, cfg, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			out, err := exec.Command(bin, "check", "-c", path).CombinedOutput()
+			if err != nil {
+				// A binary built without the v2ray_api tag rejects the stats block
+				// itself. That says nothing about the routing and outbounds this test
+				// is here for, and the sibling case covers them on the same binary.
+				if strings.Contains(string(out), "with_v2ray_api") {
+					t.Skipf("this sing-box build lacks with_v2ray_api:\n%s", out)
+				}
+				t.Fatalf("sing-box check failed: %v\n%s\n--- config ---\n%s", err, out, cfg)
+			}
+			if len(out) > 0 {
+				// check is silent on success; anything printed is a deprecation
+				// warning worth seeing before it becomes a hard failure in a later
+				// release.
+				t.Logf("sing-box check output:\n%s", out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #13。

三块：出口管理体验（克隆、粘贴解析）、链路本身的修复、以及一个在验证过程中挖出来的超时 bug。

---

## 一、链路修复（issue 第 3 条：延迟高、不稳定）

### A. 中转跳一直没有多路复用 —— 这是「推特能用、网页打不开」的主因

`relayOutbound` 构造 `LinkParams` 时镜像了 tfo / mptcp / congestion，唯独漏了 `Mux`；给用户发订阅的那份（`store/singbox.go`）是有的。也就是说即使落地入站开了多路复用，**线路机 → 落地机这一跳仍然是每条 TCP 连接一次完整协议握手**。

客户端只开几条连接感觉不到；线路机承载的是它后面所有用户的所有连接。打开一个网页要向十几个域名开几十条短连接，握手 RTT 叠起来就是「图加载一半、有的资源永远不来」，而同一条链路上的长连接 App 一切正常。

Brutal **故意不镜像**：它的 up/down 是端点物理带宽，客户端链接里那组数值描述的是订户的线路，套到线路机上不是失准而是有害——Brutal 不看拥塞信号，给错数字就是要么打爆落地、要么把线路机压到爬。

### B. 代理出口新增 UDP 策略（透传 / 阻断，空＝按类型定）

**先把话说准，因为直觉是错的。** 我起了本地 sing-box 1.13.18 实测：SOCKS5 入站上挂 `{"network":"udp","action":"reject"}`，**UDP ASSOCIATE 照样回成功**（那个回复在有目标可路由之前就发出去了），之后的数据包被静默丢弃——客户端 6s 超时，对照组 1ms 拿到 DNS 应答。SOCKS5 层面没有办法向客户端表达「拒绝」。

所以**阻断不会让浏览器更快回落 TCP**。它买到的是**确定性**：代理「半通」的 UDP 比完全没有更糟——QUIC 能握上手、被选中，然后中途卡死，浏览器反而不回落。阻断把「时好时坏」变成「一直没有」，这是每个客户端都知道怎么处理的状态。顺带也不再让 sing-box 去尝试并记录一条根本走不通的包路径。

`http` 出口只能阻断（sing-box 的 http 出站没有 UDP 通路），后端拒绝 `http + passthrough` 的组合，前端切类型时自动收回选择。

要让浏览器真正秒回落，得在客户端订阅配置里禁 UDP/443 —— 那是全局且用户可覆盖的模板改动，本 PR 没动。

### D. 代理出口出站补 `connect_timeout`（默认 5000ms，可配 0–60000）

供应商停用账号（流量用尽、IP 掉出白名单）时通常是端口不回包而不是拒绝，不设上限每条连接都要卡满系统 TCP 重传（Linux 约 2 分钟），用户看到的是既不加载也不报错的标签页。

边界写在注释里了：这是 DialerOptions 字段，只管**到代理端口的 TCP 握手**。握手完成后卡在 SOCKS5/CONNECT 阶段它管不了，那种要用下面的并发探测看。

### C. 只能加诊断：「测试连通」支持 `?n=`（2–32）并发探测

sing-box 出站没有并发连接数限制选项，供应商的上限改代码解决不了。但一条一条地测**永远看不到**这个问题：静态 IP 普遍按并发连接数限流，而所有绑同一出口的入站共用供应商那**一个账号**，浏览网页一次就能顶到上限，超出的连接被代理侧掐掉。

探测报成功/失败数、延迟分布（最小/中位/最大）、以及按出现次数折叠的错误。先做一次预检选定回显 URL，避免把「某个回显服务被墙」误判成并发上限；界面也提示了 429/rate limit 是回显服务限流而不是出口到顶。

---

## 二、出口管理（issue 第 1、2 条）

### 克隆：`POST /api/admin/sb/egresses/{id}/clone`

**必须在服务端做。** 列表接口把密码掩码成 `"***"`，而后端只在 `ID != 0` 时才把这个哨兵解释成「保持库中原值」。前端复制一行、id 置 0、走新建，会把三个星号字面量存成密码——面板里看着一切正常，上线就 407，报错离原因很远。有回归测试盯着。

源出口密码解不开（`QZ_SECRET_KEY` 变过）时拒绝克隆，而不是复制出第二行同样坏掉的记录。重名自动加「（副本）」「（副本 2）」。

### 粘贴解析：`POST /api/admin/sb/egresses/parse`

支持 `socks5://` / `socks5h://` / `http://` / `https://`（→ http + TLS）/ `user:pass@host:port` / `host:port:user:pass` / 反序的 `user:pass:host:port` / 裸 `host:port` / 带方括号的 IPv6；`#fragment` 当名称，`?sni=` 带 SNI；表格粘贴的引号和尾逗号会剥掉；密码里含 `:` 或 `@` 都不会截断。

**只解析，不落库。** 写入仍然走原来的新建接口，所以校验规则只有一份，批量导入和手工添加落到库里的东西必然一致。多行逐行报错（一行垃圾不影响其余 20 条），超过 500 行会明确告诉你截断了多少。

---

## 三、顺带修掉的一个真 bug

`sbctl.RunOnServer` 的 ctx 其实**没有约束住调用方**：`exec.CommandContext` 只杀 shell，shell 派生的子进程（这里是 curl）继承了输出管道且不会被一起杀掉，`CombinedOutput` 会一直等到最后一个写端关闭。

实测：25s 的 deadline **返回在 40s**，越过服务器 30s 的 `WriteTimeout`，面板显示连接被掐断，而不是脚本其实早就得出的「不通」——正是让「一键重装装成功了却报失败」的同一个坑。

加 `cmd.WaitDelay`，并把检测预算收到 20s + 2s（离 30s 还有 8s 余量），超时时给出可读原因而不是 `exit status 1`。回归测试验证过非空：去掉 `WaitDelay` 是 30.3s 失败，加上是 3.0s 通过。

---

## 兼容性

- 两个新列都是 `NOT NULL DEFAULT`（`udp_mode=''`、`connect_timeout_ms=0`），沿用仓库现有的 ADD COLUMN 迁移模式，旧库升级后行为由 `EffectiveUDPMode` / `EffectiveConnectTimeoutMS` 决定，不做 backfill——存哨兵而不是冻结升级当天的默认值。
- 现有 socks 出口默认仍是 UDP 透传（行为不变）；现有 http 出口变成显式阻断，而它们的 UDP 本来就走不通。
- 现有出口全部获得 5s 连接超时（之前是系统级 ~2 分钟）。这是本 PR 的意图之一，可按出口调。
- 落地入站没开多路复用的中转链，中转跳依然不带 multiplex（有测试守着，不会替谁擅自打开）。
- 无 API 破坏性变更：新增两个端点，出口 JSON 只增字段。

## 验证

| 项 | 结果 |
|---|---|
| 真 `sing-box check` @ 1.13.18（生产版本） | 通过；另跑了一个 1.14 构建也过 |
| 两个检测脚本 × 真 SOCKS5 代理 × 真 sh/curl | 通过，含「CA 文件不混进探测结果」用例 |
| 起真面板跑完整闭环 | 解析→创建→克隆→改 UDP/超时→挂入站→拒绝删除 |
| 落盘配置核对 | `connect_timeout: "2500ms"`、UDP reject 规则在引流规则**之前**、`"***"` 更新后密码仍为原值 |
| 浏览器实操 | 卡片、批量导入预览（猜类型标 `?`、坏行报行号）、http 时「透传」自动禁用 |
| 耗时 | 成功 1.2s；失败约 7s 得出结论；最坏 22s 且有可读超时原因，不再被掐断 |
| `go test ./...` | 全绿 |

新增测试：链接解析 22 例 + 拒绝 6 例、克隆（含密码/加密/重名/解密失败）、UDP 规则顺序、connect_timeout 渲染、中转跳 multiplex 两个方向、并发探测输出解析、`sing-box check`、活体代理脚本、`RunOnServer` 超时回归。

---

## 一处自我更正

我在 issue #13 的分析评论里建议给 SOCKS5 出口加 `udp_over_tcp` —— **那是错的，本 PR 没有实现**。UoT 是 sing-box / shadowsocks-rust 之间的私有约定，商用代理不认，加上只会把 UDP 包裹成一段它看不懂的 TCP 流转出去。同一条评论里「阻断能让浏览器立刻回落 TCP」的说法也被上面的实测推翻了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
