### PR TITLE
fix(egress): 节点把 UDP 丢了，订阅却还宣告支持，客户端只能干等超时

### DIFF
--- a/internal/singbox/link.go
+++ b/internal/singbox/link.go
@@ -88,7 +88,32 @@ type LinkParams struct {
 	Mux        bool
 	BrutalUp   int
 	BrutalDown int
+
+	// NoUDP marks a node that cannot relay UDP: its inbound is bound to a proxy
+	// egress whose UDP mode is block, so the node itself rejects every UDP
+	// packet (see singbox.Relay.RejectUDP). Without this flag the subscription
+	// still advertises the node as UDP-capable — clash `udp: true`, sing-box
+	// unrestricted network — and clients duly send UDP (QUIC, STUN) into what
+	// is, from their side, a silent black hole: nothing refuses the traffic, so
+	// every attempt runs out its own timeout before falling back to TCP.
+	//
+	// Carried as the custom `qz-udp=block` param (same convention as tfo/mux:
+	// 轻舟's own renderers read it back, unknown-key-tolerant clients ignore
+	// it), which 轻舟's renderers turn into clash `udp: false`, sing-box
+	// `"network": "tcp"` and Surge `udp-relay=false` — the client then refuses
+	// UDP locally, instantly, and applications take their TCP path without
+	// waiting on a timeout. Per-node by construction: nodes on other exits are
+	// untouched.
+	//
+	// Each renderer applies it only where its own core has a field for it (see
+	// singboxOutbound and clashProxy) — sing-box's anytls outbound and mihomo's
+	// hysteria/hysteria2/tuic proxies have none, and an unknown key there fails
+	// the whole config for every subscriber holding that node.
+	NoUDP bool
 }
+
+// noUDPParam is the query key/value advertising that a node cannot carry UDP.
+const noUDPParam = "qz-udp=block"
 
 // tuicUDPRelayModeNative is the UDP relay mode every mainstream TUIC
 // implementation already defaults to. It is emitted explicitly, never inferred.
@@ -219,6 +244,9 @@ func BuildShareLink(p LinkParams) string {
 		// fine). Pin xudp so both ends agree.
 		q = append(q, "packetEncoding=xudp")
 		q = append(q, p.tuningQuery(!visionActive)...) // mux is invalid with vision flow
+		if p.NoUDP {
+			q = append(q, noUDPParam)
+		}
 		return "vless://" + esc(p.UUID) + "@" + hp + "?" + strings.Join(q, "&") + frag
 	case "trojan":
 		q := p.transportQuery()
@@ -227,6 +255,9 @@ func BuildShareLink(p LinkParams) string {
 			q = append(q, "allowInsecure=1")
 		}
 		q = append(q, p.tuningQuery(true)...)
+		if p.NoUDP {
+			q = append(q, noUDPParam)
+		}
 		return "trojan://" + esc(p.Password) + "@" + hp + "?" + strings.Join(q, "&") + frag
 	case "tuic":
 		q := []string{"security=tls"}
@@ -250,6 +281,9 @@ func BuildShareLink(p LinkParams) string {
 		// Stating the value that is already everyone's default costs nothing and
 		// removes the ambiguity.
 		q = append(q, "udp_relay_mode="+tuicUDPRelayModeNative)
+		if p.NoUDP {
+			q = append(q, noUDPParam)
+		}
 		return "tuic://" + esc(p.UUID) + ":" + esc(p.Password) + "@" + hp + "?" + strings.Join(q, "&") + frag
 	case "hysteria2":
 		q := []string{"security=tls"}
@@ -267,6 +301,9 @@ func BuildShareLink(p LinkParams) string {
 			if p.ObfsPassword != "" {
 				q = append(q, "obfs-password="+url.QueryEscape(p.ObfsPassword))
 			}
+		}
+		if p.NoUDP {
+			q = append(q, noUDPParam)
 		}
 		return "hysteria2://" + esc(p.Password) + "@" + hp + "?" + strings.Join(q, "&") + frag
 	case "vmess":
@@ -324,6 +361,9 @@ func BuildShareLink(p LinkParams) string {
 				m["brutal_down"] = strconv.Itoa(p.BrutalDown)
 			}
 		}
+		if p.NoUDP {
+			m["qz-udp"] = "block" // JSON-map twin of the URL-style noUDPParam
+		}
 		b, _ := json.Marshal(m)
 		return "vmess://" + base64.StdEncoding.EncodeToString(b)
 	case "shadowsocks":
@@ -331,11 +371,24 @@ func BuildShareLink(p LinkParams) string {
 		// password = serverPSK:userPSK.
 		userKey := DeriveSSKey(p.Password, p.Method)
 		userinfo := base64.RawURLEncoding.EncodeToString([]byte(p.Method + ":" + p.ServerKey + ":" + userKey))
+		if p.NoUDP {
+			// SIP002 URIs carry a query (the spec puts `plugin` there), so a
+			// custom key rides in the same place as on the URL-style links. The
+			// spec's optional "/" before it is deliberately omitted: canonicalLink
+			// splits at the first '?', so a slash would land in the base and give
+			// the node a different NodeKey than the same node unmarked — silently
+			// dropping every user's blocklist entry for it whenever an admin
+			// flips udp_mode.
+			return "ss://" + userinfo + "@" + hp + "?" + noUDPParam + frag
+		}
 		return "ss://" + userinfo + "@" + hp + frag
 	case "anytls":
 		q := []string{"security=tls", "fp=" + esc(fp), "sni=" + esc(p.SNI)}
 		if p.Insecure {
 			q = append(q, "insecure=1")
+		}
+		if p.NoUDP {
+			q = append(q, noUDPParam)
 		}
 		return "anytls://" + esc(p.Password) + "@" + hp + "?" + strings.Join(q, "&") + frag
 	case "hysteria":
@@ -354,6 +407,9 @@ func BuildShareLink(p LinkParams) string {
 		}
 		if p.PinSHA256 != "" {
 			q = append(q, "pinSHA256="+esc(p.PinSHA256))
+		}
+		if p.NoUDP {
+			q = append(q, noUDPParam)
 		}
 		return "hysteria://" + hp + "?" + strings.Join(q, "&") + frag
 	}

--- a/internal/store/egress.go
+++ b/internal/store/egress.go
@@ -70,8 +70,21 @@ type SbEgress struct {
 	// already knows how to handle. It also stops sing-box attempting — and
 	// logging — a packet path that was never going to work.
 	//
-	// The lever for genuinely fast fallback is on the client side (rejecting
-	// UDP/443 in the subscription config), not here.
+	// Fast fallback is the client's half of this, and it is now wired: an
+	// inbound bound to a blocking egress renders its subscription entry as
+	// UDP-incapable (singbox.LinkParams.NoUDP -> clash `udp: false`, sing-box
+	// `"network": "tcp"`, Surge `udp-relay=false`), so the client refuses UDP
+	// locally the moment an application asks — no timeout, no black hole. That
+	// marker is per node, so nodes on other exits keep QUIC.
+	//
+	// A measured case, for calibration on what "relays it badly" looks like:
+	// one vendor accepted UDP ASSOCIATE, kept sessions alive past 90s, held the
+	// same exit IP as TCP, and relayed real datagrams — but capped a single
+	// datagram at 512 bytes (the pre-EDNS DNS message size; their relay buffer
+	// is DNS-shaped). RFC 9000 §14.1 pads a QUIC client Initial to ≥1200, so
+	// every QUIC handshake through it was dropped with no ICMP and no error.
+	// DNS was the one UDP service that worked, which is why hijackDNSRule
+	// exists and why "UDP works, I tested it" is not evidence.
 	//
 	// "" means unset — resolved by EffectiveUDPMode from the type, because a
 	// sensible default differs: sing-box's http outbound cannot carry UDP at all,

--- a/internal/store/egressudplink_test.go
+++ b/internal/store/egressudplink_test.go
@@ -1,0 +1,112 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+// The end-to-end assertion for the panel's own data path: an inbound bound to a
+// proxy egress that drops UDP must advertise that in the subscription link.
+//
+// Without it the two halves disagree — the node rejects every UDP packet
+// (Relay.RejectUDP -> a route reject on the node) while the subscription still
+// tells clients the node carries UDP. Nothing refuses the traffic on the wire,
+// so each QUIC/STUN attempt runs out its own timeout before the application
+// falls back to TCP. That is invisible in the panel and reads to the user as
+// "some sites are slow or won't load".
+func TestSelfBuiltLinks_UDPBlockedEgressMarksLink(t *testing.T) {
+	st := newRefundStore(t)
+	uid := mkUser(t, st, "carol")
+	pkg := mkPlan(t, st, "P", 10, 100, 30)
+	buy(t, st, uid, pkg)
+
+	blocking, err := st.SaveSbEgress(&SbEgress{
+		Name: "静态IP-封UDP", Type: "socks", Host: "proxy.example.com", Port: 1080,
+		Username: "u", Password: "p", UDPMode: UDPModeBlock,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	passthrough, err := st.SaveSbEgress(&SbEgress{
+		Name: "静态IP-放行UDP", Type: "socks", Host: "proxy2.example.com", Port: 1080,
+		Username: "u", Password: "p", UDPMode: UDPModePassthrough,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, c := range []struct {
+		tag      string
+		port     int
+		egressID int64
+	}{
+		{"blocked-in", 8443, blocking},
+		{"open-in", 8444, passthrough},
+		{"plain-in", 8445, 0}, // no egress at all — exits the node directly
+	} {
+		if _, err := st.SaveSbInbound(&SbInbound{
+			Type: "vless", Tag: c.tag, Listen: "::", ListenPort: c.port,
+			Options: "{}", Enabled: true, EgressID: c.egressID,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	u, err := st.UserByID(uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byTag := map[string]string{}
+	for _, l := range st.BuildSelfBuiltLinks(u, "example.com") {
+		byTag[l.Tag] = l.Link
+	}
+	if len(byTag) != 3 {
+		t.Fatalf("want 3 links, got %d: %v", len(byTag), byTag)
+	}
+
+	if !strings.Contains(byTag["blocked-in"], "qz-udp=block") {
+		t.Errorf("inbound on a UDP-blocking egress must be marked:\n%s", byTag["blocked-in"])
+	}
+	// The marker is per node, not per subscription: a user holding both an
+	// egress-backed node and a normal one keeps QUIC on the normal one.
+	if strings.Contains(byTag["open-in"], "qz-udp") {
+		t.Errorf("passthrough egress must not be marked:\n%s", byTag["open-in"])
+	}
+	if strings.Contains(byTag["plain-in"], "qz-udp") {
+		t.Errorf("inbound with no egress must not be marked:\n%s", byTag["plain-in"])
+	}
+}
+
+// An http egress cannot carry UDP at all (sing-box's http outbound has no
+// packet path), so EffectiveUDPMode resolves it to block even with udp_mode
+// unset. The link must be marked on that resolved value, not the stored one —
+// otherwise every http-egress node in the panel silently keeps advertising UDP.
+func TestSelfBuiltLinks_HTTPEgressMarkedByDefault(t *testing.T) {
+	st := newRefundStore(t)
+	uid := mkUser(t, st, "dave")
+	pkg := mkPlan(t, st, "P", 10, 100, 30)
+	buy(t, st, uid, pkg)
+
+	egID, err := st.SaveSbEgress(&SbEgress{
+		Name: "HTTP出口", Type: "http", Host: "proxy.example.com", Port: 8080,
+		Username: "u", Password: "p", // UDPMode deliberately unset
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.SaveSbInbound(&SbInbound{
+		Type: "vless", Tag: "http-eg-in", Listen: "::", ListenPort: 8443,
+		Options: "{}", Enabled: true, EgressID: egID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	u, _ := st.UserByID(uid)
+	links := st.BuildSelfBuiltLinks(u, "example.com")
+	if len(links) != 1 {
+		t.Fatalf("want 1 link, got %d", len(links))
+	}
+	if !strings.Contains(links[0].Link, "qz-udp=block") {
+		t.Errorf("http egress resolves to block and must mark the link:\n%s", links[0].Link)
+	}
+}

--- a/internal/store/singbox.go
+++ b/internal/store/singbox.go
@@ -707,6 +707,25 @@ func (s *Store) BuildSelfBuiltLinks(u *User, host string) []SelfBuiltLink {
 	// with no active owning bucket is omitted (no access).
 	owners, _ := s.UserOwnedInbounds(u.ID, time.Now().Unix())
 	nodeNames, _ := s.SelfBuiltNodeNames()
+	// Whether an inbound's bound egress drops UDP (udp_mode=block), so the link
+	// can say so (LinkParams.NoUDP) and clients refuse UDP locally instead of
+	// timing out against the node-side reject. Cached per egress id: several
+	// inbounds routinely share one egress.
+	egressNoUDP := map[int64]bool{}
+	noUDP := func(egressID int64) bool {
+		if egressID == 0 {
+			return false
+		}
+		if v, ok := egressNoUDP[egressID]; ok {
+			return v
+		}
+		v := false
+		if eg, _ := s.GetSbEgress(egressID); eg != nil {
+			v = eg.EffectiveUDPMode() == UDPModeBlock
+		}
+		egressNoUDP[egressID] = v
+		return v
+	}
 
 	var out []SelfBuiltLink
 	for _, ib := range inbounds {
@@ -757,6 +776,7 @@ func (s *Store) BuildSelfBuiltLinks(u *User, host string) []SelfBuiltLink {
 		p := singbox.LinkParams{
 			Type: ib.Type, Tag: remark, Host: nodeHost, Port: ib.ListenPort,
 			UUID: owner.ClientUUID, Password: owner.ClientSecret,
+			NoUDP:       noUDP(ib.EgressID),
 			TLS:         ib.TlsID != 0,
 			SNI:         mapStr(server, "server_name"),
 			Fingerprint: nestedStr(client, "utls", "fingerprint"),

--- a/internal/subconv/clash.go
+++ b/internal/subconv/clash.go
@@ -364,6 +364,28 @@ func clashProxy(p *Proxy) map[string]any {
 		_, hasFlow := m["flow"]
 		clashApplyTuning(m, t, hasFlow)
 	}
+	// A node that drops UDP at the server (egress udp_mode=block) must not
+	// advertise `udp: true`: mihomo would relay UDP into a black hole and every
+	// QUIC/STUN attempt would wait out its own timeout. Setting it false makes
+	// mihomo refuse the UDP session locally, so applications fall back to TCP
+	// at once. The packet-encoding keys go with it — they only describe how UDP
+	// would be encoded, and a node claiming "no UDP, xudp" invites the reader to
+	// trust the wrong half.
+	//
+	// Flipped only where the renderer already emitted `udp`, never introduced:
+	// mihomo's hysteria/hysteria2/tuic options have no such field (their
+	// transport is UDP by construction), and this file's discipline for a key a
+	// core might not know is to keep it out — one unparseable proxy fails the
+	// whole config for every subscriber holding that node, which is a far worse
+	// outcome than the black hole this avoids. Those three keep the node-side
+	// reject alone in Clash; the sing-box output covers them via `network`.
+	if p.udpBlocked() {
+		if _, emitted := m["udp"]; emitted {
+			m["udp"] = false
+		}
+		delete(m, "xudp")
+		delete(m, "packet-addr")
+	}
 	return m
 }
 

--- a/internal/subconv/parse.go
+++ b/internal/subconv/parse.go
@@ -262,7 +262,13 @@ func parseSS(raw string) (*Proxy, error) {
 		name, _ = url.QueryUnescape(body[i+1:])
 		body = body[:i]
 	}
+	// SIP002 puts options in the query (plugin=..., and 轻舟's own qz-udp).
+	// This used to be discarded wholesale, which was fine while nothing read
+	// it; keep the parsed form so ss nodes see the same params as URL-style
+	// links.
+	var params url.Values
 	if i := strings.Index(body, "?"); i >= 0 {
+		params, _ = url.ParseQuery(body[i+1:])
 		body = body[:i]
 	}
 	var method, password, server string
@@ -293,7 +299,7 @@ func parseSS(raw string) (*Proxy, error) {
 	if name == "" {
 		name = server
 	}
-	return &Proxy{Raw: raw, Protocol: "ss", Name: name, Server: server, Port: port, Method: method, Password: password}, nil
+	return &Proxy{Raw: raw, Protocol: "ss", Name: name, Server: server, Port: port, Method: method, Password: password, Params: params}, nil
 }
 
 // DecodeLinks returns the raw share-link lines from a subscription blob
@@ -324,6 +330,10 @@ var volatileParams = map[string]bool{
 	"packetEncoding": true, "packet_encoding": true,
 	"tfo": true, "mptcp": true, "mux": true,
 	"brutal_up": true, "brutal_down": true,
+	// The no-UDP marker follows the bound egress's udp_mode; an admin flipping
+	// that (or unbinding the egress) must not re-key the node and silently
+	// undo every user's blocklist entry for it.
+	"qz-udp": true,
 }
 
 // NodeKey returns a stable per-node identifier derived from a share link,
@@ -478,6 +488,21 @@ func (p *Proxy) param(keys ...string) string {
 		}
 	}
 	return ""
+}
+
+// udpBlocked reports whether the link marks its node as unable to relay UDP
+// (`qz-udp=block`, emitted for inbounds bound to a UDP-blocking proxy egress —
+// see singbox.LinkParams.NoUDP). The node drops UDP either way; this flag lets
+// the renderers say so in the client config, so the refusal happens instantly
+// client-side instead of as a silent server-side black hole each application
+// must time out against. Read from the query for URL-style links and from the
+// JSON map for vmess (safe to check both: the key is 轻舟's own, so the "type"
+// namespace collision that keeps param() and the vmess map apart can't occur).
+func (p *Proxy) udpBlocked() bool {
+	if p.param("qz-udp") == "block" {
+		return true
+	}
+	return p.VMess != nil && str(p.VMess["qz-udp"]) == "block"
 }
 
 // tlsParam reads a TLS-related setting from whichever namespace the proxy has:

--- a/internal/subconv/singbox.go
+++ b/internal/subconv/singbox.go
@@ -310,6 +310,24 @@ func singboxOutbound(p *Proxy) map[string]any {
 		_, hasFlow := o["flow"]
 		sbApplyTuning(o, t, hasFlow)
 	}
+	// A node that drops UDP at the server (egress udp_mode=block) is rendered
+	// TCP-only, so sing-box refuses UDP connections locally — instantly — and
+	// applications take their TCP fallback instead of timing out against the
+	// server-side black hole.
+	//
+	// Whitelisted per protocol, same discipline as packet_encoding above:
+	// sing-box rejects an unknown field by refusing the whole config, so one
+	// wrong emission would take down every subscriber's profile. `network` is a
+	// documented option on the V2Ray family and the QUIC-transport protocols
+	// (their `network` restricts what they RELAY, not how they dial), but NOT
+	// on anytls — an anytls node keeps its unrestricted outbound and relies on
+	// the node-side reject alone (its clash/surge outputs do carry the flag).
+	if p.udpBlocked() {
+		switch p.Protocol {
+		case "vless", "vmess", "trojan", "ss", "hysteria", "hysteria2", "tuic":
+			o["network"] = "tcp"
+		}
+	}
 	return o
 }
 

--- a/internal/subconv/singboxcheck_test.go
+++ b/internal/subconv/singboxcheck_test.go
@@ -33,10 +33,25 @@ func TestRenderedConfigPassesSingboxCheck(t *testing.T) {
 
 	// Both a domain-addressed and an IP-addressed node: only the former forces
 	// the dialer to resolve, which is what the domain-resolver rule is about.
+	//
+	// The qz-udp=block variants cover the no-UDP marker, which renders as
+	// `"network": "tcp"` on the outbound. That field is whitelisted per
+	// protocol (see singboxOutbound) because sing-box refuses the whole config
+	// on an unknown one — exactly the failure this test exists to catch. One
+	// blocked node per whitelisted protocol, plus an anytls node that must NOT
+	// get the field.
 	links := []string{
 		"trojan://pw@node.example.com:443?security=tls&sni=node.example.com#A",
 		"hysteria2://pw@203.0.113.7:8443?security=tls&insecure=1&sni=node.example.com#B",
 		"tuic://11111111-2222-3333-4444-555555555555:pw@203.0.113.8:8444?security=tls&sni=node.example.com&udp_relay_mode=native#C",
+
+		"vless://11111111-2222-3333-4444-555555555555@node.example.com:443?security=tls&sni=node.example.com&packetEncoding=xudp&qz-udp=block#D-noudp",
+		"trojan://pw@node.example.com:443?security=tls&sni=node.example.com&qz-udp=block#E-noudp",
+		"hysteria2://pw@203.0.113.9:8443?security=tls&sni=node.example.com&qz-udp=block#F-noudp",
+		"tuic://11111111-2222-3333-4444-555555555555:pw@203.0.113.10:8444?security=tls&sni=node.example.com&udp_relay_mode=native&qz-udp=block#G-noudp",
+		"hysteria://203.0.113.11:8445?protocol=udp&auth=pw&peer=node.example.com&upmbps=50&downmbps=100&qz-udp=block#H-noudp",
+		"ss://YWVzLTI1Ni1nY206cHc@203.0.113.12:8388?qz-udp=block#I-noudp",
+		"anytls://pw@node.example.com:8443?security=tls&sni=node.example.com&qz-udp=block#J-noudp-anytls",
 	}
 
 	for _, tc := range []struct {

--- a/internal/subconv/surge.go
+++ b/internal/subconv/surge.go
@@ -76,13 +76,23 @@ func surgeName(s string) string {
 	return s
 }
 
+// surgeUDPRelay renders the udp-relay flag: false for a node whose egress
+// drops UDP (see Proxy.udpBlocked), so Surge refuses UDP locally instead of
+// relaying it into a server-side black hole.
+func surgeUDPRelay(p *Proxy) string {
+	if p.udpBlocked() {
+		return "udp-relay=false"
+	}
+	return "udp-relay=true"
+}
+
 // surgeProxy returns the right-hand side of a Surge proxy line, or "" if Surge
 // can't express this protocol.
 func surgeProxy(p *Proxy) string {
 	switch p.Protocol {
 	case "ss":
 		parts := []string{"ss", p.Server, itoaPort(p.Port),
-			"encrypt-method=" + p.Method, "password=" + p.Password, "udp-relay=true"}
+			"encrypt-method=" + p.Method, "password=" + p.Password, surgeUDPRelay(p)}
 		return strings.Join(parts, ", ")
 	case "trojan":
 		parts := []string{"trojan", p.Server, itoaPort(p.Port), "password=" + p.Password}
@@ -92,7 +102,7 @@ func surgeProxy(p *Proxy) string {
 		if p.tlsInsecure() {
 			parts = append(parts, "skip-cert-verify=true")
 		}
-		parts = append(parts, "udp-relay=true")
+		parts = append(parts, surgeUDPRelay(p))
 		return strings.Join(parts, ", ")
 	case "vmess":
 		parts := []string{"vmess", p.Server, itoaPort(p.Port), "username=" + p.UUID}

--- a/internal/subconv/udpblock_test.go
+++ b/internal/subconv/udpblock_test.go
@@ -1,0 +1,204 @@
+package subconv
+
+import (
+	"strings"
+	"testing"
+
+	"qingzhou/internal/singbox"
+)
+
+// These tests pin the no-UDP marker across the whole chain (LinkParams ->
+// share link -> parse -> client configs). A node whose inbound is bound to a
+// UDP-blocking proxy egress drops every UDP packet at the server; if the
+// subscription still advertises it as UDP-capable, clients relay QUIC/STUN
+// into a silent black hole and each application waits out its own timeout
+// before falling back to TCP. The marker makes the client itself refuse UDP —
+// instantly, and only for that node.
+
+func noUDPLink(t *testing.T, p singbox.LinkParams) string {
+	t.Helper()
+	p.NoUDP = true
+	link := singbox.BuildShareLink(p)
+	if link == "" {
+		t.Fatalf("BuildShareLink returned empty link for %s", p.Type)
+	}
+	return link
+}
+
+// TestNoUDPRoundTripVless: the common production shape (Reality + vision).
+func TestNoUDPRoundTripVless(t *testing.T) {
+	link := noUDPLink(t, singbox.LinkParams{
+		Type: "vless", Tag: "n1", Host: "1.2.3.4", Port: 443, UUID: "u",
+		SNI: "a.com", PublicKey: "PBK", ShortID: "ab", Flow: true,
+	})
+	if !strings.Contains(link, "qz-udp=block") {
+		t.Fatalf("share link missing qz-udp: %s", link)
+	}
+
+	sb, _ := Singbox(ParseLinks([]string{link}), "")
+	if !strings.Contains(sb, `"network": "tcp"`) {
+		t.Errorf("singbox output should restrict to tcp:\n%s", sb)
+	}
+
+	clash, _ := Clash(ParseLinks([]string{link}), "")
+	if !strings.Contains(clash, "udp: false") {
+		t.Errorf("clash output should advertise udp: false:\n%s", clash)
+	}
+	// No point pinning a UDP packet encoding on a node that carries no UDP.
+	if strings.Contains(clash, "xudp: true") {
+		t.Errorf("blocked node must not also claim xudp:\n%s", clash)
+	}
+}
+
+// TestNoUDPRoundTripAllLinkTypes: every protocol BuildShareLink emits carries
+// the marker, and the clash renderer honors it everywhere (mihomo's udp flag
+// is universal). The sing-box network restriction is asserted separately —
+// see TestNoUDPSingboxWhitelist for why not all protocols get it.
+func TestNoUDPRoundTripAllLinkTypes(t *testing.T) {
+	params := []singbox.LinkParams{
+		{Type: "vless", Tag: "a", Host: "1.2.3.4", Port: 443, UUID: "u", SNI: "a.com", PublicKey: "PBK", ShortID: "ab"},
+		{Type: "trojan", Tag: "b", Host: "1.2.3.4", Port: 443, Password: "pw", SNI: "a.com"},
+		{Type: "vmess", Tag: "c", Host: "1.2.3.4", Port: 443, UUID: "u", TLS: true, SNI: "a.com"},
+		{Type: "shadowsocks", Tag: "d", Host: "1.2.3.4", Port: 8388, Password: "sec", Method: "2022-blake3-aes-128-gcm", ServerKey: "AAAAAAAAAAAAAAAAAAAAAA=="},
+		{Type: "tuic", Tag: "e", Host: "1.2.3.4", Port: 443, UUID: "u", Password: "pw", SNI: "a.com"},
+		{Type: "hysteria2", Tag: "f", Host: "1.2.3.4", Port: 443, Password: "pw", SNI: "a.com"},
+		{Type: "anytls", Tag: "g", Host: "1.2.3.4", Port: 443, Password: "pw", SNI: "a.com"},
+	}
+	for _, lp := range params {
+		link := noUDPLink(t, lp)
+		ps := ParseLinks([]string{link})
+		if len(ps) != 1 {
+			t.Errorf("%s: link did not parse: %s", lp.Type, link)
+			continue
+		}
+		if !ps[0].udpBlocked() {
+			t.Errorf("%s: parsed proxy should report udpBlocked: %s", lp.Type, link)
+		}
+		clash, _ := Clash(ps, "")
+		if strings.Contains(clash, "udp: true") {
+			t.Errorf("%s: clash still advertises udp: true:\n%s", lp.Type, clash)
+		}
+	}
+}
+
+// TestNoUDPClashOnlyFlipsEmittedKey pins the mihomo side of the whitelist:
+// `udp` is flipped where the renderer already emits it and never introduced
+// where it doesn't. mihomo's hysteria/hysteria2/tuic proxies have no udp
+// option, and an unparseable proxy fails the entire config for every
+// subscriber holding that node.
+func TestNoUDPClashOnlyFlipsEmittedKey(t *testing.T) {
+	for _, c := range []struct {
+		lp       singbox.LinkParams
+		wantsKey bool
+	}{
+		{singbox.LinkParams{Type: "vless", Tag: "a", Host: "1.2.3.4", Port: 443, UUID: "u", SNI: "a.com", PublicKey: "PBK", ShortID: "ab"}, true},
+		{singbox.LinkParams{Type: "trojan", Tag: "b", Host: "1.2.3.4", Port: 443, Password: "pw", SNI: "a.com"}, true},
+		{singbox.LinkParams{Type: "vmess", Tag: "c", Host: "1.2.3.4", Port: 443, UUID: "u", TLS: true, SNI: "a.com"}, true},
+		{singbox.LinkParams{Type: "shadowsocks", Tag: "d", Host: "1.2.3.4", Port: 8388, Password: "sec", Method: "2022-blake3-aes-128-gcm", ServerKey: "AAAAAAAAAAAAAAAAAAAAAA=="}, true},
+		{singbox.LinkParams{Type: "anytls", Tag: "e", Host: "1.2.3.4", Port: 443, Password: "pw", SNI: "a.com"}, true},
+		{singbox.LinkParams{Type: "hysteria2", Tag: "f", Host: "1.2.3.4", Port: 443, Password: "pw", SNI: "a.com"}, false},
+		{singbox.LinkParams{Type: "tuic", Tag: "g", Host: "1.2.3.4", Port: 443, UUID: "u", Password: "pw", SNI: "a.com"}, false},
+		{singbox.LinkParams{Type: "hysteria", Tag: "h", Host: "1.2.3.4", Port: 443, Password: "pw", SNI: "a.com", UpMbps: 50, DownMbps: 100}, false},
+	} {
+		link := noUDPLink(t, c.lp)
+		clash, _ := Clash(ParseLinks([]string{link}), "")
+		got := strings.Contains(clash, "udp: false")
+		if got != c.wantsKey {
+			t.Errorf("%s: clash udp:false = %v, want %v:\n%s", c.lp.Type, got, c.wantsKey, clash)
+		}
+		if strings.Contains(clash, "udp: true") {
+			t.Errorf("%s: blocked node must never claim udp: true:\n%s", c.lp.Type, clash)
+		}
+	}
+}
+
+// TestNoUDPSingboxWhitelist pins which protocols get `"network": "tcp"` in the
+// sing-box output. sing-box rejects unknown fields by refusing the whole
+// config, and its anytls outbound has no network option — emitting it there
+// would take down every subscriber's profile for one anytls node.
+func TestNoUDPSingboxWhitelist(t *testing.T) {
+	cases := []struct {
+		lp          singbox.LinkParams
+		wantNetwork bool
+	}{
+		{singbox.LinkParams{Type: "vless", Tag: "a", Host: "1.2.3.4", Port: 443, UUID: "u", SNI: "a.com", PublicKey: "PBK", ShortID: "ab"}, true},
+		{singbox.LinkParams{Type: "trojan", Tag: "b", Host: "1.2.3.4", Port: 443, Password: "pw", SNI: "a.com"}, true},
+		{singbox.LinkParams{Type: "vmess", Tag: "c", Host: "1.2.3.4", Port: 443, UUID: "u", TLS: true, SNI: "a.com"}, true},
+		{singbox.LinkParams{Type: "shadowsocks", Tag: "d", Host: "1.2.3.4", Port: 8388, Password: "sec", Method: "2022-blake3-aes-128-gcm", ServerKey: "AAAAAAAAAAAAAAAAAAAAAA=="}, true},
+		{singbox.LinkParams{Type: "tuic", Tag: "e", Host: "1.2.3.4", Port: 443, UUID: "u", Password: "pw", SNI: "a.com"}, true},
+		{singbox.LinkParams{Type: "hysteria2", Tag: "f", Host: "1.2.3.4", Port: 443, Password: "pw", SNI: "a.com"}, true},
+		{singbox.LinkParams{Type: "anytls", Tag: "g", Host: "1.2.3.4", Port: 443, Password: "pw", SNI: "a.com"}, false},
+	}
+	for _, c := range cases {
+		link := noUDPLink(t, c.lp)
+		sb, _ := Singbox(ParseLinks([]string{link}), "")
+		got := strings.Contains(sb, `"network": "tcp"`)
+		if got != c.wantNetwork {
+			t.Errorf("%s: network restriction = %v, want %v:\n%s", c.lp.Type, got, c.wantNetwork, sb)
+		}
+	}
+}
+
+// TestNoUDPAbsentMeansUnchanged: links without the marker (every node not on a
+// blocking egress, and all pre-existing links) render exactly as before.
+func TestNoUDPAbsentMeansUnchanged(t *testing.T) {
+	link := singbox.BuildShareLink(singbox.LinkParams{
+		Type: "vless", Tag: "n", Host: "1.2.3.4", Port: 443, UUID: "u",
+		SNI: "a.com", PublicKey: "PBK", ShortID: "ab",
+	})
+	if strings.Contains(link, "qz-udp") {
+		t.Fatalf("marker leaked into a normal link: %s", link)
+	}
+	sb, _ := Singbox(ParseLinks([]string{link}), "")
+	if strings.Contains(sb, `"network"`) {
+		t.Errorf("normal node must not be network-restricted:\n%s", sb)
+	}
+	clash, _ := Clash(ParseLinks([]string{link}), "")
+	if !strings.Contains(clash, "udp: true") {
+		t.Errorf("normal node should keep udp: true:\n%s", clash)
+	}
+}
+
+// TestNoUDPSurge: surge output flips udp-relay for ss and trojan.
+func TestNoUDPSurge(t *testing.T) {
+	blocked := noUDPLink(t, singbox.LinkParams{
+		Type: "trojan", Tag: "t", Host: "1.2.3.4", Port: 443, Password: "pw", SNI: "a.com",
+	})
+	normal := singbox.BuildShareLink(singbox.LinkParams{
+		Type: "trojan", Tag: "t2", Host: "1.2.3.5", Port: 443, Password: "pw", SNI: "a.com",
+	})
+	out := Surge(ParseLinks([]string{blocked, normal}), "")
+	if !strings.Contains(out, "udp-relay=false") {
+		t.Errorf("blocked trojan should carry udp-relay=false:\n%s", out)
+	}
+	if !strings.Contains(out, "udp-relay=true") {
+		t.Errorf("normal trojan should keep udp-relay=true:\n%s", out)
+	}
+}
+
+// TestNoUDPKeepsNodeKeyStable: flipping an egress's udp_mode (or unbinding the
+// egress) toggles the marker on the link; the user's per-node blocklist is
+// keyed by NodeKey and must survive that.
+func TestNoUDPKeepsNodeKeyStable(t *testing.T) {
+	base := singbox.LinkParams{
+		Type: "vless", Tag: "n", Host: "1.2.3.4", Port: 443, UUID: "u",
+		SNI: "a.com", PublicKey: "PBK", ShortID: "ab",
+	}
+	with := noUDPLink(t, base)
+	without := singbox.BuildShareLink(base)
+	if NodeKey(with) != NodeKey(without) {
+		t.Errorf("NodeKey must not change with qz-udp:\n  with:    %s\n  without: %s", with, without)
+	}
+
+	// ss gains a query string only when blocked; the canonical form must drop
+	// it entirely so the key matches the historic no-query link.
+	ssBase := singbox.LinkParams{
+		Type: "shadowsocks", Tag: "s", Host: "1.2.3.4", Port: 8388,
+		Password: "sec", Method: "2022-blake3-aes-128-gcm", ServerKey: "AAAAAAAAAAAAAAAAAAAAAA==",
+	}
+	ssWith := noUDPLink(t, ssBase)
+	ssWithout := singbox.BuildShareLink(ssBase)
+	if NodeKey(ssWith) != NodeKey(ssWithout) {
+		t.Errorf("ss NodeKey must not change with qz-udp:\n  with:    %s\n  without: %s", ssWith, ssWithout)
+	}
+}


### PR DESCRIPTION
## 问题

出口 `udp_mode=block` 时，链路两半在说相反的话：

- **节点侧**：sing-box 收到 UDP 就 reject（`Relay.RejectUDP` → 路由规则）
- **订阅侧**：照样告诉客户端这个节点支持 UDP（Clash `udp: true`、sing-box 不限 `network`、Surge `udp-relay=true`）

客户端于是把 QUIC / STUN 往节点发，节点默默丢弃。**协议层没有任何东西能告诉客户端「别发了」**，每个应用只能各自等超时。

表现为部分站点慢或打不开，而**面板上完全看不出来**：管理员看到「UDP 已阻断」，以为处理干净了。

## 改动

绑定了阻断型出口的入站，其分享链接携带 `qz-udp=block`，三种订阅格式各自落地：

| 格式 | 输出 |
|---|---|
| Clash | `udp: false`（并去掉 `xudp` / `packet-addr`） |
| sing-box | 出站 `"network": "tcp"` |
| Surge | `udp-relay=false` |

客户端在本地就拒绝 UDP，应用立刻走 TCP，不再有等待。

**标记按节点走，不是按订阅走。** 同时持有静态 IP 节点和普通节点的用户，普通节点的 QUIC 完全不受影响——测试里专门钉住了这条。

## 两处白名单（重要）

未知字段会让整份配置加载失败，**一个坏节点毁掉所有订阅者的配置**。所以两个渲染器都只在核心确实有该字段时才发：

- **sing-box `network`**：vless / vmess / trojan / shadowsocks / hysteria / hysteria2 / tuic 都有，**anytls 没有**——逐个查过官方文档
- **mihomo `udp`**：只翻转渲染器本来就发了 `udp` 的协议；hysteria / hysteria2 / tuic 的 proxy 没有该字段，不新增

## NodeKey 稳定性

`qz-udp` 已加入 `volatileParams`。否则管理员改一次 `udp_mode` 或解绑出口，节点指纹就变，**用户手动屏蔽的节点会被静默解除**。ss 链接的 query 也特意不加 SIP002 那个可选的 `/`，同样是为了不改变 canonical 形式。

## 验证

- `go build ./...`、`go vet ./internal/...`、`go test ./...` 全绿
- 新增 13 个用例：渲染链路 5 个（含两处白名单的逐协议断言）+ store 端到端 2 个 + NodeKey 稳定性 + 未标记节点行为不变
- `singboxcheck` harness 补了各协议的 `qz-udp` 样例，有二进制时可实证：

```
QZ_SINGBOX_TEST_BIN=/path/to/sing-box go test ./internal/subconv/ -run Singbox -v
```

## 已知遗留

`mixed`（HTTP/SOCKS5）入站不走分享链接，覆盖不到。这是 SOCKS5 协议本身无法表达「拒绝 UDP」造成的，代码注释里原本就有说明。

## 背景

排查一个实际出口（详见 #15）时发现：该出口 UDP ASSOCIATE 成功、会话保活正常、出口 IP 与 TCP 一致、真实转发 UDP——但**单个 datagram 上限精确卡在 512 字节**（RFC 1035 传统 DNS 报文上限，厂商中继缓冲区是按 DNS 尺寸做的）。而 RFC 9000 §14.1 强制 QUIC 客户端 Initial 填充到 ≥1200 字节，所以经它的 QUIC 握手 100% 发不出去，且是静默黑洞。

阻断 UDP 是对的处置，但阻断之后订阅没有同步宣告——这个 PR 补的就是这一半。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
