### PR TITLE
feat(stats): 管理概览新增用量分析 —— 多选用户 × 任意时间 × 套餐维度

### DIFF
--- a/frontend/src/components/AdminUsageReport.vue
+++ b/frontend/src/components/AdminUsageReport.vue
@@ -1,0 +1,538 @@
+<template>
+  <div class="usage">
+    <!-- 控制条：时间口径 + 用户选择。两者共同决定下面所有数字，所以放在最上面
+         而不是各图表各自带筛选，避免几块数据各说各的口径。 -->
+    <n-card size="small" class="sec">
+      <div class="ctl">
+        <div class="ctl-group">
+          <span class="ctl-label">时间</span>
+          <n-radio-group v-model:value="preset" size="small" @update:value="onPreset">
+            <n-radio-button v-for="p in presets" :key="p.v" :value="p.v">{{ p.l }}</n-radio-button>
+          </n-radio-group>
+          <n-date-picker
+            v-if="preset === 'custom'"
+            v-model:value="customRange"
+            type="daterange"
+            size="small"
+            clearable
+            :is-date-disabled="disableFuture"
+            style="width:250px;"
+            @update:value="load"
+          />
+        </div>
+
+        <div class="ctl-group grow">
+          <span class="ctl-label">用户</span>
+          <n-select
+            v-model:value="selected"
+            multiple
+            filterable
+            clearable
+            size="small"
+            placeholder="全部用户（可搜索选择，最多 100 个）"
+            :options="userOptions"
+            :loading="loadingUsers"
+            :max-tag-count="4"
+            class="user-select"
+            @update:value="load"
+          />
+          <n-button v-if="selected.length" size="small" quaternary @click="clearUsers">清空</n-button>
+        </div>
+      </div>
+
+      <!-- 数据口径说明。这不是装饰：累计模式用的是账户计数器（一直准），
+           区间模式用的是每日汇总表（只从开始记录那天起）。不写清楚，
+           管理员会把「区间为 0」读成「没用流量」。 -->
+      <p class="scope">
+        <template v-if="mode === 'lifetime'">
+          <b>累计口径</b>：账户开通至今的全部流量，含本功能上线前的历史。
+        </template>
+        <template v-else>
+          <b>区间口径</b>：{{ rangeLabel }}。
+          <template v-if="coverage.first">
+            明细数据自 <b>{{ coverage.first }}</b> 起记录<template v-if="hasUnattributed">，更早的流量无法归属到具体套餐，已单列为「{{ UNATTRIBUTED }}」</template>。
+          </template>
+          <template v-else>暂无区间明细数据，需等待首次流量统计。</template>
+        </template>
+      </p>
+    </n-card>
+
+    <!-- KPI -->
+    <div class="kpi-row">
+      <div v-for="k in kpis" :key="k.key" class="kpi">
+        <div class="kpi-label">{{ k.label }}</div>
+        <div class="kpi-value" :style="{ color: k.color }">{{ k.value }}</div>
+        <div class="kpi-sub">{{ k.sub }}</div>
+      </div>
+    </div>
+
+    <n-spin :show="loading">
+      <!-- 趋势：选了用户就按用户分层堆叠，没选就是全站合计 -->
+      <n-card size="small" class="sec">
+        <template #header>
+          <span class="sec-title">流量趋势</span>
+          <span class="sec-note">
+            {{ selected.length ? `${selected.length} 位用户分层对比` : '全站合计' }}
+            <template v-if="mode === 'lifetime'"> · 曲线仅覆盖已记录区间</template>
+          </span>
+        </template>
+        <div v-if="!hasSeries" class="empty">该区间没有流量记录</div>
+        <div v-show="hasSeries" ref="trendEl" class="chart" style="height:300px;" />
+      </n-card>
+
+      <div class="two-col">
+        <n-card size="small" class="sec">
+          <template #header>
+            <span class="sec-title">套餐分布</span>
+            <span class="sec-note">按流量占比</span>
+          </template>
+          <div v-if="!byPackage.length" class="empty">暂无套餐用量</div>
+          <div v-show="byPackage.length" ref="pkgEl" class="chart" style="height:280px;" />
+        </n-card>
+
+        <n-card size="small" class="sec">
+          <template #header>
+            <span class="sec-title">用户排行</span>
+            <span class="sec-note">前 {{ Math.min(byUser.length, 10) }} 名</span>
+          </template>
+          <div v-if="!byUser.length" class="empty">暂无用户用量</div>
+          <div v-show="byUser.length" ref="rankEl" class="chart" style="height:280px;" />
+        </n-card>
+      </div>
+
+      <!-- 明细：用户 × 套餐。这是「能看到用户对应各个套餐的用量」的落点 -->
+      <n-card size="small" class="sec">
+        <template #header>
+          <span class="sec-title">用户 · 套餐明细</span>
+          <span class="sec-note">共 {{ detail.length }} 行</span>
+          <n-button size="tiny" quaternary :disabled="!detail.length" style="margin-left:auto;" @click="exportCSV">
+            导出 CSV
+          </n-button>
+        </template>
+        <div v-if="!detail.length" class="empty">没有可展示的明细</div>
+        <div v-else class="tbl-wrap">
+          <table class="tbl">
+            <thead>
+              <tr>
+                <th class="l">用户</th>
+                <th class="l">套餐</th>
+                <th v-for="c in cols" :key="c.k" class="sortable" :class="{ on: sortKey === c.k }" @click="sortBy(c.k)">
+                  {{ c.l }}<span v-if="sortKey === c.k">{{ sortDesc ? ' ↓' : ' ↑' }}</span>
+                </th>
+                <th class="l">占比</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(d, i) in sortedDetail" :key="i">
+                <td class="l"><span class="u-name">{{ d.username || '—' }}</span></td>
+                <td class="l">
+                  <span class="pkg" :class="{ synthetic: d.package_id <= 0 }">{{ d.package_name }}</span>
+                </td>
+                <td>{{ fmtBytes(d.up) }}</td>
+                <td>{{ fmtBytes(d.down) }}</td>
+                <td><b>{{ fmtBytes(d.up + d.down) }}</b></td>
+                <td class="l">
+                  <div class="ratio">
+                    <div class="ratio-bar"><i :style="{ width: pct(d) + '%' }" /></div>
+                    <span class="ratio-num">{{ pct(d).toFixed(1) }}%</span>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </n-card>
+    </n-spin>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted, nextTick, watch } from 'vue'
+import { NCard, NRadioGroup, NRadioButton, NSelect, NButton, NSpin, NDatePicker, useMessage } from 'naive-ui'
+import * as echarts from 'echarts'
+import { apiGet, apiList } from '@/api'
+import { fmtBytes } from '@/utils/format'
+
+const message = useMessage()
+
+// 与 AdminOverview 同一套暖中性色板，跨页视觉一致。
+const C = { up: '#6f8f76', down: '#5e7a99', gold: '#bf9540', red: '#c2685c', gray: '#9aa0a6' }
+const PALETTE = ['#5e7a99', '#6f8f76', '#bf9540', '#c2685c', '#8d7fa8', '#7f9ea8', '#a89a7f', '#9aa0a6',
+                 '#7b93b3', '#85a58c']
+const UNATTRIBUTED = '未记录套餐（升级前）'
+
+const presets = [
+  { v: 'total', l: '累计' },
+  { v: '7d', l: '7天' },
+  { v: '30d', l: '30天' },
+  { v: '90d', l: '90天' },
+  { v: 'custom', l: '自定义' },
+]
+
+const preset = ref('30d')
+const customRange = ref<[number, number] | null>(null)
+const selected = ref<number[]>([])
+const loading = ref(false)
+const loadingUsers = ref(false)
+
+const mode = ref('window')
+const coverage = ref<{ first: string; last: string }>({ first: '', last: '' })
+const series = ref<any[]>([])
+const totalSeries = ref<any[]>([])
+const byUser = ref<any[]>([])
+const byPackage = ref<any[]>([])
+const candidates = ref<any[]>([])
+
+const userOptions = computed(() =>
+  candidates.value.map(c => ({ label: `${c.username}（${fmtBytes(c.traffic)}）`, value: c.id })))
+
+// 未来日期没有数据，选了只会得到空图 —— 直接禁掉比让人选完再解释更好。
+function disableFuture(ts: number) { return ts > Date.now() }
+
+const rangeLabel = computed(() => {
+  if (preset.value === 'custom' && customRange.value) {
+    return `${toDay(customRange.value[0])} 至 ${toDay(customRange.value[1])}`
+  }
+  const l = presets.find(p => p.v === preset.value)?.l
+  return l ? `最近 ${l}` : ''
+})
+
+const hasUnattributed = computed(() => byPackage.value.some(p => p.package_id < 0))
+const hasSeries = computed(() => totalSeries.value.length > 0)
+
+const sumUp = computed(() => byUser.value.reduce((s, d) => s + (d.up || 0), 0))
+const sumDown = computed(() => byUser.value.reduce((s, d) => s + (d.down || 0), 0))
+const grandTotal = computed(() => sumUp.value + sumDown.value)
+
+const kpis = computed(() => {
+  const days = totalSeries.value.length
+  const avg = days ? grandTotal.value / days : 0
+  const peak = totalSeries.value.reduce(
+    (m: any, d: any) => ((d.up + d.down) > (m.v || 0) ? { v: d.up + d.down, date: d.date } : m), {} as any)
+  return [
+    { key: 'total', label: '总流量', value: fmtBytes(grandTotal.value), color: C.down,
+      sub: `${byUser.value.length} 位用户产生` },
+    { key: 'updown', label: '上行 / 下行', value: `${fmtBytes(sumUp.value)} / ${fmtBytes(sumDown.value)}`,
+      color: C.up, sub: grandTotal.value ? `下行占 ${(sumDown.value / grandTotal.value * 100).toFixed(0)}%` : '—' },
+    { key: 'avg', label: '日均', value: fmtBytes(avg), color: C.gold,
+      sub: days ? `覆盖 ${days} 个有流量的日子` : '暂无每日数据' },
+    { key: 'peak', label: '单日峰值', value: peak.v ? fmtBytes(peak.v) : '—', color: C.red,
+      sub: peak.date || '暂无每日数据' },
+  ]
+})
+
+// ---- 明细表 ----
+const cols = [{ k: 'up', l: '上行' }, { k: 'down', l: '下行' }, { k: 'total', l: '合计' }]
+const sortKey = ref('total')
+const sortDesc = ref(true)
+const detail = computed(() => byPackage.value)
+const maxDetail = computed(() => Math.max(...detail.value.map(d => d.up + d.down), 1))
+
+const sortedDetail = computed(() => {
+  const rows = [...detail.value]
+  const get = (d: any) => sortKey.value === 'total' ? d.up + d.down : d[sortKey.value] || 0
+  rows.sort((a, b) => sortDesc.value ? get(b) - get(a) : get(a) - get(b))
+  return rows
+})
+
+function sortBy(k: string) {
+  if (sortKey.value === k) sortDesc.value = !sortDesc.value
+  else { sortKey.value = k; sortDesc.value = true }
+}
+
+// 占比以「本表最大行」为基准而非总量：几十行时按总量算出来的条全是细线，看不出差异。
+function pct(d: any) { return (d.up + d.down) / maxDetail.value * 100 }
+
+function exportCSV() {
+  const head = ['用户', '套餐', '上行(字节)', '下行(字节)', '合计(字节)']
+  const esc = (s: any) => `"${String(s ?? '').replace(/"/g, '""')}"`
+  const body = sortedDetail.value.map(d =>
+    [d.username, d.package_name, d.up, d.down, d.up + d.down].map(esc).join(','))
+  // BOM：没有它 Excel 会把中文列名读成乱码。
+  const blob = new Blob(['﻿' + [head.map(esc).join(','), ...body].join('\r\n')],
+    { type: 'text/csv;charset=utf-8' })
+  const a = document.createElement('a')
+  a.href = URL.createObjectURL(blob)
+  a.download = `用量_${preset.value}_${toDay(Date.now())}.csv`
+  a.click()
+  URL.revokeObjectURL(a.href)
+  message.success('已导出')
+}
+
+// ---- 图表 ----
+const trendEl = ref<HTMLElement | null>(null)
+const pkgEl = ref<HTMLElement | null>(null)
+const rankEl = ref<HTMLElement | null>(null)
+const charts: Record<string, echarts.ECharts> = {}
+
+const axisStyle = {
+  axisLine: { lineStyle: { color: '#e5e5e5' } },
+  axisTick: { show: false },
+  axisLabel: { color: '#767676', fontSize: 11 },
+}
+const byteAxis = {
+  type: 'value', splitLine: { lineStyle: { color: '#f1f1f1' } }, ...axisStyle,
+  axisLine: { show: false },
+  axisLabel: { color: '#767676', fontSize: 11, formatter: (v: number) => fmtBytes(v) },
+}
+
+function draw(key: string, el: HTMLElement | null, option: any) {
+  if (!el || !el.clientWidth) return // 隐藏容器宽度为 0，此时 init 会画出永久 0 宽画布
+  if (!charts[key]) charts[key] = echarts.init(el)
+  charts[key].setOption(option, true)
+}
+
+// 所有出现过的日期的并集，作为统一 x 轴 —— 各用户的稀疏序列必须对齐到同一根轴上，
+// 否则同一个 x 位置在两条线里代表不同的日子。
+const axisDays = computed(() => {
+  const s = new Set<string>()
+  totalSeries.value.forEach((d: any) => s.add(d.date))
+  series.value.forEach((u: any) => u.days.forEach((d: any) => s.add(d.date)))
+  return [...s].sort()
+})
+
+function trendOption() {
+  const x = axisDays.value
+  const mkStack = (name: string, days: any[], color: string) => {
+    const m = new Map(days.map((d: any) => [d.date, d.up + d.down]))
+    return {
+      name, type: 'line', smooth: 0.35, stack: 'u', showSymbol: false,
+      lineStyle: { width: 1.2, color },
+      areaStyle: {
+        color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+          { offset: 0, color: color + 'cc' }, { offset: 1, color: color + '18' },
+        ]),
+      },
+      data: x.map(d => m.get(d) ?? 0),
+    }
+  }
+
+  let s: any[]
+  if (selected.value.length && series.value.length) {
+    s = series.value.map((u: any, i: number) => mkStack(u.username || `#${u.user_id}`, u.days, PALETTE[i % PALETTE.length]))
+  } else {
+    const up = new Map(totalSeries.value.map((d: any) => [d.date, d.up]))
+    const down = new Map(totalSeries.value.map((d: any) => [d.date, d.down]))
+    s = [
+      { name: '上行', type: 'line', smooth: 0.35, stack: 't', showSymbol: false,
+        lineStyle: { width: 1.5, color: C.up },
+        areaStyle: { color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+          { offset: 0, color: C.up + 'cc' }, { offset: 1, color: C.up + '14' }]) },
+        data: x.map(d => up.get(d) ?? 0) },
+      { name: '下行', type: 'line', smooth: 0.35, stack: 't', showSymbol: false,
+        lineStyle: { width: 1.5, color: C.down },
+        areaStyle: { color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+          { offset: 0, color: C.down + 'cc' }, { offset: 1, color: C.down + '14' }]) },
+        data: x.map(d => down.get(d) ?? 0) },
+    ]
+  }
+
+  return {
+    grid: { left: 8, right: 12, top: 34, bottom: 4, containLabel: true },
+    tooltip: {
+      trigger: 'axis',
+      valueFormatter: (v: number) => fmtBytes(v),
+      // 多用户堆叠时按值降序，最大的贡献者排最前，省得在十条里找。
+      order: 'valueDesc',
+    },
+    legend: { top: 0, icon: 'roundRect', itemWidth: 10, itemHeight: 10,
+      textStyle: { color: '#767676', fontSize: 11 }, type: 'scroll' },
+    xAxis: { type: 'category', boundaryGap: false, data: x.map(d => d.slice(5)), ...axisStyle },
+    yAxis: byteAxis,
+    series: s,
+  }
+}
+
+function pkgOption() {
+  // 同名套餐跨用户合并 —— 环图问的是「哪个套餐吃掉了流量」，不是「谁的哪个套餐」。
+  const agg = new Map<string, number>()
+  byPackage.value.forEach((p: any) => {
+    agg.set(p.package_name, (agg.get(p.package_name) || 0) + p.up + p.down)
+  })
+  const data = [...agg.entries()]
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => b.value - a.value)
+  return {
+    tooltip: { trigger: 'item', valueFormatter: (v: number) => fmtBytes(v) },
+    legend: { type: 'scroll', orient: 'vertical', right: 0, top: 'center',
+      textStyle: { color: '#767676', fontSize: 11 }, itemWidth: 10, itemHeight: 10 },
+    series: [{
+      type: 'pie', radius: ['52%', '76%'], center: ['36%', '50%'],
+      avoidLabelOverlap: true, itemStyle: { borderColor: '#fff', borderWidth: 2 },
+      label: { show: false }, labelLine: { show: false },
+      data: data.map((d, i) => ({ ...d, itemStyle: { color: PALETTE[i % PALETTE.length] } })),
+    }],
+  }
+}
+
+function rankOption() {
+  const rows = [...byUser.value].sort((a, b) => (b.up + b.down) - (a.up + a.down)).slice(0, 10).reverse()
+  return {
+    grid: { left: 8, right: 24, top: 12, bottom: 4, containLabel: true },
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' }, valueFormatter: (v: number) => fmtBytes(v) },
+    xAxis: byteAxis,
+    yAxis: { type: 'category', data: rows.map(r => r.username || `#${r.user_id}`), ...axisStyle },
+    series: [{
+      type: 'bar', barMaxWidth: 16, itemStyle: { borderRadius: [0, 3, 3, 0], color: C.down },
+      data: rows.map(r => r.up + r.down),
+      label: { show: true, position: 'right', color: '#767676', fontSize: 11,
+        formatter: (p: any) => fmtBytes(p.value) },
+    }],
+  }
+}
+
+function renderAll() {
+  draw('trend', trendEl.value, trendOption())
+  draw('pkg', pkgEl.value, pkgOption())
+  draw('rank', rankEl.value, rankOption())
+}
+
+let resizeTimer: any
+function onResize() {
+  clearTimeout(resizeTimer)
+  resizeTimer = setTimeout(() => {
+    Object.values(charts).forEach(c => c.resize())
+    renderAll() // 之前因宽度为 0 跳过的图，在这里补画
+  }, 120)
+}
+
+// ---- 加载 ----
+function toDay(ts: number) {
+  const d = new Date(ts)
+  const p = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`
+}
+
+function onPreset(v: string) {
+  // 切到自定义时给一个合理的默认区间，省得面对空 picker 还要自己想选哪天。
+  if (v === 'custom' && !customRange.value) {
+    customRange.value = [Date.now() - 29 * 86400_000, Date.now()]
+  }
+  load()
+}
+
+function clearUsers() {
+  selected.value = []
+  load()
+}
+
+function buildQuery() {
+  const q = new URLSearchParams()
+  q.set('preset', preset.value)
+  if (preset.value === 'custom' && customRange.value) {
+    q.set('from', toDay(customRange.value[0]))
+    q.set('to', toDay(customRange.value[1]))
+  }
+  if (selected.value.length) q.set('users', selected.value.join(','))
+  return q.toString()
+}
+
+async function load() {
+  // 自定义但还没选日期：不要发请求，否则后端会回落到 30 天，
+  // 界面显示「自定义」而数据是 30 天的，口径对不上。
+  if (preset.value === 'custom' && !customRange.value) return
+  loading.value = true
+  try {
+    const d = await apiGet<any>(`/api/admin/stats/usage?${buildQuery()}`)
+    mode.value = d?.mode || 'window'
+    coverage.value = d?.coverage || { first: '', last: '' }
+    series.value = d?.series || []
+    totalSeries.value = d?.total_series || []
+    byUser.value = d?.by_user || []
+    byPackage.value = d?.by_package || []
+  } catch (e: any) {
+    message.error(e?.message || '读取用量统计失败')
+  } finally {
+    loading.value = false
+  }
+  await nextTick()
+  renderAll()
+}
+
+async function loadUsers() {
+  loadingUsers.value = true
+  try {
+    candidates.value = await apiList('/api/admin/stats/usage/users?limit=300')
+  } catch {} finally {
+    loadingUsers.value = false
+  }
+}
+
+// 父组件切到本标签页时容器才有宽度，此时补画。
+defineExpose({ refresh: () => { renderAll() } })
+
+watch(() => [byUser.value, byPackage.value], () => nextTick(renderAll), { deep: false })
+
+onMounted(async () => {
+  await Promise.all([loadUsers(), load()])
+  window.addEventListener('resize', onResize)
+})
+onUnmounted(() => {
+  window.removeEventListener('resize', onResize)
+  clearTimeout(resizeTimer)
+  Object.values(charts).forEach(c => c.dispose())
+})
+</script>
+
+<style scoped>
+.sec { margin-bottom: 14px; border-radius: var(--r-sm); }
+.sec-title { font-weight: 650; font-size: 13.5px; }
+.sec-note { color: var(--text-3); font-size: 11.5px; margin-left: 8px; }
+.chart { width: 100%; }
+.empty { text-align: center; color: var(--text-3); padding: 40px 0; font-size: 12.5px; }
+
+/* 控制条 */
+.ctl { display: flex; flex-wrap: wrap; gap: 12px 20px; align-items: center; }
+.ctl-group { display: flex; align-items: center; gap: 8px; }
+.ctl-group.grow { flex: 1; min-width: 280px; }
+.ctl-label { font-size: 12px; color: var(--text-2); font-weight: 550; white-space: nowrap; }
+.user-select { flex: 1; min-width: 220px; }
+.scope {
+  margin: 10px 0 0; padding-top: 10px; border-top: 1px solid var(--border);
+  font-size: 11.5px; color: var(--text-3); line-height: 1.6;
+}
+.scope b { color: var(--text-2); font-weight: 650; }
+
+/* KPI */
+.kpi-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 12px; margin-bottom: 14px; }
+.kpi {
+  background: var(--card); border: 1px solid var(--border); border-radius: var(--r-sm);
+  padding: 13px 15px; transition: box-shadow .15s, border-color .15s;
+}
+.kpi:hover { box-shadow: var(--shadow); border-color: #d5d5d5; }
+.kpi-label { font-size: 12px; color: var(--text-2); font-weight: 550; }
+.kpi-value { font-size: 21px; font-weight: 720; letter-spacing: -0.02em; margin-top: 5px; line-height: 1.2; }
+.kpi-sub { font-size: 11px; color: var(--text-3); margin-top: 3px; }
+
+/* minmax(0, 1fr), not 1fr: a bare `1fr` is minmax(auto, 1fr), and `auto` floors
+   the track at the item's min-content width. An echarts canvas keeps its last
+   pixel width until resize() is called, so on a narrowing viewport the stale
+   canvas holds the track open, resize() then measures that same held-open
+   container, and the column never shrinks — the chart stays desktop-wide inside
+   a phone-width card. Verified at 375px: without this the cards render 457px in
+   a 351px container. */
+.two-col { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 14px; }
+@media (max-width: 900px) { .two-col { grid-template-columns: minmax(0, 1fr); } }
+/* Same reasoning one level down: the chart box must be allowed to shrink rather
+   than be sized by the canvas it contains. */
+.chart { min-width: 0; }
+
+/* 表格 */
+.tbl-wrap { overflow-x: auto; }
+.tbl { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.tbl th, .tbl td { padding: 8px 10px; text-align: right; white-space: nowrap; }
+.tbl th.l, .tbl td.l { text-align: left; }
+.tbl thead th { color: var(--text-3); font-weight: 600; font-size: 11.5px; border-bottom: 1px solid var(--border); }
+.tbl tbody tr { border-bottom: 1px solid var(--border-soft, #f2f2f2); }
+.tbl tbody tr:hover { background: var(--bg-soft); }
+.tbl th.sortable { cursor: pointer; user-select: none; }
+.tbl th.sortable:hover, .tbl th.on { color: var(--text-1); }
+.u-name { font-weight: 600; }
+.pkg { color: var(--text-2); }
+.pkg.synthetic { color: var(--text-3); font-style: italic; }
+
+.ratio { display: flex; align-items: center; gap: 8px; min-width: 120px; }
+.ratio-bar { flex: 1; height: 5px; background: var(--bg-soft); border-radius: 3px; overflow: hidden; }
+.ratio-bar i { display: block; height: 100%; background: #5e7a99; border-radius: 3px; }
+.ratio-num { color: var(--text-3); font-size: 11px; min-width: 38px; text-align: right; }
+</style>

--- a/frontend/src/views/AdminOverview.vue
+++ b/frontend/src/views/AdminOverview.vue
@@ -133,6 +133,13 @@
         </n-card>
       </n-tab-pane>
 
+      <!-- ========== 用量分析 ========== -->
+      <!-- 自带时间口径（含「累计」与自定义区间），所以刻意不受页头 range 影响：
+           页头那个是「近 N 天」的运营视角，这里要能回答任意区间与全生命周期。 -->
+      <n-tab-pane name="usage" tab="用量分析" display-directive="show:lazy">
+        <AdminUsageReport ref="usageReport" />
+      </n-tab-pane>
+
       <!-- ========== 用户分析 ========== -->
       <n-tab-pane name="user" tab="用户分析">
         <n-card size="small" class="sec">
@@ -230,8 +237,10 @@ import { NCard, NTabs, NTabPane, NRadioGroup, NRadioButton, NInput, NSelect, NCh
 import * as echarts from 'echarts'
 import { apiGet, apiList } from '@/api'
 import { fmtBytes, fmtTotal, fmtDate, timeAgo } from '@/utils/format'
+import AdminUsageReport from '@/components/AdminUsageReport.vue'
 
 const message = useMessage()
+const usageReport = ref<any>(null)
 
 // 图表配色沿用全站的暖中性色板（global.css 的 --info/--warn 等），不引入高饱和色。
 const C = { up: '#6f8f76', down: '#5e7a99', gold: '#bf9540', red: '#c2685c', gray: '#9aa0a6' }
@@ -437,7 +446,9 @@ function renderAll() {
 }
 
 // 切标签页时被隐藏的图表宽度为 0，回到该页要补画一次。
-watch(tab, () => nextTick(() => { renderAll(); redrawUserChart() }))
+// 标签页在隐藏时容器宽度为 0，echarts 会画出一个永久 0 宽的画布，所以每次切页
+// 都要让当前页重画一次 —— 用量分析在自己的组件里，通过 ref 转达。
+watch(tab, () => nextTick(() => { renderAll(); redrawUserChart(); usageReport.value?.refresh?.() }))
 
 function onResize() {
   Object.values(charts).forEach(c => c.resize())

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -350,6 +350,9 @@ func (a *API) Router() http.Handler {
 		ar.Get("/api/admin/stats/packages", a.handleAdminPackageStats)
 		ar.Get("/api/admin/stats/users", a.handleAdminUserStats)
 		ar.Get("/api/admin/stats/user/{id}/traffic", a.handleAdminUserTraffic)
+		// 用量分析：多选用户 × 任意时间范围 × 套餐维度
+		ar.Get("/api/admin/stats/usage", a.handleAdminUsage)
+		ar.Get("/api/admin/stats/usage/users", a.handleAdminUsageUsers)
 
 		ar.Get("/api/admin/reg-codes", a.handleAdminListRegCodes)
 		ar.Post("/api/admin/reg-codes/generate", a.handleAdminGenerateRegCodes)

--- a/internal/api/usage.go
+++ b/internal/api/usage.go
@@ -1,0 +1,248 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"qingzhou/internal/store"
+)
+
+// The usage report: per-user and per-package traffic over a chosen window.
+//
+// Two modes, and the response always says which one produced the numbers:
+//
+//	lifetime — running counters, accurate for the whole life of the account.
+//	window   — the traffic_daily rollup, accurate only from the day it started
+//	           recording (coverage.first). An account older than that has real
+//	           traffic the rollup never saw, so presenting a windowed number as
+//	           a lifetime one would understate it without saying so.
+//
+// The client shows coverage.first next to any windowed figure. This is the
+// whole reason the modes are not merged: an admin reconciling a bill needs to
+// know whether a number is "everything" or "everything we have".
+
+const (
+	usageModeLifetime = "lifetime"
+	usageModeWindow   = "window"
+)
+
+// maxUsageUsers caps how many users one report may select. Well past any real
+// comparison (the chart is unreadable long before this) and low enough that the
+// IN list stays inside SQLite's parameter limit with room to spare.
+const maxUsageUsers = 100
+
+// parseUserIDs reads the repeated/comma-joined `users` param. An empty result
+// means "every user", which is the report's default view.
+func parseUserIDs(r *http.Request) []int64 {
+	seen := map[int64]bool{}
+	var out []int64
+	for _, raw := range r.URL.Query()["users"] {
+		for _, part := range strings.Split(raw, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			id, err := strconv.ParseInt(part, 10, 64)
+			if err != nil || id <= 0 || seen[id] {
+				continue
+			}
+			seen[id] = true
+			out = append(out, id)
+			if len(out) >= maxUsageUsers {
+				return out
+			}
+		}
+	}
+	return out
+}
+
+// validDay accepts only a YYYY-MM-DD calendar date. Anything else is dropped
+// rather than passed through: the value reaches a string comparison against
+// traffic_daily.day, and a half-parsed date silently widens the window instead
+// of erroring.
+func validDay(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if _, err := time.Parse("2006-01-02", s); err != nil {
+		return ""
+	}
+	return s
+}
+
+// usageWindowFromQuery resolves preset/from/to into a mode and a window.
+//
+//	preset=total          -> lifetime
+//	preset=30d | 7d | 90d -> trailing window
+//	preset=custom         -> from/to (either side may be open)
+//
+// An unparseable or reversed custom range falls back to the 30-day preset
+// rather than querying an empty window: a report that silently shows zero for
+// everyone reads as "nobody used anything", which is a wrong answer, not a
+// missing one.
+func usageWindowFromQuery(r *http.Request) (mode string, w store.UsageWindow, preset string) {
+	q := r.URL.Query()
+	preset = q.Get("preset")
+	switch preset {
+	case "total":
+		return usageModeLifetime, store.UsageWindow{}, "total"
+	case "custom":
+		from, to := validDay(q.Get("from")), validDay(q.Get("to"))
+		if from != "" && to != "" && from > to {
+			from, to = to, from // an inverted range is a slip, not a request for nothing
+		}
+		if from == "" && to == "" {
+			break // nothing usable — fall through to the default preset
+		}
+		return usageModeWindow, store.UsageWindow{From: from, To: to}, "custom"
+	case "7d", "14d", "90d":
+		d := rangeDays(preset)
+		return usageModeWindow, store.UsageWindow{From: store.DaysAgo(d - 1)}, preset
+	}
+	return usageModeWindow, store.UsageWindow{From: store.DaysAgo(29)}, "30d"
+}
+
+// GET /api/admin/stats/usage?preset=total|7d|14d|30d|90d|custom&from=&to=&users=1,2
+//
+// Returns everything the report renders in one round trip: the per-day series
+// (per user and combined), per-user totals, per-package totals, and the rollup's
+// coverage so the client can caveat the window.
+func (a *API) handleAdminUsage(w http.ResponseWriter, r *http.Request) {
+	userIDs := parseUserIDs(r)
+	mode, win, preset := usageWindowFromQuery(r)
+
+	first, last, err := a.st.TrafficDailyCoverage()
+	if err != nil {
+		fail(w, http.StatusInternalServerError, "读取用量统计失败")
+		return
+	}
+
+	resp := J{
+		"mode":     mode,
+		"preset":   preset,
+		"from":     win.From,
+		"to":       win.To,
+		"users":    userIDs,
+		"coverage": J{"first": first, "last": last},
+	}
+
+	if mode == usageModeLifetime {
+		byUser, err := a.st.UsageLifetimeByUser(userIDs)
+		if err != nil {
+			fail(w, http.StatusInternalServerError, "读取用量统计失败")
+			return
+		}
+		byPkg, err := a.st.UsageByPackageLifetime(userIDs)
+		if err != nil {
+			fail(w, http.StatusInternalServerError, "读取套餐用量失败")
+			return
+		}
+		// The daily curve has no lifetime equivalent — the counters are scalars.
+		// Send the rollup's full extent so the chart still has something true to
+		// draw, flagged by series_scope so the client can label it.
+		series, err := a.st.UsageDailyByUser(userIDs, store.UsageWindow{})
+		if err != nil {
+			fail(w, http.StatusInternalServerError, "读取用量曲线失败")
+			return
+		}
+		total, err := a.st.UsageDailyTotal(userIDs, store.UsageWindow{})
+		if err != nil {
+			fail(w, http.StatusInternalServerError, "读取用量曲线失败")
+			return
+		}
+		resp["by_user"] = nonNilTotals(trimZeroTotals(byUser))
+		resp["by_package"] = nonNilTotals(byPkg)
+		resp["series"] = nonNilSeries(series)
+		resp["total_series"] = nonNilDays(total)
+		resp["series_scope"] = "recorded" // curve covers only what the rollup holds
+		ok(w, resp)
+		return
+	}
+
+	byUser, err := a.st.UsageWindowedByUser(userIDs, win)
+	if err != nil {
+		fail(w, http.StatusInternalServerError, "读取用量统计失败")
+		return
+	}
+	byPkg, err := a.st.UsageByPackageWindowed(userIDs, win)
+	if err != nil {
+		fail(w, http.StatusInternalServerError, "读取套餐用量失败")
+		return
+	}
+	series, err := a.st.UsageDailyByUser(userIDs, win)
+	if err != nil {
+		fail(w, http.StatusInternalServerError, "读取用量曲线失败")
+		return
+	}
+	total, err := a.st.UsageDailyTotal(userIDs, win)
+	if err != nil {
+		fail(w, http.StatusInternalServerError, "读取用量曲线失败")
+		return
+	}
+	resp["by_user"] = nonNilTotals(byUser)
+	resp["by_package"] = nonNilTotals(byPkg)
+	resp["series"] = nonNilSeries(series)
+	resp["total_series"] = nonNilDays(total)
+	resp["series_scope"] = "window"
+	ok(w, resp)
+}
+
+// GET /api/admin/stats/usage/users?q=&limit= — the report's user picker.
+func (a *API) handleAdminUsageUsers(w http.ResponseWriter, r *http.Request) {
+	rows, err := a.st.UsageUserCandidates(r.URL.Query().Get("q"), int(atoi(r.URL.Query().Get("limit"))))
+	if err != nil {
+		fail(w, http.StatusInternalServerError, "读取用户列表失败")
+		return
+	}
+	if rows == nil {
+		rows = []store.UsageCandidate{}
+	}
+	ok(w, rows)
+}
+
+// trimZeroTotals drops users with no traffic at all. Only applied to the
+// lifetime per-user list, which otherwise returns every account on the panel
+// including the ones that never connected — hundreds of zero rows an admin has
+// to scroll past to reach the data. The windowed query already excludes them by
+// construction (no rows, no traffic).
+func trimZeroTotals(in []store.UsageTotal) []store.UsageTotal {
+	out := in[:0]
+	for _, t := range in {
+		if t.Up+t.Down > 0 {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// The three nonNil* helpers keep the JSON shape stable: encoding/json renders a
+// nil slice as null, and the client's chart code would then have to guard every
+// field it iterates.
+func nonNilTotals(in []store.UsageTotal) []store.UsageTotal {
+	if in == nil {
+		return []store.UsageTotal{}
+	}
+	return in
+}
+
+func nonNilSeries(in []store.UsageSeries) []store.UsageSeries {
+	if in == nil {
+		return []store.UsageSeries{}
+	}
+	for i := range in {
+		if in[i].Days == nil {
+			in[i].Days = []store.UsageDay{}
+		}
+	}
+	return in
+}
+
+func nonNilDays(in []store.UsageDay) []store.UsageDay {
+	if in == nil {
+		return []store.UsageDay{}
+	}
+	return in
+}

--- a/internal/api/usage_test.go
+++ b/internal/api/usage_test.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"qingzhou/internal/store"
+)
+
+// parseUserIDs is the report's only untrusted input path. It must accept the
+// shapes a client actually sends, and drop everything else rather than letting
+// it reach the query builder.
+func TestParseUserIDs(t *testing.T) {
+	for _, c := range []struct {
+		query string
+		want  []int64
+	}{
+		{"", nil},
+		{"?users=3", []int64{3}},
+		{"?users=3,1,2", []int64{3, 1, 2}},        // order preserved
+		{"?users=3&users=4", []int64{3, 4}},       // repeated param
+		{"?users=3,3,3", []int64{3}},              // de-duplicated
+		{"?users=%205%20,%206%20", []int64{5, 6}}, // whitespace tolerated
+		{"?users=0,-1,abc,1", []int64{1}},         // junk and non-positives dropped
+		{"?users=,,,", nil},                       // empty segments
+		{"?users=1;DROP+TABLE+users", nil},        // not a number, not passed on
+		{"?users=99999999999999999999", nil},      // overflows int64
+	} {
+		r := httptest.NewRequest("GET", "/api/admin/stats/usage"+c.query, nil)
+		got := parseUserIDs(r)
+		if len(got) != len(c.want) {
+			t.Errorf("%q -> %v, want %v", c.query, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("%q -> %v, want %v", c.query, got, c.want)
+				break
+			}
+		}
+	}
+}
+
+// A client must not be able to blow the IN list (and SQLite's parameter limit)
+// by sending thousands of ids.
+func TestParseUserIDs_Capped(t *testing.T) {
+	q := "?users="
+	for i := 1; i <= maxUsageUsers+50; i++ {
+		if i > 1 {
+			q += ","
+		}
+		q += strconv.Itoa(i)
+	}
+	r := httptest.NewRequest("GET", "/api/admin/stats/usage"+q, nil)
+	if got := parseUserIDs(r); len(got) != maxUsageUsers {
+		t.Errorf("selected %d users, want the cap %d", len(got), maxUsageUsers)
+	}
+}
+
+// validDay is what stands between a query param and a string comparison against
+// traffic_daily.day. A partially-valid date must be rejected outright, not
+// silently widen the window.
+func TestValidDay(t *testing.T) {
+	for _, c := range []struct{ in, want string }{
+		{"2026-08-12", "2026-08-12"},
+		{"  2026-08-12  ", "2026-08-12"},
+		{"2026-8-12", ""},   // not zero-padded
+		{"2026-13-01", ""},  // month out of range
+		{"2026-02-30", ""},  // day out of range for the month
+		{"20260812", ""},    // wrong format
+		{"yesterday", ""},   // not a date
+		{"2026-08-12'", ""}, // quote smuggling
+		{"", ""},
+	} {
+		if got := validDay(c.in); got != c.want {
+			t.Errorf("validDay(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// The preset decides which of the two data sources answers, so a wrong mode is
+// a wrong number, not a cosmetic issue.
+func TestUsageWindowFromQuery(t *testing.T) {
+	for _, c := range []struct {
+		query      string
+		wantMode   string
+		wantPreset string
+		wantFromNZ bool // From should be non-empty
+		wantTo     string
+	}{
+		{"", usageModeWindow, "30d", true, ""},
+		{"?preset=total", usageModeLifetime, "total", false, ""},
+		{"?preset=7d", usageModeWindow, "7d", true, ""},
+		{"?preset=90d", usageModeWindow, "90d", true, ""},
+		{"?preset=bogus", usageModeWindow, "30d", true, ""},
+		{"?preset=custom&from=2026-01-01&to=2026-02-01", usageModeWindow, "custom", true, "2026-02-01"},
+		// Open-ended custom ranges are legitimate: "everything since launch day".
+		{"?preset=custom&from=2026-01-01", usageModeWindow, "custom", true, ""},
+		// Neither side usable — fall back to the default rather than query nothing.
+		{"?preset=custom&from=nonsense", usageModeWindow, "30d", true, ""},
+	} {
+		r := httptest.NewRequest("GET", "/api/admin/stats/usage"+c.query, nil)
+		mode, win, preset := usageWindowFromQuery(r)
+		if mode != c.wantMode || preset != c.wantPreset {
+			t.Errorf("%q -> mode=%q preset=%q, want %q/%q", c.query, mode, preset, c.wantMode, c.wantPreset)
+		}
+		if (win.From != "") != c.wantFromNZ {
+			t.Errorf("%q -> From=%q, wantNonEmpty=%v", c.query, win.From, c.wantFromNZ)
+		}
+		if win.To != c.wantTo {
+			t.Errorf("%q -> To=%q, want %q", c.query, win.To, c.wantTo)
+		}
+	}
+}
+
+// An inverted custom range is a slip (the admin picked the dates backwards);
+// swapping is what they meant, and returning nothing is not.
+func TestUsageWindowFromQuery_InvertedRangeSwapped(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/admin/stats/usage?preset=custom&from=2026-03-01&to=2026-01-01", nil)
+	_, win, preset := usageWindowFromQuery(r)
+	if preset != "custom" {
+		t.Fatalf("preset = %q, want custom", preset)
+	}
+	if win.From != "2026-01-01" || win.To != "2026-03-01" {
+		t.Errorf("range = %q..%q, want 2026-01-01..2026-03-01", win.From, win.To)
+	}
+}
+
+// The JSON shape must not contain nulls where the client iterates.
+func TestUsageNonNilHelpers(t *testing.T) {
+	if got := nonNilTotals(nil); got == nil || len(got) != 0 {
+		t.Errorf("nonNilTotals(nil) = %v, want empty slice", got)
+	}
+	if got := nonNilDays(nil); got == nil || len(got) != 0 {
+		t.Errorf("nonNilDays(nil) = %v, want empty slice", got)
+	}
+	s := nonNilSeries([]store.UsageSeries{{UserID: 1}})
+	if s[0].Days == nil {
+		t.Error("nonNilSeries left Days nil")
+	}
+	if got := nonNilSeries(nil); got == nil || len(got) != 0 {
+		t.Errorf("nonNilSeries(nil) = %v, want empty slice", got)
+	}
+}
+
+// trimZeroTotals exists so the lifetime view isn't hundreds of never-connected
+// accounts; it must keep every row that has any traffic.
+func TestTrimZeroTotals(t *testing.T) {
+	in := []store.UsageTotal{
+		{UserID: 1, Up: 0, Down: 0},
+		{UserID: 2, Up: 1, Down: 0},
+		{UserID: 3, Up: 0, Down: 0},
+		{UserID: 4, Up: 0, Down: 5},
+	}
+	got := trimZeroTotals(in)
+	if len(got) != 2 || got[0].UserID != 2 || got[1].UserID != 4 {
+		t.Errorf("trimZeroTotals = %+v, want users 2 and 4", got)
+	}
+}

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -382,6 +382,38 @@ CREATE TABLE IF NOT EXISTS traffic_samples (
 CREATE INDEX IF NOT EXISTS idx_traffic_samples_user_ts ON traffic_samples(user_id, ts);
 CREATE INDEX IF NOT EXISTS idx_traffic_samples_ts ON traffic_samples(ts);
 
+-- Per-day, per-bucket traffic rollup. Exists because traffic_samples answers
+-- neither question the usage report asks: it carries no bucket, so "which
+-- package did this traffic belong to" is unanswerable, and it is pruned to 35
+-- days, so any longer range comes back empty.
+--
+-- Kept forever, unlike the samples. One row per user per bucket per active day
+-- is tiny (1000 users × 2 buckets × 365 days ≈ 730k rows, tens of MB) and
+-- append-mostly, so there is no bloat argument for dropping history that an
+-- admin reconciling a year-old order would want.
+--
+-- day is the LOCAL calendar date (YYYY-MM-DD), matching what the existing
+-- strftime(...,'localtime') daily queries produce, so both views agree on where
+-- a day starts.
+--
+-- package_id is denormalised rather than joined through bucket_id: buckets are
+-- deleted by mergeDuplicatePlanBuckets, and history whose grouping key vanishes
+-- when an unrelated maintenance job runs is not history. 0 = the shared pool,
+-- -1 = traffic recorded before this table existed (see backfillTrafficDaily) —
+-- real bytes, but no attributable package, and the UI says so rather than
+-- silently folding them into a package that did not earn them.
+CREATE TABLE IF NOT EXISTS traffic_daily (
+  day        TEXT    NOT NULL,
+  user_id    INTEGER NOT NULL,
+  bucket_id  INTEGER NOT NULL DEFAULT 0,
+  package_id INTEGER NOT NULL DEFAULT 0,
+  up         INTEGER NOT NULL DEFAULT 0,
+  down       INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (day, user_id, bucket_id)
+);
+CREATE INDEX IF NOT EXISTS idx_traffic_daily_user_day ON traffic_daily(user_id, day);
+CREATE INDEX IF NOT EXISTS idx_traffic_daily_day ON traffic_daily(day);
+
 CREATE TABLE IF NOT EXISTS servers (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   name            TEXT    NOT NULL,
@@ -646,9 +678,38 @@ func (s *Store) Migrate() error {
 	if err := s.backfillFreeBuckets(); err != nil {
 		return err
 	}
+	// Seed traffic_daily from the samples still on disk (idempotent).
+	if err := s.backfillTrafficDaily(); err != nil {
+		return err
+	}
 	// Extract inline-PEM sb_tls (mode=tls) profiles into managed certificates
 	// rows and repoint them via cert_id (idempotent).
 	return s.backfillCerts()
+}
+
+// backfillTrafficDaily seeds the rollup from the traffic_samples still on disk
+// (up to 35 days) so the usage report is not blank on the day it ships.
+//
+// Those samples predate per-bucket recording, so the bytes are real but their
+// package is not knowable — they land under package_id -1, which the report
+// labels as unattributed instead of assigning it to a package that may not have
+// carried it.
+//
+// Idempotent by construction, and safe to run against a DB that has already
+// been recording properly: it only writes days that have NO row at all for that
+// user, so a day already attributed per bucket is never touched, and re-running
+// cannot double-count.
+func (s *Store) backfillTrafficDaily() error {
+	_, err := s.db.Exec(`
+		INSERT INTO traffic_daily (day, user_id, bucket_id, package_id, up, down)
+		SELECT strftime('%Y-%m-%d', ts, 'unixepoch', 'localtime') AS d,
+		       user_id, 0, -1, COALESCE(SUM(up),0), COALESCE(SUM(down),0)
+		  FROM traffic_samples
+		 GROUP BY d, user_id
+		HAVING NOT EXISTS (
+		         SELECT 1 FROM traffic_daily t
+		          WHERE t.day = d AND t.user_id = traffic_samples.user_id)`)
+	return err
 }
 
 // backfillFreeBuckets creates the free-group bucket for users provisioned before

--- a/internal/store/usage.go
+++ b/internal/store/usage.go
@@ -1,0 +1,377 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Usage reporting: per-user and per-package traffic over an arbitrary window.
+//
+// Two sources, deliberately, because they answer different questions and only
+// one of them can answer both honestly:
+//
+//   - LIFETIME totals come from the running counters (users.used_*,
+//     user_plans.used_*). They have been maintained since the account existed,
+//     so "总计" is accurate all the way back — including for traffic that
+//     predates this report.
+//   - WINDOWED totals come from traffic_daily, which only starts when the
+//     rollup ships. Asking the lifetime counters for "last 30 days" is not
+//     possible (they are scalars), and asking traffic_daily for "all time"
+//     would silently under-report every account older than the rollup.
+//
+// Callers pick by whether the window is open-ended; the report labels which one
+// it used rather than presenting a windowed number as if it were lifetime.
+
+// UsageWindow is a closed [From, To] range of LOCAL calendar dates, matching how
+// traffic_daily.day is written. Empty From/To means unbounded on that side.
+type UsageWindow struct {
+	From string // YYYY-MM-DD inclusive; "" = from the first recorded day
+	To   string // YYYY-MM-DD inclusive; "" = through the last recorded day
+}
+
+// UsageTotal is one subject's traffic. Subject is a user for the per-user
+// breakdown and a (user, package) pair for the per-package one.
+type UsageTotal struct {
+	UserID      int64  `json:"user_id"`
+	Username    string `json:"username"`
+	PackageID   int64  `json:"package_id"`   // 0 = shared pool, -1 = unattributed
+	PackageName string `json:"package_name"` // resolved for display
+	Up          int64  `json:"up"`
+	Down        int64  `json:"down"`
+}
+
+// UsageDay is one calendar day of one series.
+type UsageDay struct {
+	Date string `json:"date"`
+	Up   int64  `json:"up"`
+	Down int64  `json:"down"`
+}
+
+// UsageSeries is one user's daily curve over the window.
+type UsageSeries struct {
+	UserID   int64      `json:"user_id"`
+	Username string     `json:"username"`
+	Days     []UsageDay `json:"days"`
+}
+
+// poolPackageName / unattributedPackageName label the two synthetic package ids
+// in traffic_daily. They are not rows in `packages`, so no join can name them.
+const (
+	poolPackageName         = "流量包（公共池）"
+	unattributedPackageName = "未记录套餐（升级前）"
+)
+
+// PackageIDUnattributed marks traffic recorded before per-bucket rollup existed.
+const PackageIDUnattributed = -1
+
+// inClause renders "(?,?,?)" plus the args for an IN list. Returns ok=false for
+// an empty list so callers can choose between "no filter" and "match nothing"
+// explicitly — SQLite has no valid syntax for `IN ()`, and building one by
+// string-joining ids is how an id from a query param becomes injection.
+func inClause(ids []int64) (string, []any, bool) {
+	if len(ids) == 0 {
+		return "", nil, false
+	}
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	return "(" + strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",") + ")", args, true
+}
+
+// where builds the shared user/day filter. userIDs empty = every user.
+func usageWhere(userIDs []int64, w UsageWindow, userCol string) (string, []any) {
+	var sb strings.Builder
+	var args []any
+	if clause, ids, ok := inClause(userIDs); ok {
+		sb.WriteString(" AND " + userCol + " IN " + clause)
+		args = append(args, ids...)
+	}
+	if w.From != "" {
+		sb.WriteString(" AND day >= ?")
+		args = append(args, w.From)
+	}
+	if w.To != "" {
+		sb.WriteString(" AND day <= ?")
+		args = append(args, w.To)
+	}
+	return sb.String(), args
+}
+
+// UsageDailyByUser returns each selected user's daily curve inside the window,
+// sparse (only days with traffic). Callers fill gaps for plotting.
+func (s *Store) UsageDailyByUser(userIDs []int64, w UsageWindow) ([]UsageSeries, error) {
+	cond, args := usageWhere(userIDs, w, "t.user_id")
+	rows, err := s.db.Query(`
+		SELECT t.user_id, COALESCE(u.username,''), t.day,
+		       COALESCE(SUM(t.up),0), COALESCE(SUM(t.down),0)
+		  FROM traffic_daily t
+		  LEFT JOIN users u ON u.id = t.user_id
+		 WHERE 1=1`+cond+`
+		 GROUP BY t.user_id, t.day
+		 ORDER BY t.user_id, t.day`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []UsageSeries
+	byUser := map[int64]int{} // user id -> index in out, preserving query order
+	for rows.Next() {
+		var uid int64
+		var name string
+		var d UsageDay
+		if err := rows.Scan(&uid, &name, &d.Date, &d.Up, &d.Down); err != nil {
+			return nil, err
+		}
+		idx, ok := byUser[uid]
+		if !ok {
+			out = append(out, UsageSeries{UserID: uid, Username: name})
+			idx = len(out) - 1
+			byUser[uid] = idx
+		}
+		out[idx].Days = append(out[idx].Days, d)
+	}
+	return out, rows.Err()
+}
+
+// UsageDailyTotal returns the combined daily curve across the selected users —
+// the stacked chart's total line. Computed in SQL rather than by summing the
+// per-user series so a caller that only needs the total doesn't pay for the
+// per-user grouping.
+func (s *Store) UsageDailyTotal(userIDs []int64, w UsageWindow) ([]UsageDay, error) {
+	cond, args := usageWhere(userIDs, w, "user_id")
+	rows, err := s.db.Query(`
+		SELECT day, COALESCE(SUM(up),0), COALESCE(SUM(down),0)
+		  FROM traffic_daily
+		 WHERE 1=1`+cond+`
+		 GROUP BY day ORDER BY day`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []UsageDay
+	for rows.Next() {
+		var d UsageDay
+		if err := rows.Scan(&d.Date, &d.Up, &d.Down); err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// UsageByPackageWindowed returns per (user, package) totals inside the window,
+// from the rollup.
+//
+// The package name is resolved in three steps because a package row can be
+// deleted while its traffic history must stay readable: the live packages row
+// first, then the name snapshot the user's own bucket kept, then a placeholder.
+func (s *Store) UsageByPackageWindowed(userIDs []int64, w UsageWindow) ([]UsageTotal, error) {
+	cond, args := usageWhere(userIDs, w, "t.user_id")
+	rows, err := s.db.Query(`
+		SELECT t.user_id, COALESCE(u.username,''), t.package_id,
+		       COALESCE(NULLIF(p.name,''),
+		                NULLIF((SELECT b.name FROM user_plans b
+		                         WHERE b.user_id=t.user_id AND b.package_id=t.package_id
+		                         ORDER BY b.id DESC LIMIT 1), ''),
+		                '') AS pkg_name,
+		       COALESCE(SUM(t.up),0), COALESCE(SUM(t.down),0)
+		  FROM traffic_daily t
+		  LEFT JOIN users u ON u.id = t.user_id
+		  LEFT JOIN packages p ON p.id = t.package_id
+		 WHERE 1=1`+cond+`
+		 GROUP BY t.user_id, t.package_id
+		 ORDER BY (SUM(t.up)+SUM(t.down)) DESC`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanUsageTotals(rows)
+}
+
+// UsageByPackageLifetime returns per (user, package) totals from the bucket
+// counters — accurate for the whole life of the account, including before the
+// rollup existed. Buckets of the same package are summed, so an account that
+// repurchased before renewal stacking reads as one package.
+func (s *Store) UsageByPackageLifetime(userIDs []int64) ([]UsageTotal, error) {
+	var cond string
+	var args []any
+	if clause, ids, ok := inClause(userIDs); ok {
+		cond = " AND b.user_id IN " + clause
+		args = append(args, ids...)
+	}
+	rows, err := s.db.Query(`
+		SELECT b.user_id, COALESCE(u.username,''), b.package_id,
+		       COALESCE(NULLIF(p.name,''), NULLIF(MAX(b.name),''), '') AS pkg_name,
+		       COALESCE(SUM(b.used_up),0), COALESCE(SUM(b.used_down),0)
+		  FROM user_plans b
+		  LEFT JOIN users u ON u.id = b.user_id
+		  LEFT JOIN packages p ON p.id = b.package_id
+		 WHERE 1=1`+cond+`
+		 GROUP BY b.user_id, b.package_id
+		HAVING SUM(b.used_up) + SUM(b.used_down) > 0
+		 ORDER BY (SUM(b.used_up)+SUM(b.used_down)) DESC`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanUsageTotals(rows)
+}
+
+func scanUsageTotals(rows interface {
+	Next() bool
+	Scan(...any) error
+	Err() error
+}) ([]UsageTotal, error) {
+	var out []UsageTotal
+	for rows.Next() {
+		var t UsageTotal
+		if err := rows.Scan(&t.UserID, &t.Username, &t.PackageID, &t.PackageName, &t.Up, &t.Down); err != nil {
+			return nil, err
+		}
+		t.PackageName = usagePackageLabel(t.PackageID, t.PackageName)
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// usagePackageLabel names the two synthetic ids and rescues a package whose row
+// was deleted and whose bucket kept no snapshot — an empty legend entry reads
+// as a rendering bug rather than as deleted history.
+func usagePackageLabel(id int64, name string) string {
+	switch {
+	case id == PackageIDUnattributed:
+		return unattributedPackageName
+	case id == 0:
+		return poolPackageName
+	case name != "":
+		return name
+	default:
+		return fmt.Sprintf("已删除套餐 #%d", id)
+	}
+}
+
+// UsageLifetimeByUser returns each selected user's all-time total from the
+// mirrored user counter.
+func (s *Store) UsageLifetimeByUser(userIDs []int64) ([]UsageTotal, error) {
+	cond := ""
+	var args []any
+	if clause, ids, ok := inClause(userIDs); ok {
+		cond = " AND id IN " + clause
+		args = append(args, ids...)
+	}
+	rows, err := s.db.Query(`
+		SELECT id, username, 0, '', used_up, used_down
+		  FROM users
+		 WHERE role='user'`+cond+`
+		 ORDER BY (used_up+used_down) DESC`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []UsageTotal
+	for rows.Next() {
+		var t UsageTotal
+		if err := rows.Scan(&t.UserID, &t.Username, &t.PackageID, &t.PackageName, &t.Up, &t.Down); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// UsageWindowedByUser returns each selected user's total inside the window.
+func (s *Store) UsageWindowedByUser(userIDs []int64, w UsageWindow) ([]UsageTotal, error) {
+	cond, args := usageWhere(userIDs, w, "t.user_id")
+	rows, err := s.db.Query(`
+		SELECT t.user_id, COALESCE(u.username,''), 0, '',
+		       COALESCE(SUM(t.up),0), COALESCE(SUM(t.down),0)
+		  FROM traffic_daily t
+		  LEFT JOIN users u ON u.id = t.user_id
+		 WHERE 1=1`+cond+`
+		 GROUP BY t.user_id
+		 ORDER BY (SUM(t.up)+SUM(t.down)) DESC`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []UsageTotal
+	for rows.Next() {
+		var t UsageTotal
+		if err := rows.Scan(&t.UserID, &t.Username, &t.PackageID, &t.PackageName, &t.Up, &t.Down); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// TrafficDailyCoverage reports the first and last day the rollup holds, so the
+// report can state the period it can actually speak for. Empty strings mean the
+// table is empty (a fresh install, before the first stats poll).
+func (s *Store) TrafficDailyCoverage() (first, last string, err error) {
+	var f, l *string
+	err = s.db.QueryRow(`SELECT MIN(day), MAX(day) FROM traffic_daily`).Scan(&f, &l)
+	if f != nil {
+		first = *f
+	}
+	if l != nil {
+		last = *l
+	}
+	return
+}
+
+// UsageCandidate is one selectable user for the report's picker.
+type UsageCandidate struct {
+	ID       int64  `json:"id"`
+	Username string `json:"username"`
+	Traffic  int64  `json:"traffic"` // lifetime, for ordering the list usefully
+}
+
+// UsageUserCandidates lists users for the picker, heaviest first so the accounts
+// an admin is most likely looking for are at the top. q filters by username.
+func (s *Store) UsageUserCandidates(q string, limit int) ([]UsageCandidate, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 200
+	}
+	args := []any{}
+	cond := ""
+	if q = strings.TrimSpace(q); q != "" {
+		cond = " AND username LIKE ? ESCAPE '\\'"
+		args = append(args, "%"+escapeLike(q)+"%")
+	}
+	args = append(args, limit)
+	rows, err := s.db.Query(`
+		SELECT id, username, used_up+used_down AS v
+		  FROM users WHERE role='user'`+cond+`
+		 ORDER BY v DESC, username LIMIT ?`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []UsageCandidate
+	for rows.Next() {
+		var c UsageCandidate
+		if err := rows.Scan(&c.ID, &c.Username, &c.Traffic); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// escapeLike neutralises the LIKE wildcards in user input, so a username search
+// for "100%" doesn't match everything.
+func escapeLike(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return r.Replace(s)
+}
+
+// LocalDay renders a unix timestamp as the local calendar date, the same form
+// traffic_daily.day stores.
+func LocalDay(ts int64) string { return time.Unix(ts, 0).Format("2006-01-02") }
+
+// DaysAgo renders the local calendar date n days before today.
+func DaysAgo(n int) string { return time.Now().AddDate(0, 0, -n).Format("2006-01-02") }

--- a/internal/store/usagereport_test.go
+++ b/internal/store/usagereport_test.go
@@ -1,0 +1,453 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// The usage report's contract, in one place: traffic must be attributable to
+// the package that carried it, filterable by date, and it must not survive the
+// account it belonged to. Every assertion here is something an admin would read
+// off the report and act on, so a silent wrong number is the failure mode.
+
+// bucketOf returns a user's bucket id + package id for the given kind.
+func bucketOf(t *testing.T, st *Store, userID int64, kind string) (bucketID, packageID int64) {
+	t.Helper()
+	if err := st.db.QueryRow(`SELECT id, package_id FROM user_plans WHERE user_id=? AND kind=?`,
+		userID, kind).Scan(&bucketID, &packageID); err != nil {
+		t.Fatalf("bucket %s for user %d: %v", kind, userID, err)
+	}
+	return
+}
+
+// clientNameOf returns the sing-box stats identity of a user's bucket, which is
+// what AddUsageBatch is keyed by.
+func clientNameOf(t *testing.T, st *Store, userID int64, kind string) string {
+	t.Helper()
+	var name string
+	if err := st.db.QueryRow(`SELECT client_name FROM user_plans WHERE user_id=? AND kind=?`,
+		userID, kind).Scan(&name); err != nil {
+		t.Fatalf("client_name %s for user %d: %v", kind, userID, err)
+	}
+	return name
+}
+
+// backdate moves a rollup row to another day, standing in for traffic that
+// arrived earlier — the poll always writes "today", so a window test cannot be
+// built any other way.
+func backdate(t *testing.T, st *Store, userID int64, day string) {
+	t.Helper()
+	if _, err := st.db.Exec(`UPDATE traffic_daily SET day=? WHERE user_id=? AND day=?`,
+		day, userID, LocalDay(time.Now().Unix())); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A poll must land in traffic_daily attributed to the bucket's package, and
+// repeated polls on the same day must accumulate into that one row rather than
+// creating duplicates (the report sums them either way, but a growing row count
+// per poll is the bloat the rollup exists to avoid).
+func TestTrafficDaily_AttributesAndAccumulates(t *testing.T) {
+	st := newRefundStore(t)
+	uid := mkUser(t, st, "alice")
+	pkg := mkPlan(t, st, "尊享套餐", 10, 100, 30)
+	buy(t, st, uid, pkg)
+
+	name := clientNameOf(t, st, uid, "plan")
+	_, wantPkg := bucketOf(t, st, uid, "plan")
+
+	for i := 0; i < 3; i++ {
+		if _, err := st.AddUsageBatch(map[string]UsageDelta{name: {Up: 100, Down: 200}}); err != nil {
+			t.Fatalf("poll %d: %v", i, err)
+		}
+	}
+
+	var rows int
+	var day string
+	var gotPkg, up, down int64
+	if err := st.db.QueryRow(`SELECT COUNT(*) FROM traffic_daily WHERE user_id=?`, uid).Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 {
+		t.Fatalf("traffic_daily rows = %d, want 1 (three polls on one day collapse)", rows)
+	}
+	if err := st.db.QueryRow(`SELECT day, package_id, up, down FROM traffic_daily WHERE user_id=?`, uid).
+		Scan(&day, &gotPkg, &up, &down); err != nil {
+		t.Fatal(err)
+	}
+	if gotPkg != wantPkg {
+		t.Errorf("package_id = %d, want %d — traffic attributed to the wrong package", gotPkg, wantPkg)
+	}
+	if up != 300 || down != 600 {
+		t.Errorf("rollup = %d/%d, want 300/600", up, down)
+	}
+	if day != LocalDay(time.Now().Unix()) {
+		t.Errorf("day = %q, want today %q", day, LocalDay(time.Now().Unix()))
+	}
+}
+
+// Traffic from two different packages held by the same user must stay separate.
+// This is the question the report exists to answer, and the one the old schema
+// could not.
+func TestUsageByPackage_SplitsPerPackage(t *testing.T) {
+	st := newRefundStore(t)
+	uid := mkUser(t, st, "bob")
+	basic := mkPlan(t, st, "基础版", 10, 100, 30)
+	pro := mkPlan(t, st, "专业版", 20, 200, 30)
+	buy(t, st, uid, basic)
+	buy(t, st, uid, pro)
+
+	var names []string
+	rows, err := st.db.Query(`SELECT client_name FROM user_plans WHERE user_id=? AND kind='plan' ORDER BY id`, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		names = append(names, n)
+	}
+	rows.Close()
+	if len(names) != 2 {
+		t.Fatalf("want 2 plan buckets, got %d", len(names))
+	}
+
+	if _, err := st.AddUsageBatch(map[string]UsageDelta{
+		names[0]: {Up: 1000, Down: 2000},
+		names[1]: {Up: 30, Down: 40},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := st.UsageByPackageWindowed([]int64{uid}, UsageWindow{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 package rows, got %d: %+v", len(got), got)
+	}
+	byName := map[string]int64{}
+	for _, g := range got {
+		byName[g.PackageName] = g.Up + g.Down
+	}
+	if byName["基础版"] != 3000 {
+		t.Errorf("基础版 = %d, want 3000", byName["基础版"])
+	}
+	if byName["专业版"] != 70 {
+		t.Errorf("专业版 = %d, want 70", byName["专业版"])
+	}
+}
+
+// The date filter must actually exclude days outside the window. A report that
+// ignores its own range is worse than one that has no range.
+func TestUsageWindow_FiltersByDay(t *testing.T) {
+	st := newRefundStore(t)
+	uid := mkUser(t, st, "carol")
+	pkg := mkPlan(t, st, "P", 10, 100, 30)
+	buy(t, st, uid, pkg)
+	name := clientNameOf(t, st, uid, "plan")
+
+	// Day A (old), then day B (today).
+	if _, err := st.AddUsageBatch(map[string]UsageDelta{name: {Up: 500, Down: 500}}); err != nil {
+		t.Fatal(err)
+	}
+	old := DaysAgo(40)
+	backdate(t, st, uid, old)
+	if _, err := st.AddUsageBatch(map[string]UsageDelta{name: {Up: 7, Down: 3}}); err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := st.UsageWindowedByUser([]int64{uid}, UsageWindow{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 1 || all[0].Up+all[0].Down != 1010 {
+		t.Fatalf("unbounded window = %+v, want 1010 total", all)
+	}
+
+	recent, err := st.UsageWindowedByUser([]int64{uid}, UsageWindow{From: DaysAgo(29)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recent) != 1 || recent[0].Up+recent[0].Down != 10 {
+		t.Fatalf("last-30-days window = %+v, want only the 10 bytes from today", recent)
+	}
+
+	// A window that ends before the old day sees nothing at all.
+	none, err := st.UsageWindowedByUser([]int64{uid}, UsageWindow{From: DaysAgo(60), To: DaysAgo(50)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("empty window returned %+v, want nothing", none)
+	}
+}
+
+// Selecting users must select exactly those users — the report's multi-select
+// is how an admin isolates one account's bill from everyone else's.
+func TestUsageSelection_ScopesToChosenUsers(t *testing.T) {
+	st := newRefundStore(t)
+	pkg := mkPlan(t, st, "P", 10, 100, 30)
+	ids := map[string]int64{}
+	for _, n := range []string{"u1", "u2", "u3"} {
+		id := mkUser(t, st, n)
+		buy(t, st, id, pkg)
+		ids[n] = id
+		if _, err := st.AddUsageBatch(map[string]UsageDelta{
+			clientNameOf(t, st, id, "plan"): {Up: 10, Down: 10},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	all, err := st.UsageWindowedByUser(nil, UsageWindow{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("no selection should mean everyone: got %d rows, want 3", len(all))
+	}
+
+	two, err := st.UsageWindowedByUser([]int64{ids["u1"], ids["u3"]}, UsageWindow{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(two) != 2 {
+		t.Fatalf("selected 2 users, got %d rows", len(two))
+	}
+	for _, r := range two {
+		if r.UserID == ids["u2"] {
+			t.Errorf("unselected user u2 leaked into the result: %+v", r)
+		}
+		if r.Username == "" {
+			t.Errorf("row %+v has no username — the join lost it", r)
+		}
+	}
+}
+
+// Lifetime totals must include traffic that predates the rollup, which is the
+// entire reason the report keeps two modes instead of one.
+func TestUsageLifetime_IncludesPreRollupTraffic(t *testing.T) {
+	st := newRefundStore(t)
+	uid := mkUser(t, st, "dave")
+	pkg := mkPlan(t, st, "老套餐", 10, 100, 30)
+	buy(t, st, uid, pkg)
+
+	// Simulate history recorded before traffic_daily existed: counters only.
+	setBucketUsed(t, st, uid, "plan", 900, 100)
+	if _, err := st.db.Exec(`UPDATE users SET used_up=900, used_down=100 WHERE id=?`, uid); err != nil {
+		t.Fatal(err)
+	}
+
+	life, err := st.UsageLifetimeByUser([]int64{uid})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(life) != 1 || life[0].Up+life[0].Down != 1000 {
+		t.Fatalf("lifetime = %+v, want 1000", life)
+	}
+
+	pkgs, err := st.UsageByPackageLifetime([]int64{uid})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pkgs) != 1 || pkgs[0].PackageName != "老套餐" || pkgs[0].Up+pkgs[0].Down != 1000 {
+		t.Fatalf("lifetime by package = %+v, want 老套餐 with 1000", pkgs)
+	}
+
+	// The rollup, correctly, knows nothing about it.
+	win, err := st.UsageWindowedByUser([]int64{uid}, UsageWindow{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(win) != 0 {
+		t.Fatalf("rollup should hold nothing for pre-rollup traffic, got %+v", win)
+	}
+}
+
+// The synthetic package ids must be labelled, never rendered blank: an empty
+// legend entry reads as a bug and an admin cannot tell pool traffic from
+// unattributed history.
+func TestUsagePackageLabels(t *testing.T) {
+	for _, c := range []struct {
+		id   int64
+		name string
+		want string
+	}{
+		{PackageIDUnattributed, "", unattributedPackageName},
+		{0, "", poolPackageName},
+		{7, "专业版", "专业版"},
+		{7, "", "已删除套餐 #7"},
+	} {
+		if got := usagePackageLabel(c.id, c.name); got != c.want {
+			t.Errorf("usagePackageLabel(%d, %q) = %q, want %q", c.id, c.name, got, c.want)
+		}
+	}
+}
+
+// Deleting a user must take their rollup rows with them. traffic_daily is never
+// pruned by age, so a leftover row would inflate every site-wide total forever
+// and attach a deleted account's bytes to whoever is next given that id.
+func TestDeleteUser_RemovesRollup(t *testing.T) {
+	st := newRefundStore(t)
+	uid := mkUser(t, st, "erin")
+	pkg := mkPlan(t, st, "P", 10, 100, 30)
+	buy(t, st, uid, pkg)
+	if _, err := st.AddUsageBatch(map[string]UsageDelta{
+		clientNameOf(t, st, uid, "plan"): {Up: 10, Down: 10},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var before int
+	if err := st.db.QueryRow(`SELECT COUNT(*) FROM traffic_daily WHERE user_id=?`, uid).Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+	if before == 0 {
+		t.Fatal("no rollup rows to begin with — test proves nothing")
+	}
+	if err := st.DeleteUser(uid); err != nil {
+		t.Fatal(err)
+	}
+	var after int
+	if err := st.db.QueryRow(`SELECT COUNT(*) FROM traffic_daily WHERE user_id=?`, uid).Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if after != 0 {
+		t.Errorf("traffic_daily still holds %d rows for the deleted user", after)
+	}
+}
+
+// The backfill seeds days that have no rollup row, and must never double-count
+// on a re-run or overwrite a day already attributed per bucket.
+func TestBackfillTrafficDaily_IdempotentAndNonDestructive(t *testing.T) {
+	st := newRefundStore(t)
+	uid := mkUser(t, st, "frank")
+	pkg := mkPlan(t, st, "P", 10, 100, 30)
+	buy(t, st, uid, pkg)
+
+	// A properly attributed day (today), written by the normal path.
+	if _, err := st.AddUsageBatch(map[string]UsageDelta{
+		clientNameOf(t, st, uid, "plan"): {Up: 5, Down: 5},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, wantPkg := bucketOf(t, st, uid, "plan")
+
+	// A legacy sample on an older day, with no rollup row — what an upgrading
+	// install looks like.
+	oldTS := time.Now().AddDate(0, 0, -3).Unix()
+	if _, err := st.db.Exec(`INSERT INTO traffic_samples (user_id, ts, up, down) VALUES (?,?,?,?)`,
+		uid, oldTS, 70, 30); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 3; i++ { // re-running must change nothing after the first
+		if err := st.backfillTrafficDaily(); err != nil {
+			t.Fatalf("backfill run %d: %v", i, err)
+		}
+	}
+
+	var oldUp, oldDown, oldPkg int64
+	if err := st.db.QueryRow(`SELECT up, down, package_id FROM traffic_daily WHERE user_id=? AND day=?`,
+		uid, LocalDay(oldTS)).Scan(&oldUp, &oldDown, &oldPkg); err != nil {
+		t.Fatalf("backfilled day missing: %v", err)
+	}
+	if oldUp != 70 || oldDown != 30 {
+		t.Errorf("backfilled day = %d/%d, want 70/30 (re-runs must not accumulate)", oldUp, oldDown)
+	}
+	if oldPkg != PackageIDUnattributed {
+		t.Errorf("backfilled package_id = %d, want %d (unattributable)", oldPkg, PackageIDUnattributed)
+	}
+
+	// Today's row keeps its real attribution and its exact bytes — the backfill
+	// must not have folded the same traffic in a second time via its sample.
+	var todayUp, todayDown, todayPkg int64
+	if err := st.db.QueryRow(`SELECT up, down, package_id FROM traffic_daily WHERE user_id=? AND day=?`,
+		uid, LocalDay(time.Now().Unix())).Scan(&todayUp, &todayDown, &todayPkg); err != nil {
+		t.Fatal(err)
+	}
+	if todayUp != 5 || todayDown != 5 {
+		t.Errorf("attributed day = %d/%d, want 5/5 — backfill double-counted it", todayUp, todayDown)
+	}
+	if todayPkg != wantPkg {
+		t.Errorf("attributed day package_id = %d, want %d — backfill clobbered attribution", todayPkg, wantPkg)
+	}
+}
+
+// The daily series must come back per user, in date order, so the chart can
+// plot several accounts against one axis.
+func TestUsageDailySeries_PerUserOrdered(t *testing.T) {
+	st := newRefundStore(t)
+	pkg := mkPlan(t, st, "P", 10, 100, 30)
+	a := mkUser(t, st, "ua")
+	b := mkUser(t, st, "ub")
+	buy(t, st, a, pkg)
+	buy(t, st, b, pkg)
+
+	if _, err := st.AddUsageBatch(map[string]UsageDelta{
+		clientNameOf(t, st, a, "plan"): {Up: 1, Down: 1},
+		clientNameOf(t, st, b, "plan"): {Up: 2, Down: 2},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	backdate(t, st, a, DaysAgo(2))
+	if _, err := st.AddUsageBatch(map[string]UsageDelta{
+		clientNameOf(t, st, a, "plan"): {Up: 4, Down: 4},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	series, err := st.UsageDailyByUser([]int64{a, b}, UsageWindow{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(series) != 2 {
+		t.Fatalf("want 2 series, got %d", len(series))
+	}
+	for _, s := range series {
+		for i := 1; i < len(s.Days); i++ {
+			if s.Days[i-1].Date > s.Days[i].Date {
+				t.Errorf("user %d series out of order: %s before %s", s.UserID, s.Days[i-1].Date, s.Days[i].Date)
+			}
+		}
+	}
+	var aDays int
+	for _, s := range series {
+		if s.UserID == a {
+			aDays = len(s.Days)
+		}
+	}
+	if aDays != 2 {
+		t.Errorf("user a should have 2 distinct days, got %d", aDays)
+	}
+
+	total, err := st.UsageDailyTotal([]int64{a, b}, UsageWindow{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sum int64
+	for _, d := range total {
+		sum += d.Up + d.Down
+	}
+	if sum != 14 { // a: 2 + 8, b: 4
+		t.Errorf("combined total = %d, want 14", sum)
+	}
+}
+
+// The picker must not let a username containing LIKE wildcards match everyone.
+func TestUsageUserCandidates_EscapesWildcards(t *testing.T) {
+	st := newRefundStore(t)
+	mkUser(t, st, "alice")
+	mkUser(t, st, "100%off")
+
+	got, err := st.UsageUserCandidates("100%", 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Username != "100%off" {
+		t.Errorf("search %q matched %+v, want only 100%%off", "100%", got)
+	}
+}

--- a/internal/store/userplans.go
+++ b/internal/store/userplans.go
@@ -748,14 +748,14 @@ func (s *Store) AddBucketUsage(statName string, up, down int64) error {
 	// custom proxy_username. Both meter the same bucket. proxy_username can never
 	// equal a client_name (client_names are qz_-prefixed, proxy_usernames may not
 	// be) and is globally unique, so at most one row matches.
-	bucketID, userID, err := resolveStatsIdentity(tx, statName)
+	bucketID, userID, packageID, err := resolveStatsIdentity(tx, statName)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil // unknown identity (e.g. a just-removed bucket) — ignore, rolls back
 	}
 	if err != nil {
 		return err
 	}
-	if err = applyBucketUsage(tx, bucketID, userID, up, down, now); err != nil {
+	if err = applyBucketUsage(tx, bucketID, userID, packageID, up, down, now); err != nil {
 		return err
 	}
 	if err = tx.Commit(); err != nil {
@@ -803,7 +803,7 @@ func (s *Store) AddUsageBatch(deltas map[string]UsageDelta) (int, error) {
 		if name == "" || (d.Up == 0 && d.Down == 0) {
 			continue
 		}
-		bucketID, userID, rerr := resolveStatsIdentity(tx, name)
+		bucketID, userID, packageID, rerr := resolveStatsIdentity(tx, name)
 		if errors.Is(rerr, sql.ErrNoRows) {
 			continue // unknown / just-removed identity — skip, not a failure
 		}
@@ -817,7 +817,7 @@ func (s *Store) AddUsageBatch(deltas map[string]UsageDelta) (int, error) {
 		if _, err := tx.Exec(`SAVEPOINT usg`); err != nil {
 			return applied, err // savepoint itself failing means the tx is unusable
 		}
-		if werr := applyBucketUsage(tx, bucketID, userID, d.Up, d.Down, now); werr != nil {
+		if werr := applyBucketUsage(tx, bucketID, userID, packageID, d.Up, d.Down, now); werr != nil {
 			_, _ = tx.Exec(`ROLLBACK TO usg`)
 			_, _ = tx.Exec(`RELEASE usg`)
 			if firstErr == nil {
@@ -844,16 +844,21 @@ func (s *Store) AddUsageBatch(deltas map[string]UsageDelta) (int, error) {
 // optional custom proxy_username. Both meter the same bucket; proxy_username can
 // never equal a client_name (client_names are qz_-prefixed, proxy_usernames may
 // not be) and is globally unique, so at most one row matches.
-func resolveStatsIdentity(tx txLike, statName string) (bucketID, userID int64, err error) {
-	err = tx.QueryRow(`SELECT id, user_id FROM user_plans WHERE client_name=? OR (proxy_username<>'' AND proxy_username=?)`,
-		statName, statName).Scan(&bucketID, &userID)
+//
+// packageID rides along for the traffic_daily rollup: resolving it here costs
+// nothing (the row is already being read) and saves a second lookup inside the
+// hot per-identity write path.
+func resolveStatsIdentity(tx txLike, statName string) (bucketID, userID, packageID int64, err error) {
+	err = tx.QueryRow(`SELECT id, user_id, package_id FROM user_plans WHERE client_name=? OR (proxy_username<>'' AND proxy_username=?)`,
+		statName, statName).Scan(&bucketID, &userID, &packageID)
 	return
 }
 
 // applyBucketUsage writes one identity's delta: the bucket counter, the mirrored
-// user aggregate + last_online, and the per-user time-series sample. Caller owns
-// the transaction (or savepoint) so these three land together or not at all.
-func applyBucketUsage(tx txLike, bucketID, userID, up, down, now int64) error {
+// user aggregate + last_online, the per-user time-series sample, and the daily
+// per-bucket rollup. Caller owns the transaction (or savepoint) so these land
+// together or not at all.
+func applyBucketUsage(tx txLike, bucketID, userID, packageID, up, down, now int64) error {
 	if _, err := tx.Exec(`UPDATE user_plans SET used_up=used_up+?, used_down=used_down+?, last_online_at=?, updated_at=? WHERE id=?`,
 		up, down, now, now, bucketID); err != nil {
 		return err
@@ -864,6 +869,21 @@ func applyBucketUsage(tx txLike, bucketID, userID, up, down, now int64) error {
 	}
 	if _, err := tx.Exec(`INSERT INTO traffic_samples (user_id, ts, up, down) VALUES (?, ?, ?, ?)`,
 		userID, now, up, down); err != nil {
+		return err
+	}
+	// The day is derived in SQL from the same `now` the rest of the row uses,
+	// with the same 'localtime' modifier the daily read queries apply — deriving
+	// it in Go instead would put the boundary in a second place to keep in sync,
+	// and the two would disagree for anyone whose process TZ differs from
+	// SQLite's.
+	if _, err := tx.Exec(`
+		INSERT INTO traffic_daily (day, user_id, bucket_id, package_id, up, down)
+		VALUES (strftime('%Y-%m-%d', ?, 'unixepoch', 'localtime'), ?, ?, ?, ?, ?)
+		ON CONFLICT(day, user_id, bucket_id) DO UPDATE SET
+		  up = up + excluded.up,
+		  down = down + excluded.down,
+		  package_id = excluded.package_id`,
+		now, userID, bucketID, packageID, up, down); err != nil {
 		return err
 	}
 	return nil

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -330,6 +330,11 @@ func (s *Store) DeleteUser(id int64) error {
 		`DELETE FROM user_group_members WHERE user_id=?`,
 		`DELETE FROM user_plans WHERE user_id=?`,
 		`DELETE FROM traffic_samples WHERE user_id=?`,
+		// The daily rollup is keyed by user_id too, and unlike the samples it is
+		// never pruned by age — leaving it behind would keep a deleted account's
+		// bytes in every site-wide usage total forever, and hand them to whoever
+		// is next assigned that id.
+		`DELETE FROM traffic_daily WHERE user_id=?`,
 		`DELETE FROM users WHERE id=?`,
 	} {
 		if _, err := tx.Exec(q, id); err != nil {


### PR DESCRIPTION
管理概览新增「用量分析」标签页：多选用户 × 任意时间范围 × 套餐维度。

## 先说数据模型，因为这决定了功能能做到哪一步

原来的 `traffic_samples` 回答不了这个页面要问的两个问题：

- **不带 bucket** → 「这笔流量属于哪个套餐」历史上根本没记录过
- **只保留 35 天** → 更长的自定义区间查出来是空的

所以新增 `traffic_daily(day, user_id, bucket_id, package_id, up, down)`，**永久保留**。一个用户一个套餐一个活跃日一行，体积极小（1000 用户 × 2 套餐 × 365 天 ≈ 73 万行，几十 MB），且只增不改。

`package_id` 反规范化存储而非靠 `bucket_id` 关联：buckets 会被 `mergeDuplicatePlanBuckets` 删除，**一份历史的分组键因为一个无关维护任务跑过就消失，那就不叫历史**。

## 两种口径，界面明确标注用的是哪一种

| 口径 | 数据源 | 准确范围 |
|---|---|---|
| **累计** | 账户计数器 `users` / `user_plans.used_*` | 开户至今全部，**含本功能上线前** |
| **区间** | `traffic_daily` 汇总表 | 从开始记录那天起 |

**不合并成一种是刻意的**：管理员对账时需要知道手上这个数字是「全部」还是「我们有记录的全部」。页面把 `coverage.first` 直接写在数字旁边。

升级时用现存 `traffic_samples` 回填最多 35 天，标为 `package_id=-1`「未记录套餐（升级前）」——**字节是真的，但归属不可知，界面单列显示而不是悄悄算进某个没赚到这笔流量的套餐里**。

回填幂等：只写完全没有行的 `(day, user)`，重跑不会重复计数，也不会覆盖已按 bucket 归属的那天。

## 前端

独立组件 `AdminUsageReport.vue`。时间口径与用户多选**共同决定整页数字**，避免各图表各带筛选、口径互相打架。含 KPI、分层堆叠趋势图、套餐环图、用户排行、用户×套餐明细表与 CSV 导出（带 BOM，Excel 中文不乱码）。配色沿用 AdminOverview 的暖中性色板。

## 实测发现并修掉的一个自己的 bug

窄屏下 `.two-col` 塌成单列后，两个图表卡片仍是 **457px 宽、超出 351px 的容器**。

原因是 CSS Grid 的 `1fr` 等价于 `minmax(auto, 1fr)`，`auto` 的最小尺寸取内容宽度；echarts 画布在 `resize()` 前保持旧像素宽，于是**旧画布把轨道撑开，`resize()` 又读到这个被撑开的容器，列永远缩不回去**——自锁。

改用 `minmax(0, 1fr)` 并给 `.chart` 加 `min-width: 0`。375px 下已复验：容器 317px，页面零横向滚动，表格在 `.tbl-wrap` 内自己横滚。

## 验证

本地起实例灌了 6 用户 / 3 套餐 / 45 天数据实跑（种子程序走真实的 `AddUsageBatch` 写入路径）：

| 口径 | 用户合计 | 套餐合计 | 曲线合计 | 一致 |
|---|---|---|---|---|
| 7d | 7.26 GB | 7.26 GB | 7.26 GB | ✓ |
| 30d | 32.34 GB | 32.34 GB | 32.34 GB | ✓ |
| 90d | 48.93 GB | 48.93 GB | 48.93 GB | ✓ |
| 累计 | 48.93 GB | 48.93 GB | — | ✓ |

- 自定义区间 `2026-07-01..2026-07-15`：15 天、边界精确、**无越界日期**
- 多选用户后，单用户数字与全量中该用户**逐字节一致**
- 三个图表均以真实尺寸绘制（非 0 宽画布）
- 单元测试：store 10 个 + api 7 个，覆盖归属、窗口过滤、用户隔离、回填幂等、删号清理、LIKE 通配符转义、参数注入与上限

## 未验证的部分

用户多选下拉的**选项点击**这一步没能在浏览器面板里验证——虚拟列表需要合成帧才能渲染选项，而面板不可见时取不到。同一个 `load()` 函数已通过时间口径单选按钮的真实点击走通全链路，风险较低，但如实标注。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
