### PR TITLE
feat(stats): 用量分析补上套餐筛选，并让图表可点击筛选

### DIFF
--- a/frontend/src/components/AdminUsageReport.vue
+++ b/frontend/src/components/AdminUsageReport.vue
@@ -22,6 +22,22 @@
         </div>
 
         <div class="ctl-group grow">
+          <span class="ctl-label">套餐</span>
+          <n-select
+            v-model:value="selectedPkgs"
+            multiple
+            filterable
+            clearable
+            size="small"
+            placeholder="全部套餐"
+            :options="pkgOptions"
+            :max-tag-count="3"
+            class="user-select"
+            @update:value="load"
+          />
+        </div>
+
+        <div class="ctl-group grow">
           <span class="ctl-label">用户</span>
           <n-select
             v-model:value="selected"
@@ -36,7 +52,9 @@
             class="user-select"
             @update:value="load"
           />
-          <n-button v-if="selected.length" size="small" quaternary @click="clearUsers">清空</n-button>
+          <n-button v-if="selected.length || selectedPkgs.length" size="small" quaternary @click="clearFilters">
+            清空筛选
+          </n-button>
         </div>
       </div>
 
@@ -84,7 +102,7 @@
         <n-card size="small" class="sec">
           <template #header>
             <span class="sec-title">套餐分布</span>
-            <span class="sec-note">按流量占比</span>
+            <span class="sec-note">按流量占比 · 点击扇区筛选</span>
           </template>
           <div v-if="!byPackage.length" class="empty">暂无套餐用量</div>
           <div v-show="byPackage.length" ref="pkgEl" class="chart" style="height:280px;" />
@@ -93,7 +111,7 @@
         <n-card size="small" class="sec">
           <template #header>
             <span class="sec-title">用户排行</span>
-            <span class="sec-note">前 {{ Math.min(byUser.length, 10) }} 名</span>
+            <span class="sec-note">前 {{ Math.min(byUser.length, 10) }} 名 · 点击柱条筛选</span>
           </template>
           <div v-if="!byUser.length" class="empty">暂无用户用量</div>
           <div v-show="byUser.length" ref="rankEl" class="chart" style="height:280px;" />
@@ -172,6 +190,7 @@ const presets = [
 const preset = ref('30d')
 const customRange = ref<[number, number] | null>(null)
 const selected = ref<number[]>([])
+const selectedPkgs = ref<number[]>([])
 const loading = ref(false)
 const loadingUsers = ref(false)
 
@@ -182,9 +201,18 @@ const totalSeries = ref<any[]>([])
 const byUser = ref<any[]>([])
 const byPackage = ref<any[]>([])
 const candidates = ref<any[]>([])
+const pkgCandidates = ref<any[]>([])
 
 const userOptions = computed(() =>
   candidates.value.map(c => ({ label: `${c.username}（${fmtBytes(c.traffic)}）`, value: c.id })))
+const pkgOptions = computed(() =>
+  pkgCandidates.value.map(c => ({ label: `${c.name}（${fmtBytes(c.traffic)}）`, value: c.id })))
+// 套餐名 -> id，供环图点击回填筛选（图上只有名字，没有 id）
+const pkgIdByName = computed(() => {
+  const m = new Map<string, number>()
+  pkgCandidates.value.forEach(c => m.set(c.name, c.id))
+  return m
+})
 
 // 未来日期没有数据，选了只会得到空图 —— 直接禁掉比让人选完再解释更好。
 function disableFuture(ts: number) { return ts > Date.now() }
@@ -276,9 +304,14 @@ const byteAxis = {
   axisLabel: { color: '#767676', fontSize: 11, formatter: (v: number) => fmtBytes(v) },
 }
 
-function draw(key: string, el: HTMLElement | null, option: any) {
+function draw(key: string, el: HTMLElement | null, option: any, onClick?: (p: any) => void) {
   if (!el || !el.clientWidth) return // 隐藏容器宽度为 0，此时 init 会画出永久 0 宽画布
-  if (!charts[key]) charts[key] = echarts.init(el)
+  if (!charts[key]) {
+    charts[key] = echarts.init(el)
+    // 只在实例创建时绑一次。setOption 不会清掉监听器，每次重画都绑会导致
+    // 点一下触发 N 次 load()。
+    if (onClick) charts[key].on('click', onClick)
+  }
   charts[key].setOption(option, true)
 }
 
@@ -357,10 +390,14 @@ function pkgOption() {
     legend: { type: 'scroll', orient: 'vertical', right: 0, top: 'center',
       textStyle: { color: '#767676', fontSize: 11 }, itemWidth: 10, itemHeight: 10 },
     series: [{
-      type: 'pie', radius: ['52%', '76%'], center: ['36%', '50%'],
+      type: 'pie', radius: ['52%', '76%'], center: ['36%', '50%'], cursor: 'pointer',
       avoidLabelOverlap: true, itemStyle: { borderColor: '#fff', borderWidth: 2 },
       label: { show: false }, labelLine: { show: false },
-      data: data.map((d, i) => ({ ...d, itemStyle: { color: PALETTE[i % PALETTE.length] } })),
+      data: data.map((d, i) => {
+        const id = pkgIdByName.value.get(d.name)
+        const dim = selectedPkgs.value.length && id !== undefined && !selectedPkgs.value.includes(id)
+        return { ...d, itemStyle: { color: PALETTE[i % PALETTE.length], opacity: dim ? 0.25 : 1 } }
+      }),
     }],
   }
 }
@@ -373,7 +410,8 @@ function rankOption() {
     xAxis: byteAxis,
     yAxis: { type: 'category', data: rows.map(r => r.username || `#${r.user_id}`), ...axisStyle },
     series: [{
-      type: 'bar', barMaxWidth: 16, itemStyle: { borderRadius: [0, 3, 3, 0], color: C.down },
+      type: 'bar', barMaxWidth: 16, cursor: 'pointer',
+      itemStyle: { borderRadius: [0, 3, 3, 0], color: C.down },
       data: rows.map(r => r.up + r.down),
       label: { show: true, position: 'right', color: '#767676', fontSize: 11,
         formatter: (p: any) => fmtBytes(p.value) },
@@ -383,8 +421,25 @@ function rankOption() {
 
 function renderAll() {
   draw('trend', trendEl.value, trendOption())
-  draw('pkg', pkgEl.value, pkgOption())
-  draw('rank', rankEl.value, rankOption())
+  draw('pkg', pkgEl.value, pkgOption(), onPkgClick)
+  draw('rank', rankEl.value, rankOption(), onRankClick)
+}
+
+// 环图按套餐名聚合（同名跨用户合并），所以点击只能拿到名字，需要回查 id。
+function onPkgClick(p: any) {
+  const id = pkgIdByName.value.get(p?.name)
+  if (id === undefined) return
+  toggleIn(selectedPkgs.value, id)
+  load()
+}
+
+function onRankClick(p: any) {
+  const row = [...byUser.value]
+    .sort((a, b) => (b.up + b.down) - (a.up + a.down))
+    .slice(0, 10).reverse()[p?.dataIndex]
+  if (!row) return
+  toggleIn(selected.value, row.user_id)
+  load()
 }
 
 let resizeTimer: any
@@ -411,9 +466,17 @@ function onPreset(v: string) {
   load()
 }
 
-function clearUsers() {
+function clearFilters() {
   selected.value = []
+  selectedPkgs.value = []
   load()
+}
+
+// 图表点击 = 筛选。再点一次同一项则取消，否则没有回到「全部」的路径。
+function toggleIn(list: number[], id: number) {
+  const i = list.indexOf(id)
+  if (i >= 0) list.splice(i, 1)
+  else list.push(id)
 }
 
 function buildQuery() {
@@ -424,6 +487,7 @@ function buildQuery() {
     q.set('to', toDay(customRange.value[1]))
   }
   if (selected.value.length) q.set('users', selected.value.join(','))
+  if (selectedPkgs.value.length) q.set('packages', selectedPkgs.value.join(','))
   return q.toString()
 }
 
@@ -458,13 +522,17 @@ async function loadUsers() {
   }
 }
 
+async function loadPkgs() {
+  try { pkgCandidates.value = await apiList('/api/admin/stats/usage/packages') } catch {}
+}
+
 // 父组件切到本标签页时容器才有宽度，此时补画。
 defineExpose({ refresh: () => { renderAll() } })
 
 watch(() => [byUser.value, byPackage.value], () => nextTick(renderAll), { deep: false })
 
 onMounted(async () => {
-  await Promise.all([loadUsers(), load()])
+  await Promise.all([loadUsers(), loadPkgs(), load()])
   window.addEventListener('resize', onResize)
 })
 onUnmounted(() => {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -353,6 +353,7 @@ func (a *API) Router() http.Handler {
 		// 用量分析：多选用户 × 任意时间范围 × 套餐维度
 		ar.Get("/api/admin/stats/usage", a.handleAdminUsage)
 		ar.Get("/api/admin/stats/usage/users", a.handleAdminUsageUsers)
+		ar.Get("/api/admin/stats/usage/packages", a.handleAdminUsagePackages)
 
 		ar.Get("/api/admin/reg-codes", a.handleAdminListRegCodes)
 		ar.Post("/api/admin/reg-codes/generate", a.handleAdminGenerateRegCodes)

--- a/internal/api/usage.go
+++ b/internal/api/usage.go
@@ -36,16 +36,35 @@ const maxUsageUsers = 100
 // parseUserIDs reads the repeated/comma-joined `users` param. An empty result
 // means "every user", which is the report's default view.
 func parseUserIDs(r *http.Request) []int64 {
+	return parseIDList(r, "users", false)
+}
+
+// parsePackageIDs reads the `packages` param. Unlike users, non-positive ids
+// are meaningful here and must survive: 0 is the shared pool and -1 is the
+// pre-rollup unattributed bucket, which are two of the entries an admin most
+// wants to isolate.
+func parsePackageIDs(r *http.Request) []int64 {
+	return parseIDList(r, "packages", true)
+}
+
+// parseIDList reads a repeated/comma-joined id param, dropping anything that is
+// not an integer so it can never reach the query builder. allowNonPositive
+// keeps the synthetic package ids (0, -1); user ids are always positive, and
+// letting a 0 through there would silently widen nothing but confuse the echo.
+func parseIDList(r *http.Request, key string, allowNonPositive bool) []int64 {
 	seen := map[int64]bool{}
 	var out []int64
-	for _, raw := range r.URL.Query()["users"] {
+	for _, raw := range r.URL.Query()[key] {
 		for _, part := range strings.Split(raw, ",") {
 			part = strings.TrimSpace(part)
 			if part == "" {
 				continue
 			}
 			id, err := strconv.ParseInt(part, 10, 64)
-			if err != nil || id <= 0 || seen[id] {
+			if err != nil || seen[id] {
+				continue
+			}
+			if !allowNonPositive && id <= 0 {
 				continue
 			}
 			seen[id] = true
@@ -112,7 +131,9 @@ func usageWindowFromQuery(r *http.Request) (mode string, w store.UsageWindow, pr
 // coverage so the client can caveat the window.
 func (a *API) handleAdminUsage(w http.ResponseWriter, r *http.Request) {
 	userIDs := parseUserIDs(r)
+	pkgIDs := parsePackageIDs(r)
 	mode, win, preset := usageWindowFromQuery(r)
+	filter := store.UsageFilter{UserIDs: userIDs, PackageIDs: pkgIDs, Window: win}
 
 	first, last, err := a.st.TrafficDailyCoverage()
 	if err != nil {
@@ -126,16 +147,17 @@ func (a *API) handleAdminUsage(w http.ResponseWriter, r *http.Request) {
 		"from":     win.From,
 		"to":       win.To,
 		"users":    userIDs,
+		"packages": pkgIDs,
 		"coverage": J{"first": first, "last": last},
 	}
 
 	if mode == usageModeLifetime {
-		byUser, err := a.st.UsageLifetimeByUser(userIDs)
+		byUser, err := a.st.UsageLifetimeByUser(filter)
 		if err != nil {
 			fail(w, http.StatusInternalServerError, "读取用量统计失败")
 			return
 		}
-		byPkg, err := a.st.UsageByPackageLifetime(userIDs)
+		byPkg, err := a.st.UsageByPackageLifetime(filter)
 		if err != nil {
 			fail(w, http.StatusInternalServerError, "读取套餐用量失败")
 			return
@@ -143,12 +165,12 @@ func (a *API) handleAdminUsage(w http.ResponseWriter, r *http.Request) {
 		// The daily curve has no lifetime equivalent — the counters are scalars.
 		// Send the rollup's full extent so the chart still has something true to
 		// draw, flagged by series_scope so the client can label it.
-		series, err := a.st.UsageDailyByUser(userIDs, store.UsageWindow{})
+		series, err := a.st.UsageDailyByUser(store.UsageFilter{UserIDs: userIDs, PackageIDs: pkgIDs})
 		if err != nil {
 			fail(w, http.StatusInternalServerError, "读取用量曲线失败")
 			return
 		}
-		total, err := a.st.UsageDailyTotal(userIDs, store.UsageWindow{})
+		total, err := a.st.UsageDailyTotal(store.UsageFilter{UserIDs: userIDs, PackageIDs: pkgIDs})
 		if err != nil {
 			fail(w, http.StatusInternalServerError, "读取用量曲线失败")
 			return
@@ -162,22 +184,22 @@ func (a *API) handleAdminUsage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	byUser, err := a.st.UsageWindowedByUser(userIDs, win)
+	byUser, err := a.st.UsageWindowedByUser(filter)
 	if err != nil {
 		fail(w, http.StatusInternalServerError, "读取用量统计失败")
 		return
 	}
-	byPkg, err := a.st.UsageByPackageWindowed(userIDs, win)
+	byPkg, err := a.st.UsageByPackageWindowed(filter)
 	if err != nil {
 		fail(w, http.StatusInternalServerError, "读取套餐用量失败")
 		return
 	}
-	series, err := a.st.UsageDailyByUser(userIDs, win)
+	series, err := a.st.UsageDailyByUser(filter)
 	if err != nil {
 		fail(w, http.StatusInternalServerError, "读取用量曲线失败")
 		return
 	}
-	total, err := a.st.UsageDailyTotal(userIDs, win)
+	total, err := a.st.UsageDailyTotal(filter)
 	if err != nil {
 		fail(w, http.StatusInternalServerError, "读取用量曲线失败")
 		return
@@ -199,6 +221,19 @@ func (a *API) handleAdminUsageUsers(w http.ResponseWriter, r *http.Request) {
 	}
 	if rows == nil {
 		rows = []store.UsageCandidate{}
+	}
+	ok(w, rows)
+}
+
+// GET /api/admin/stats/usage/packages — the report's package picker.
+func (a *API) handleAdminUsagePackages(w http.ResponseWriter, r *http.Request) {
+	rows, err := a.st.UsagePackageCandidates()
+	if err != nil {
+		fail(w, http.StatusInternalServerError, "读取套餐列表失败")
+		return
+	}
+	if rows == nil {
+		rows = []store.UsagePackageCandidate{}
 	}
 	ok(w, rows)
 }

--- a/internal/store/usage.go
+++ b/internal/store/usage.go
@@ -30,6 +30,25 @@ type UsageWindow struct {
 	To   string // YYYY-MM-DD inclusive; "" = through the last recorded day
 }
 
+// UsageFilter is everything that narrows a usage query. Carried as one struct
+// rather than as parallel arguments because every query in this file needs the
+// identical set, and a third dimension threaded positionally through six
+// functions is how one of them quietly ends up filtering on the wrong thing.
+//
+// Empty UserIDs / PackageIDs mean "no restriction on that axis", NOT "match
+// nothing" — the report's default view is everyone, everything.
+type UsageFilter struct {
+	UserIDs    []int64
+	PackageIDs []int64 // 0 = shared pool, -1 = unattributed; both are selectable
+	Window     UsageWindow
+}
+
+// HasPackageFilter reports whether a package restriction is in play. Callers in
+// lifetime mode need this: the per-user counters they normally read are scalars
+// with no package dimension, so a package filter forces them onto the bucket
+// counters instead (see UsageLifetimeByUser).
+func (f UsageFilter) HasPackageFilter() bool { return len(f.PackageIDs) > 0 }
+
 // UsageTotal is one subject's traffic. Subject is a user for the per-user
 // breakdown and a (user, package) pair for the per-package one.
 type UsageTotal struct {
@@ -80,29 +99,34 @@ func inClause(ids []int64) (string, []any, bool) {
 	return "(" + strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",") + ")", args, true
 }
 
-// where builds the shared user/day filter. userIDs empty = every user.
-func usageWhere(userIDs []int64, w UsageWindow, userCol string) (string, []any) {
+// usageWhere builds the shared user/package/day filter against traffic_daily.
+// userCol / pkgCol are the qualified column names for the query being built.
+func usageWhere(f UsageFilter, userCol, pkgCol string) (string, []any) {
 	var sb strings.Builder
 	var args []any
-	if clause, ids, ok := inClause(userIDs); ok {
+	if clause, ids, ok := inClause(f.UserIDs); ok {
 		sb.WriteString(" AND " + userCol + " IN " + clause)
 		args = append(args, ids...)
 	}
-	if w.From != "" {
-		sb.WriteString(" AND day >= ?")
-		args = append(args, w.From)
+	if clause, ids, ok := inClause(f.PackageIDs); ok {
+		sb.WriteString(" AND " + pkgCol + " IN " + clause)
+		args = append(args, ids...)
 	}
-	if w.To != "" {
+	if f.Window.From != "" {
+		sb.WriteString(" AND day >= ?")
+		args = append(args, f.Window.From)
+	}
+	if f.Window.To != "" {
 		sb.WriteString(" AND day <= ?")
-		args = append(args, w.To)
+		args = append(args, f.Window.To)
 	}
 	return sb.String(), args
 }
 
 // UsageDailyByUser returns each selected user's daily curve inside the window,
 // sparse (only days with traffic). Callers fill gaps for plotting.
-func (s *Store) UsageDailyByUser(userIDs []int64, w UsageWindow) ([]UsageSeries, error) {
-	cond, args := usageWhere(userIDs, w, "t.user_id")
+func (s *Store) UsageDailyByUser(f UsageFilter) ([]UsageSeries, error) {
+	cond, args := usageWhere(f, "t.user_id", "t.package_id")
 	rows, err := s.db.Query(`
 		SELECT t.user_id, COALESCE(u.username,''), t.day,
 		       COALESCE(SUM(t.up),0), COALESCE(SUM(t.down),0)
@@ -140,8 +164,8 @@ func (s *Store) UsageDailyByUser(userIDs []int64, w UsageWindow) ([]UsageSeries,
 // the stacked chart's total line. Computed in SQL rather than by summing the
 // per-user series so a caller that only needs the total doesn't pay for the
 // per-user grouping.
-func (s *Store) UsageDailyTotal(userIDs []int64, w UsageWindow) ([]UsageDay, error) {
-	cond, args := usageWhere(userIDs, w, "user_id")
+func (s *Store) UsageDailyTotal(f UsageFilter) ([]UsageDay, error) {
+	cond, args := usageWhere(f, "user_id", "package_id")
 	rows, err := s.db.Query(`
 		SELECT day, COALESCE(SUM(up),0), COALESCE(SUM(down),0)
 		  FROM traffic_daily
@@ -168,8 +192,8 @@ func (s *Store) UsageDailyTotal(userIDs []int64, w UsageWindow) ([]UsageDay, err
 // The package name is resolved in three steps because a package row can be
 // deleted while its traffic history must stay readable: the live packages row
 // first, then the name snapshot the user's own bucket kept, then a placeholder.
-func (s *Store) UsageByPackageWindowed(userIDs []int64, w UsageWindow) ([]UsageTotal, error) {
-	cond, args := usageWhere(userIDs, w, "t.user_id")
+func (s *Store) UsageByPackageWindowed(f UsageFilter) ([]UsageTotal, error) {
+	cond, args := usageWhere(f, "t.user_id", "t.package_id")
 	rows, err := s.db.Query(`
 		SELECT t.user_id, COALESCE(u.username,''), t.package_id,
 		       COALESCE(NULLIF(p.name,''),
@@ -195,11 +219,15 @@ func (s *Store) UsageByPackageWindowed(userIDs []int64, w UsageWindow) ([]UsageT
 // counters — accurate for the whole life of the account, including before the
 // rollup existed. Buckets of the same package are summed, so an account that
 // repurchased before renewal stacking reads as one package.
-func (s *Store) UsageByPackageLifetime(userIDs []int64) ([]UsageTotal, error) {
+func (s *Store) UsageByPackageLifetime(f UsageFilter) ([]UsageTotal, error) {
 	var cond string
 	var args []any
-	if clause, ids, ok := inClause(userIDs); ok {
-		cond = " AND b.user_id IN " + clause
+	if clause, ids, ok := inClause(f.UserIDs); ok {
+		cond += " AND b.user_id IN " + clause
+		args = append(args, ids...)
+	}
+	if clause, ids, ok := inClause(f.PackageIDs); ok {
+		cond += " AND b.package_id IN " + clause
 		args = append(args, ids...)
 	}
 	rows, err := s.db.Query(`
@@ -253,20 +281,54 @@ func usagePackageLabel(id int64, name string) string {
 	}
 }
 
-// UsageLifetimeByUser returns each selected user's all-time total from the
-// mirrored user counter.
-func (s *Store) UsageLifetimeByUser(userIDs []int64) ([]UsageTotal, error) {
-	cond := ""
+// UsageLifetimeByUser returns each selected user's all-time total.
+//
+// Source depends on whether a package filter is in play, and it has to:
+// users.used_* is a single scalar per account with no package dimension, so
+// under a package filter it would report the user's WHOLE lifetime traffic
+// while the table beside it shows only the filtered packages — two numbers on
+// one screen disagreeing, with the bigger one wrong. With a filter, the bucket
+// counters answer instead; they carry package_id and sum to the same total when
+// nothing is filtered.
+//
+// Without a filter the users row still wins, because it also covers buckets
+// that have since been deleted — traffic the bucket table can no longer account
+// for but the account really did use.
+func (s *Store) UsageLifetimeByUser(f UsageFilter) ([]UsageTotal, error) {
+	var cond string
 	var args []any
-	if clause, ids, ok := inClause(userIDs); ok {
+	if f.HasPackageFilter() {
+		if clause, ids, ok := inClause(f.UserIDs); ok {
+			cond += " AND b.user_id IN " + clause
+			args = append(args, ids...)
+		}
+		if clause, ids, ok := inClause(f.PackageIDs); ok {
+			cond += " AND b.package_id IN " + clause
+			args = append(args, ids...)
+		}
+		return s.scanLifetimeUsers(`
+			SELECT b.user_id, COALESCE(u.username,''), 0, '',
+			       COALESCE(SUM(b.used_up),0), COALESCE(SUM(b.used_down),0)
+			  FROM user_plans b
+			  LEFT JOIN users u ON u.id = b.user_id
+			 WHERE 1=1`+cond+`
+			 GROUP BY b.user_id
+			HAVING SUM(b.used_up) + SUM(b.used_down) > 0
+			 ORDER BY (SUM(b.used_up)+SUM(b.used_down)) DESC`, args...)
+	}
+	if clause, ids, ok := inClause(f.UserIDs); ok {
 		cond = " AND id IN " + clause
 		args = append(args, ids...)
 	}
-	rows, err := s.db.Query(`
+	return s.scanLifetimeUsers(`
 		SELECT id, username, 0, '', used_up, used_down
 		  FROM users
 		 WHERE role='user'`+cond+`
 		 ORDER BY (used_up+used_down) DESC`, args...)
+}
+
+func (s *Store) scanLifetimeUsers(q string, args ...any) ([]UsageTotal, error) {
+	rows, err := s.db.Query(q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -283,8 +345,8 @@ func (s *Store) UsageLifetimeByUser(userIDs []int64) ([]UsageTotal, error) {
 }
 
 // UsageWindowedByUser returns each selected user's total inside the window.
-func (s *Store) UsageWindowedByUser(userIDs []int64, w UsageWindow) ([]UsageTotal, error) {
-	cond, args := usageWhere(userIDs, w, "t.user_id")
+func (s *Store) UsageWindowedByUser(f UsageFilter) ([]UsageTotal, error) {
+	cond, args := usageWhere(f, "t.user_id", "t.package_id")
 	rows, err := s.db.Query(`
 		SELECT t.user_id, COALESCE(u.username,''), 0, '',
 		       COALESCE(SUM(t.up),0), COALESCE(SUM(t.down),0)
@@ -357,6 +419,50 @@ func (s *Store) UsageUserCandidates(q string, limit int) ([]UsageCandidate, erro
 		if err := rows.Scan(&c.ID, &c.Username, &c.Traffic); err != nil {
 			return nil, err
 		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// UsagePackageCandidate is one selectable package for the report's picker.
+type UsagePackageCandidate struct {
+	ID      int64  `json:"id"`
+	Name    string `json:"name"`
+	Traffic int64  `json:"traffic"` // recorded traffic, for ordering
+}
+
+// UsagePackageCandidates lists the packages that actually appear in the rollup,
+// heaviest first.
+//
+// Sourced from traffic_daily rather than from the packages table on purpose:
+// the picker must offer exactly what the report can filter to. A package with
+// no recorded traffic would filter to an empty screen, and — the other
+// direction — the pool and the unattributed bucket have no packages row at all
+// yet are two of the entries an admin most needs to isolate.
+func (s *Store) UsagePackageCandidates() ([]UsagePackageCandidate, error) {
+	rows, err := s.db.Query(`
+		SELECT t.package_id,
+		       COALESCE(NULLIF(p.name,''),
+		                NULLIF((SELECT b.name FROM user_plans b
+		                         WHERE b.package_id=t.package_id AND b.name<>''
+		                         ORDER BY b.id DESC LIMIT 1), ''),
+		                '') AS pkg_name,
+		       COALESCE(SUM(t.up),0) + COALESCE(SUM(t.down),0) AS v
+		  FROM traffic_daily t
+		  LEFT JOIN packages p ON p.id = t.package_id
+		 GROUP BY t.package_id
+		 ORDER BY v DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []UsagePackageCandidate
+	for rows.Next() {
+		var c UsagePackageCandidate
+		if err := rows.Scan(&c.ID, &c.Name, &c.Traffic); err != nil {
+			return nil, err
+		}
+		c.Name = usagePackageLabel(c.ID, c.Name)
 		out = append(out, c)
 	}
 	return out, rows.Err()

--- a/internal/store/usagereport_test.go
+++ b/internal/store/usagereport_test.go
@@ -121,7 +121,7 @@ func TestUsageByPackage_SplitsPerPackage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := st.UsageByPackageWindowed([]int64{uid}, UsageWindow{})
+	got, err := st.UsageByPackageWindowed(UsageFilter{UserIDs: []int64{uid}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func TestUsageWindow_FiltersByDay(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	all, err := st.UsageWindowedByUser([]int64{uid}, UsageWindow{})
+	all, err := st.UsageWindowedByUser(UsageFilter{UserIDs: []int64{uid}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestUsageWindow_FiltersByDay(t *testing.T) {
 		t.Fatalf("unbounded window = %+v, want 1010 total", all)
 	}
 
-	recent, err := st.UsageWindowedByUser([]int64{uid}, UsageWindow{From: DaysAgo(29)})
+	recent, err := st.UsageWindowedByUser(UsageFilter{UserIDs: []int64{uid}, Window: UsageWindow{From: DaysAgo(29)}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +176,7 @@ func TestUsageWindow_FiltersByDay(t *testing.T) {
 	}
 
 	// A window that ends before the old day sees nothing at all.
-	none, err := st.UsageWindowedByUser([]int64{uid}, UsageWindow{From: DaysAgo(60), To: DaysAgo(50)})
+	none, err := st.UsageWindowedByUser(UsageFilter{UserIDs: []int64{uid}, Window: UsageWindow{From: DaysAgo(60), To: DaysAgo(50)}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestUsageSelection_ScopesToChosenUsers(t *testing.T) {
 		}
 	}
 
-	all, err := st.UsageWindowedByUser(nil, UsageWindow{})
+	all, err := st.UsageWindowedByUser(UsageFilter{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ func TestUsageSelection_ScopesToChosenUsers(t *testing.T) {
 		t.Fatalf("no selection should mean everyone: got %d rows, want 3", len(all))
 	}
 
-	two, err := st.UsageWindowedByUser([]int64{ids["u1"], ids["u3"]}, UsageWindow{})
+	two, err := st.UsageWindowedByUser(UsageFilter{UserIDs: []int64{ids["u1"], ids["u3"]}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +241,7 @@ func TestUsageLifetime_IncludesPreRollupTraffic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	life, err := st.UsageLifetimeByUser([]int64{uid})
+	life, err := st.UsageLifetimeByUser(UsageFilter{UserIDs: []int64{uid}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +249,7 @@ func TestUsageLifetime_IncludesPreRollupTraffic(t *testing.T) {
 		t.Fatalf("lifetime = %+v, want 1000", life)
 	}
 
-	pkgs, err := st.UsageByPackageLifetime([]int64{uid})
+	pkgs, err := st.UsageByPackageLifetime(UsageFilter{UserIDs: []int64{uid}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,7 +258,7 @@ func TestUsageLifetime_IncludesPreRollupTraffic(t *testing.T) {
 	}
 
 	// The rollup, correctly, knows nothing about it.
-	win, err := st.UsageWindowedByUser([]int64{uid}, UsageWindow{})
+	win, err := st.UsageWindowedByUser(UsageFilter{UserIDs: []int64{uid}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestUsageDailySeries_PerUserOrdered(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	series, err := st.UsageDailyByUser([]int64{a, b}, UsageWindow{})
+	series, err := st.UsageDailyByUser(UsageFilter{UserIDs: []int64{a, b}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -424,7 +424,7 @@ func TestUsageDailySeries_PerUserOrdered(t *testing.T) {
 		t.Errorf("user a should have 2 distinct days, got %d", aDays)
 	}
 
-	total, err := st.UsageDailyTotal([]int64{a, b}, UsageWindow{})
+	total, err := st.UsageDailyTotal(UsageFilter{UserIDs: []int64{a, b}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -449,5 +449,235 @@ func TestUsageUserCandidates_EscapesWildcards(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].Username != "100%off" {
 		t.Errorf("search %q matched %+v, want only 100%%off", "100%", got)
+	}
+}
+
+// --- 套餐维度筛选 ---
+
+// The package filter must narrow every query the report draws from, and must
+// treat the two synthetic ids (pool = 0, unattributed = -1) as selectable —
+// they are exactly the entries an admin needs to isolate.
+func TestUsagePackageFilter_NarrowsWindowedQueries(t *testing.T) {
+	st := newRefundStore(t)
+	uid := mkUser(t, st, "gina")
+	basic := mkPlan(t, st, "基础版", 10, 100, 30)
+	pro := mkPlan(t, st, "专业版", 20, 200, 30)
+	buy(t, st, uid, basic)
+	buy(t, st, uid, pro)
+
+	rows, err := st.db.Query(`SELECT client_name, package_id FROM user_plans WHERE user_id=? AND kind='plan' ORDER BY id`, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type bk struct {
+		name string
+		pkg  int64
+	}
+	var bks []bk
+	for rows.Next() {
+		var b bk
+		if err := rows.Scan(&b.name, &b.pkg); err != nil {
+			t.Fatal(err)
+		}
+		bks = append(bks, b)
+	}
+	rows.Close()
+	if len(bks) != 2 {
+		t.Fatalf("want 2 plan buckets, got %d", len(bks))
+	}
+
+	if _, err := st.AddUsageBatch(map[string]UsageDelta{
+		bks[0].name: {Up: 1000, Down: 1000},
+		bks[1].name: {Up: 30, Down: 30},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	only := UsageFilter{PackageIDs: []int64{bks[0].pkg}}
+
+	byUser, err := st.UsageWindowedByUser(only)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(byUser) != 1 || byUser[0].Up+byUser[0].Down != 2000 {
+		t.Errorf("per-user under package filter = %+v, want 2000", byUser)
+	}
+
+	byPkg, err := st.UsageByPackageWindowed(only)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(byPkg) != 1 || byPkg[0].PackageID != bks[0].pkg {
+		t.Errorf("per-package under filter = %+v, want only package %d", byPkg, bks[0].pkg)
+	}
+
+	total, err := st.UsageDailyTotal(only)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sum int64
+	for _, d := range total {
+		sum += d.Up + d.Down
+	}
+	if sum != 2000 {
+		t.Errorf("daily total under package filter = %d, want 2000", sum)
+	}
+
+	series, err := st.UsageDailyByUser(only)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ssum int64
+	for _, s := range series {
+		for _, d := range s.Days {
+			ssum += d.Up + d.Down
+		}
+	}
+	if ssum != 2000 {
+		t.Errorf("per-user series under package filter = %d, want 2000 — the trend chart would disagree with the table", ssum)
+	}
+}
+
+// Lifetime mode is the trap: users.used_* is a scalar with no package
+// dimension, so under a package filter it must NOT be the source, or the KPI
+// would show the account's whole lifetime beside a table showing one package.
+func TestUsagePackageFilter_LifetimeUsesBucketCounters(t *testing.T) {
+	st := newRefundStore(t)
+	uid := mkUser(t, st, "hana")
+	basic := mkPlan(t, st, "基础版", 10, 100, 30)
+	pro := mkPlan(t, st, "专业版", 20, 200, 30)
+	buy(t, st, uid, basic)
+	buy(t, st, uid, pro)
+
+	var pkgOfBasic int64
+	if err := st.db.QueryRow(`SELECT package_id FROM user_plans WHERE user_id=? AND package_id=?`,
+		uid, basic.ID).Scan(&pkgOfBasic); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.db.Exec(`UPDATE user_plans SET used_up=700, used_down=300 WHERE user_id=? AND package_id=?`, uid, basic.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.db.Exec(`UPDATE user_plans SET used_up=40, used_down=60 WHERE user_id=? AND package_id=?`, uid, pro.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.db.Exec(`UPDATE users SET used_up=740, used_down=360 WHERE id=?`, uid); err != nil {
+		t.Fatal(err)
+	}
+
+	unfiltered, err := st.UsageLifetimeByUser(UsageFilter{UserIDs: []int64{uid}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unfiltered) != 1 || unfiltered[0].Up+unfiltered[0].Down != 1100 {
+		t.Fatalf("unfiltered lifetime = %+v, want 1100 (the users counter)", unfiltered)
+	}
+
+	filtered, err := st.UsageLifetimeByUser(UsageFilter{UserIDs: []int64{uid}, PackageIDs: []int64{pkgOfBasic}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) != 1 || filtered[0].Up+filtered[0].Down != 1000 {
+		t.Errorf("lifetime under package filter = %+v, want 1000 (基础版 only) — "+
+			"reading users.used_* here would report the whole account", filtered)
+	}
+
+	byPkg, err := st.UsageByPackageLifetime(UsageFilter{UserIDs: []int64{uid}, PackageIDs: []int64{pkgOfBasic}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(byPkg) != 1 || byPkg[0].Up+byPkg[0].Down != 1000 {
+		t.Errorf("lifetime by package under filter = %+v, want a single 1000 row", byPkg)
+	}
+	// The two must agree — they are shown side by side on one screen.
+	if filtered[0].Up+filtered[0].Down != byPkg[0].Up+byPkg[0].Down {
+		t.Errorf("KPI (%d) and table (%d) disagree under the same filter",
+			filtered[0].Up+filtered[0].Down, byPkg[0].Up+byPkg[0].Down)
+	}
+}
+
+// The pool (0) and the unattributed bucket (-1) must be selectable, and the
+// picker must offer them — they have no `packages` row to join to.
+func TestUsagePackageCandidates_IncludesSyntheticIDs(t *testing.T) {
+	st := newRefundStore(t)
+	uid := mkUser(t, st, "ian")
+	pkg := mkPlan(t, st, "真套餐", 10, 100, 30)
+	buy(t, st, uid, pkg)
+	if _, err := st.AddUsageBatch(map[string]UsageDelta{
+		clientNameOf(t, st, uid, "plan"): {Up: 5, Down: 5},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Pool + pre-rollup rows, as an upgraded install would have.
+	for _, r := range []struct {
+		pkgID int64
+		bkt   int64
+		bytes int64
+	}{{0, 900, 40}, {PackageIDUnattributed, 0, 70}} {
+		if _, err := st.db.Exec(`INSERT INTO traffic_daily (day, user_id, bucket_id, package_id, up, down)
+			VALUES (?,?,?,?,?,?)`, DaysAgo(2), uid, r.bkt, r.pkgID, r.bytes, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := st.UsagePackageCandidates()
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := map[int64]string{}
+	for _, c := range got {
+		names[c.ID] = c.Name
+	}
+	if names[0] != poolPackageName {
+		t.Errorf("pool missing or unlabelled: %+v", got)
+	}
+	if names[PackageIDUnattributed] != unattributedPackageName {
+		t.Errorf("unattributed missing or unlabelled: %+v", got)
+	}
+	if names[pkg.ID] != "真套餐" {
+		t.Errorf("real package missing: %+v", got)
+	}
+	for _, c := range got {
+		if c.Name == "" {
+			t.Errorf("candidate %d has an empty label — renders as a blank picker row", c.ID)
+		}
+	}
+
+	// And filtering to a synthetic id actually works.
+	poolOnly, err := st.UsageWindowedByUser(UsageFilter{PackageIDs: []int64{0}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(poolOnly) != 1 || poolOnly[0].Up+poolOnly[0].Down != 40 {
+		t.Errorf("pool-only filter = %+v, want 40", poolOnly)
+	}
+}
+
+// User and package filters must intersect, not union.
+func TestUsageFilters_Intersect(t *testing.T) {
+	st := newRefundStore(t)
+	pkgA := mkPlan(t, st, "A", 10, 100, 30)
+	pkgB := mkPlan(t, st, "B", 10, 100, 30)
+	u1 := mkUser(t, st, "j1")
+	u2 := mkUser(t, st, "j2")
+	for _, u := range []int64{u1, u2} {
+		buy(t, st, u, pkgA)
+		buy(t, st, u, pkgB)
+		rows, _ := st.db.Query(`SELECT client_name FROM user_plans WHERE user_id=? AND kind='plan'`, u)
+		for rows.Next() {
+			var n string
+			_ = rows.Scan(&n)
+			if _, err := st.AddUsageBatch(map[string]UsageDelta{n: {Up: 10, Down: 0}}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		rows.Close()
+	}
+
+	got, err := st.UsageWindowedByUser(UsageFilter{UserIDs: []int64{u1}, PackageIDs: []int64{pkgA.ID}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].UserID != u1 || got[0].Up+got[0].Down != 10 {
+		t.Errorf("u1 ∩ pkgA = %+v, want exactly one row of 10 bytes", got)
 	}
 }


### PR DESCRIPTION
上一版只有「用户」和「时间」两个筛选，套餐只是展示维度。生产上 34 行明细里想看清某个套餐是谁在用，只能靠眼睛扫。

## 为什么不能只在前端过滤

趋势图的数据是按「用户 × 天」聚合的，**不带套餐维度**。纯前端过滤只能改表格和环图，趋势图会跟着对不上——正是这个文件里写着要避免的「各图表各带筛选、口径互相打架」。

所以从查询层加。

## 改动

**store**
- 三个筛选维度合并成 `UsageFilter` 结构体，一并下推到全部六个查询。第三个维度用位置参数穿过六个函数，是其中某个悄悄按错东西过滤的经典写法。
- 新增 `UsagePackageCandidates`：候选来自 `traffic_daily` 而非 `packages` 表——选择器必须只提供报表**真能筛到**的东西。没有流量的套餐筛出来是空屏；而公共池和「未记录套餐」压根没有 `packages` 行，却恰恰是最需要单独看的两项。

**API**
- 新增 `packages=` 参数与 `/api/admin/stats/usage/packages` 端点
- 用户 id 仍拒绝非正数，套餐 id **必须放行 0（公共池）和 -1（升级前未归属）**

**前端**
- 套餐多选筛选器
- 环图扇区 / 排行柱条**点击即筛**，再点取消
- 未选中的扇区降透明度，筛选状态在图上直接可见
- 监听器只在 echarts 实例创建时绑一次（`setOption` 不清监听器，每次重画都绑会导致点一下触发 N 次请求）

## 累计口径下的一个陷阱

`users.used_*` 是每账户一个标量，**没有套餐维度**。若在套餐筛选下仍读它，KPI 会显示该账户的**全部**历史流量，而旁边的表只显示被筛的套餐——同一屏两个数字打架，且更大的那个是错的。

所以：有套餐筛选时改读 bucket 计数器（带 `package_id`，无筛选时两者总额相等）；无筛选时仍走 `users` 行，因为它还涵盖了已被删除的 bucket 那部分流量。

实测确认：

| 场景 | KPI | 明细表 |
|---|---|---|
| mllt 账户，不筛套餐 | 22.32 GB | — |
| mllt 账户，筛「索隆云」 | **6.47 GB** | **6.47 GB** ✓ |

## 验证

本地灌 5 用户 / 4 套餐 / 21 天数据实跑（种子走真实 `AddUsageBatch` 写入路径）：

| 检查 | 结果 |
|---|---|
| 套餐筛选后 用户合计 = 套餐合计 = 曲线合计 | ✓ 15.69 GB |
| 结果只含被选套餐 | ✓ |
| 用户 ∩ 套餐 为交集而非并集 | ✓ |
| 累计口径下 KPI 与明细表一致 | ✓ |

新增 4 个 store 测试：筛选下推到全部查询、累计口径改用 bucket 计数器、合成 id（公共池 / 未归属）可选可筛、两个维度求交。

全量 `go build` / `go vet` / `go test ./...` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
