### PR TITLE
feat(settings): 「节点对外地址」能自动获取，别让人自己去猜源站 IP

### DIFF
--- a/frontend/src/views/AdminSettings.vue
+++ b/frontend/src/views/AdminSettings.vue
@@ -53,8 +53,23 @@
                出现在任何人的订阅里 —— 节点建好了、套餐也生效，订阅却是空的。 -->
           <n-form-item label="节点对外地址">
             <div style="width:100%;max-width:560px;">
-              <n-input v-model:value="form.node_host_override"
-                placeholder="留空 = 用第一台已启用服务器的地址" style="max-width:420px;" />
+              <n-input-group style="max-width:420px;">
+                <n-input v-model:value="form.node_host_override"
+                  placeholder="留空 = 用第一台已启用服务器的地址" />
+                <n-button ghost :loading="detecting" @click="detectNodeHost">自动获取</n-button>
+              </n-input-group>
+              <!-- 探测只给候选、不直接落库：填错的代价不对等。留空的表现是「共 0 个
+                   节点」，一眼看得出；静默填错（比如橙云代理的域名）变成「订阅里
+                   有链接但连不上」，排查成本高得多。所以来源要摆在眼前让人挑。 -->
+              <div v-if="hostCandidates.length" class="host-cands">
+                <div class="host-cands-t">点一条填入：</div>
+                <button v-for="c in hostCandidates" :key="c.value" type="button"
+                  class="host-cand" @click="pickNodeHost(c)">
+                  <span class="host-cand-v">{{ c.value }}</span>
+                  <span class="host-cand-l">{{ c.label }}<template v-if="c.recommended"> · 推荐</template></span>
+                  <span class="host-cand-n">{{ c.note }}</span>
+                </button>
+              </div>
               <p style="font-size:12px;color:var(--text-3);margin-top:6px;line-height:1.7;">
                 写进订阅里的节点地址（只填域名或 IP，不带端口和 <code>http://</code>）。留空时自动取第一台已启用「服务器」的地址。
                 <b>节点跑在面板本机时必须填这里</b> —— 本机不是一条「服务器」记录（它不需要 SSH 下发），
@@ -284,6 +299,31 @@ function envLocked(key: string): boolean {
   return (form._env_keys || '').split(',').includes(key)
 }
 
+type NodeHostCandidate = { value: string; source: string; label: string; note: string; recommended?: boolean }
+const detecting = ref(false)
+const hostCandidates = ref<NodeHostCandidate[]>([])
+
+// 「节点对外地址」自动获取：后端并发探出口 IP，并把面板访问地址、第一台已启用
+// 服务器、本机网卡一起作为候选返回。只有一条时直接填，多条时列出来让管理员挑。
+async function detectNodeHost() {
+  detecting.value = true
+  try {
+    const res = await apiGet<{ candidates: NodeHostCandidate[] }>('/api/admin/settings/detect-node-host')
+    const list = res?.candidates || []
+    hostCandidates.value = list
+    if (!list.length) { message.warning('没探测到可用地址，请手动填写'); return }
+    // 只有「实测出来的那条」才直接填。剩下的（面板访问地址、本机网卡）都带着
+    // 「什么时候不能用」的说明，得让人看过再点。
+    if (list.length === 1 && list[0].recommended) pickNodeHost(list[0])
+  } catch (e: any) { message.error(e.message || '探测失败') } finally { detecting.value = false }
+}
+
+function pickNodeHost(c: NodeHostCandidate) {
+  form.node_host_override = c.value
+  hostCandidates.value = []
+  message.success(`已填入 ${c.value}（${c.label}），记得点保存`)
+}
+
 async function copyInstall() {
   try {
     await navigator.clipboard.writeText(installCmd.value)
@@ -392,6 +432,15 @@ onMounted(async () => {
 .cf-guide ol { margin: 0; padding-left: 20px; display: flex; flex-direction: column; gap: 6px; }
 .cf-guide li { font-size: 12.5px; color: var(--text-2); line-height: 1.6; }
 .cf-guide a { color: var(--accent-strong); }
+.host-cands { margin-top: 8px; display: flex; flex-direction: column; gap: 6px; }
+.host-cands-t { font-size: 12px; color: var(--text-3); }
+.host-cand { display: grid; grid-template-columns: auto 1fr; gap: 2px 10px; width: 100%; max-width: 420px;
+  text-align: left; background: var(--bg-soft); border: 1px solid var(--border); border-radius: 8px;
+  padding: 8px 10px; cursor: pointer; font: inherit; }
+.host-cand:hover { border-color: var(--accent-strong); }
+.host-cand-v { font-family: monospace; font-size: 13px; color: var(--text); }
+.host-cand-l { font-size: 12px; color: var(--text-2); align-self: center; }
+.host-cand-n { grid-column: 1 / -1; font-size: 11.5px; color: var(--text-3); line-height: 1.6; }
 .cf-guide-n { margin-top: 10px; font-size: 12px; color: var(--text-3); line-height: 1.55; }
 .cf-guide code { background: var(--border); padding: 0 4px; border-radius: 4px; }
 </style>

--- a/internal/api/nodehost_admin.go
+++ b/internal/api/nodehost_admin.go
@@ -1,0 +1,332 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Auto-detection for 「节点对外地址」(node_host_override).
+//
+// nodeHost() only knows two things: the override, and the first enabled
+// server's host. A node running on the panel's own machine is neither — the
+// panel host is not a servers row (it needs no SSH delivery) — so the address
+// resolves to empty and every subscription comes back with no self-built links
+// at all. That is the case this endpoint exists for.
+//
+// It *suggests*, it does not decide. A silent server-side fallback would trade
+// a loud failure ("共 0 个节点", obviously broken) for a quiet one (links that
+// exist but never connect, e.g. a Cloudflare-proxied hostname), which is far
+// more expensive to diagnose. So the candidates are handed to the admin with
+// their provenance and they pick.
+
+type nodeHostCandidate struct {
+	Value       string `json:"value"`
+	Source      string `json:"source"`
+	Label       string `json:"label"`
+	Note        string `json:"note"`
+	Recommended bool   `json:"recommended"`
+}
+
+// nodeHostEchoURLs are the IP-echo services probed to learn this machine's own
+// egress address. Same set the egress checker uses (see egressEchoURLs); more
+// than one because any single service is blocked somewhere.
+var nodeHostEchoURLs = []string{
+	"https://api.ip.sb/ip",
+	"https://ifconfig.me/ip",
+	"https://ipinfo.io/ip",
+}
+
+// Budget: the echo probes run concurrently under one deadline, so the whole
+// handler costs about this much wall-clock in the worst case. Kept far below
+// the server's 30s WriteTimeout — a handler that outlives it reports failure to
+// the browser while having succeeded, with nothing in the log to say so.
+const nodeHostProbeTimeout = 4 * time.Second
+
+// GET /api/admin/settings/detect-node-host — suggest values for 节点对外地址.
+func (a *API) handleDetectNodeHost(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), nodeHostProbeTimeout)
+	defer cancel()
+
+	echoed := detectEgressIPs(ctx)
+	out := append([]nodeHostCandidate{}, echoed...)
+	out = append(out, a.configuredNodeHostCandidates()...)
+	// Private NIC addresses only when the echo probes found nothing: a machine
+	// with no working outbound is the LAN/intranet case, where a private address
+	// really is what clients dial. Otherwise they are pure noise — a host with
+	// VPN, container and hypervisor adapters has several, none of them the
+	// answer, and they would bury the one that is.
+	out = append(out, localInterfaceCandidates(len(echoed) == 0)...)
+	out = dedupeNodeHostCandidates(out)
+	// Only a measured address is endorsed. The configured 访问地址 is the one
+	// candidate that is routinely wrong (橙云), so when the probes are blocked
+	// and it is all that is left, it is offered — with its warning — but never
+	// marked 推荐 and never filled in without the admin reading it.
+	for i := range out {
+		if out[i].Source == "echo" {
+			out[i].Recommended = true
+			break
+		}
+	}
+	ok(w, J{"candidates": out})
+}
+
+// detectEgressIPs asks the echo services what address this machine comes from,
+// once per family so a dual-stack host gets both listed separately instead of
+// whichever one the dialer happened to pick.
+func detectEgressIPs(ctx context.Context) []nodeHostCandidate {
+	type result struct {
+		family string
+		ip     string
+		via    string
+	}
+	var (
+		mu   sync.Mutex
+		hits []result
+		wg   sync.WaitGroup
+	)
+	for _, family := range []string{"tcp4", "tcp6"} {
+		client := echoClient(family)
+		for _, u := range nodeHostEchoURLs {
+			wg.Add(1)
+			go func(family, u string) {
+				defer wg.Done()
+				ip := fetchEchoIP(ctx, client, u)
+				if ip == "" {
+					return
+				}
+				mu.Lock()
+				hits = append(hits, result{family: family, ip: ip, via: echoServiceName(u)})
+				mu.Unlock()
+			}(family, u)
+		}
+	}
+	wg.Wait()
+
+	var out []nodeHostCandidate
+	for _, family := range []string{"tcp4", "tcp6"} {
+		for _, h := range hits {
+			if h.family != family {
+				continue
+			}
+			label := "公网出口 IPv4"
+			if family == "tcp6" {
+				label = "公网出口 IPv6"
+			}
+			out = append(out, nodeHostCandidate{
+				Value:  h.ip,
+				Source: "echo",
+				Label:  label,
+				Note:   "面板所在机器的出口地址（" + h.via + " 回显）",
+			})
+			break // one per family; the rest of the services are redundancy
+		}
+	}
+	return out
+}
+
+// echoClient dials only the given family and never honors a proxy: the whole
+// point is to learn *this machine's* egress address, and an HTTP_PROXY picked
+// up from the environment would report the proxy's IP as if it were ours.
+func echoClient(network string) *http.Client {
+	dialer := &net.Dialer{Timeout: 2 * time.Second}
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
+				host, port, err := net.SplitHostPort(addr)
+				if err != nil {
+					return nil, err
+				}
+				ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+				if err != nil {
+					return nil, err
+				}
+				lastErr := errors.New("没有可用的 " + network + " 地址")
+				for _, ip := range ips {
+					v4 := ip.IP.To4() != nil
+					if isInternalIP(ip.IP) || (network == "tcp4") != v4 {
+						continue
+					}
+					c, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.IP.String(), port))
+					if err == nil {
+						return c, nil
+					}
+					lastErr = err
+				}
+				return nil, lastErr
+			},
+		},
+	}
+}
+
+// fetchEchoIP returns the IP literal the service echoed back, or "" for any
+// failure — a probe that cannot answer is simply one fewer candidate.
+func fetchEchoIP(ctx context.Context, c *http.Client, url string) string {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return ""
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 128))
+	if err != nil {
+		return ""
+	}
+	return parseEchoBody(body)
+}
+
+// parseEchoBody accepts only a public IP literal. A captive portal, an error
+// page or a service that answered with something else must yield nothing —
+// whatever comes back here would otherwise be written into every subscription.
+func parseEchoBody(body []byte) string {
+	ip := net.ParseIP(strings.TrimSpace(string(body)))
+	if ip == nil || isInternalIP(ip) {
+		return ""
+	}
+	return ip.String()
+}
+
+func echoServiceName(rawURL string) string {
+	s := strings.TrimPrefix(strings.TrimPrefix(rawURL, "https://"), "http://")
+	if i := strings.IndexByte(s, '/'); i > 0 {
+		s = s[:i]
+	}
+	return s
+}
+
+// configuredNodeHostCandidates offers what the panel already knows: the
+// configured 访问地址, and the server row nodeHost() falls back to today.
+func (a *API) configuredNodeHostCandidates() []nodeHostCandidate {
+	var out []nodeHostCandidate
+	// The *configured* base only — publicBase falls back to the request's Host,
+	// which is whatever the admin happens to be browsing (a LAN name, an SSH
+	// tunnel's localhost:8099). That guess is fine for building a link back to
+	// the panel and useless as an address clients dial.
+	base := os.Getenv("QZ_PUBLIC_BASE")
+	if base == "" {
+		base, _ = a.st.GetSetting("public_base")
+	}
+	if base != "" {
+		if h := hostOnly(normalizeBase(base)); h != "" && !isInternalHost(h) {
+			out = append(out, nodeHostCandidate{
+				Value:  h,
+				Source: "public_base",
+				Label:  "面板访问地址",
+				// The one candidate that is routinely wrong: behind Cloudflare's
+				// orange cloud this is the proxied hostname, which clients cannot
+				// reach on a node port. Say so where it is read, not in a doc.
+				Note: "面板挂在 Cloudflare 橙云等反代后面时不能用，要填源站 IP",
+			})
+		}
+	}
+	if servers, err := a.st.ListServers(); err == nil {
+		for _, sv := range servers {
+			if sv.Enabled && sv.Host != "" {
+				out = append(out, nodeHostCandidate{
+					Value:  sv.Host,
+					Source: "server",
+					Label:  "服务器「" + sv.Name + "」",
+					Note:   "留空时的当前默认取值（第一台已启用服务器）",
+				})
+				break
+			}
+		}
+	}
+	return out
+}
+
+// isInternalHost reports whether a bare host is something no client could dial:
+// a loopback/LAN IP literal, or a localhost name. Hostnames are not resolved —
+// a name that only resolves internally is the admin's call to make.
+func isInternalHost(h string) bool {
+	if ip := net.ParseIP(h); ip != nil {
+		return isInternalIP(ip)
+	}
+	h = strings.ToLower(h)
+	return h == "localhost" || strings.HasSuffix(h, ".localhost")
+}
+
+// hostOnly strips scheme, port and path from a base URL, leaving a bare host —
+// the field takes a host, not a URL.
+func hostOnly(base string) string {
+	s := base
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+	if i := strings.IndexAny(s, "/?#"); i >= 0 {
+		s = s[:i]
+	}
+	if h, _, err := net.SplitHostPort(s); err == nil {
+		s = h
+	}
+	return strings.Trim(strings.TrimSpace(s), "[]")
+}
+
+// localInterfaceCandidates lists addresses configured on this machine's NICs.
+// On a plain VPS the public one here matches the echo probe (and dedupes away);
+// includePrivate adds the LAN addresses, which are the right answer only when
+// the clients live on that LAN — see the caller.
+func localInterfaceCandidates(includePrivate bool) []nodeHostCandidate {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil
+	}
+	var out []nodeHostCandidate
+	for _, a := range addrs {
+		ipn, okAddr := a.(*net.IPNet)
+		if !okAddr || ipn.IP == nil {
+			continue
+		}
+		ip := ipn.IP
+		// Loopback and link-local are never reachable by a client. Note that a
+		// global IPv6 here may still be a privacy/temporary address (they are
+		// indistinguishable through InterfaceAddrs, which exposes no address
+		// flags) — one more reason these are last resort, below a measured
+		// egress address, and never the recommended pick.
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+			continue
+		}
+		c := nodeHostCandidate{Value: ip.String(), Source: "iface", Label: "本机网卡"}
+		if isInternalIP(ip) {
+			if !includePrivate {
+				continue
+			}
+			c.Note = "内网地址，只有同一局域网的客户端能连"
+		} else {
+			c.Note = "网卡上直接配置的公网地址"
+		}
+		out = append(out, c)
+		if len(out) >= 4 {
+			break
+		}
+	}
+	return out
+}
+
+// dedupeNodeHostCandidates keeps the first occurrence of each address, so a
+// value that several sources agree on is shown once, attributed to the most
+// trustworthy source (the slice is assembled in descending confidence).
+func dedupeNodeHostCandidates(in []nodeHostCandidate) []nodeHostCandidate {
+	seen := map[string]bool{}
+	out := make([]nodeHostCandidate, 0, len(in))
+	for _, c := range in {
+		if c.Value == "" || seen[c.Value] {
+			continue
+		}
+		seen[c.Value] = true
+		out = append(out, c)
+	}
+	return out
+}

--- a/internal/api/nodehost_admin.go
+++ b/internal/api/nodehost_admin.go
@@ -63,17 +63,7 @@ func (a *API) handleDetectNodeHost(w http.ResponseWriter, r *http.Request) {
 	// VPN, container and hypervisor adapters has several, none of them the
 	// answer, and they would bury the one that is.
 	out = append(out, localInterfaceCandidates(len(echoed) == 0)...)
-	out = dedupeNodeHostCandidates(out)
-	// Only a measured address is endorsed. The configured 访问地址 is the one
-	// candidate that is routinely wrong (橙云), so when the probes are blocked
-	// and it is all that is left, it is offered — with its warning — but never
-	// marked 推荐 and never filled in without the admin reading it.
-	for i := range out {
-		if out[i].Source == "echo" {
-			out[i].Recommended = true
-			break
-		}
-	}
+	out = recommendMeasured(dedupeNodeHostCandidates(out))
 	ok(w, J{"candidates": out})
 }
 
@@ -93,6 +83,11 @@ func detectEgressIPs(ctx context.Context) []nodeHostCandidate {
 	)
 	for _, family := range []string{"tcp4", "tcp6"} {
 		client := echoClient(family)
+		// The client is per-call, so its keep-alive connections have no second
+		// user and nothing to time them out (a zero-value Transport keeps idle
+		// conns forever). Left open, every click parks up to six established TLS
+		// connections, and their read loops, until the far end happens to hang up.
+		defer client.CloseIdleConnections()
 		for _, u := range nodeHostEchoURLs {
 			wg.Add(1)
 			go func(family, u string) {
@@ -313,6 +308,21 @@ func localInterfaceCandidates(includePrivate bool) []nodeHostCandidate {
 		}
 	}
 	return out
+}
+
+// recommendMeasured endorses at most one candidate, and only one we actually
+// measured. The configured 访问地址 is the candidate that is routinely wrong
+// (橙云 proxies it), so when the probes are blocked and it is all that is left
+// it is still offered — with its warning — but never marked 推荐, and the UI
+// keys its one-click fill off this flag rather than off "there is only one".
+func recommendMeasured(in []nodeHostCandidate) []nodeHostCandidate {
+	for i := range in {
+		if in[i].Source == "echo" {
+			in[i].Recommended = true
+			break
+		}
+	}
+	return in
 }
 
 // dedupeNodeHostCandidates keeps the first occurrence of each address, so a

--- a/internal/api/nodehost_admin_test.go
+++ b/internal/api/nodehost_admin_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"net"
+	"testing"
+
+	"qingzhou/internal/store"
+)
+
+func TestHostOnlyStripsSchemePortAndPath(t *testing.T) {
+	cases := map[string]string{
+		"https://panel.example.com":            "panel.example.com",
+		"http://1.2.3.4:8081":                  "1.2.3.4",
+		"https://panel.example.com:8443/sub?x": "panel.example.com",
+		"http://[2001:db8::1]:8081":            "2001:db8::1",
+		"1.2.3.4":                              "1.2.3.4",
+	}
+	for in, want := range cases {
+		if got := hostOnly(in); got != want {
+			t.Errorf("hostOnly(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// The field takes a bare host, so a configured 访问地址 has to arrive stripped —
+// pasting "https://panel.example.com" into a node address would produce links
+// nothing can dial.
+func TestConfiguredNodeHostCandidates(t *testing.T) {
+	a, st := newNodeUpgradeAPI(t)
+	if err := st.SetSetting("public_base", "https://panel.example.com:8443"); err != nil {
+		t.Fatal(err)
+	}
+	// A disabled row must not be offered: it is not what nodeHost() would pick.
+	if _, err := st.CreateServer(store.Server{Name: "off", Host: "10.0.0.9", Enabled: false}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateServer(store.Server{Name: "hk", Host: "1.2.3.4", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := a.configuredNodeHostCandidates()
+	if len(got) != 2 {
+		t.Fatalf("want 访问地址 + 已启用服务器, got %+v", got)
+	}
+	if got[0].Source != "public_base" || got[0].Value != "panel.example.com" {
+		t.Errorf("public_base candidate = %+v", got[0])
+	}
+	if got[1].Source != "server" || got[1].Value != "1.2.3.4" {
+		t.Errorf("server candidate = %+v", got[1])
+	}
+}
+
+// Sources overlap constantly (the echo probe and the server row are the same
+// machine on a single-node install). Showing one address twice would read as
+// two different answers.
+func TestDedupeNodeHostCandidatesKeepsMostTrustedSource(t *testing.T) {
+	got := dedupeNodeHostCandidates([]nodeHostCandidate{
+		{Value: "1.2.3.4", Source: "echo"},
+		{Value: "1.2.3.4", Source: "server"},
+		{Value: "", Source: "public_base"},
+		{Value: "2001:db8::1", Source: "iface"},
+	})
+	if len(got) != 2 {
+		t.Fatalf("want 2 distinct non-empty candidates, got %+v", got)
+	}
+	if got[0].Source != "echo" {
+		t.Errorf("first occurrence wins (highest confidence first): %+v", got[0])
+	}
+	if got[1].Value != "2001:db8::1" {
+		t.Errorf("second candidate = %+v", got[1])
+	}
+}
+
+// With 访问地址 unset, publicBase() would answer with the request's Host —
+// which for an admin on an SSH tunnel is "localhost:8099". Suggesting that as
+// the address written into every client's subscription is worse than
+// suggesting nothing.
+func TestConfiguredNodeHostCandidatesSkipUnreachableBase(t *testing.T) {
+	a, st := newNodeUpgradeAPI(t)
+	for _, base := range []string{"", "http://localhost:8099", "http://127.0.0.1:8099", "http://192.168.1.10"} {
+		if err := st.SetSetting("public_base", base); err != nil {
+			t.Fatal(err)
+		}
+		for _, c := range a.configuredNodeHostCandidates() {
+			if c.Source == "public_base" {
+				t.Errorf("public_base %q offered as %q", base, c.Value)
+			}
+		}
+	}
+}
+
+// A dev box or a VPS with containers has a handful of private NIC addresses
+// (docker0, WSL, hypervisor bridges), none of which any client can dial. They
+// are only offered when the echo probes came back empty.
+func TestLocalInterfaceCandidatesHidePrivateUnlessAsked(t *testing.T) {
+	for _, c := range localInterfaceCandidates(false) {
+		ip := net.ParseIP(c.Value)
+		if ip == nil {
+			t.Fatalf("candidate %q is not an IP literal", c.Value)
+		}
+		if isInternalIP(ip) {
+			t.Errorf("private address %s offered without includePrivate", c.Value)
+		}
+	}
+}
+
+// The echo probe must reject anything that is not a usable public address —
+// a captive portal or an error page would otherwise be written into every
+// subscription link.
+func TestFetchEchoIPRejectsNonPublicBodies(t *testing.T) {
+	for _, body := range []string{"", "127.0.0.1", "10.0.0.5", "100.64.0.1", "<html>error</html>", "not an ip"} {
+		if ip := parseEchoBody([]byte(body)); ip != "" {
+			t.Errorf("body %q accepted as %q", body, ip)
+		}
+	}
+	if ip := parseEchoBody([]byte(" 203.0.113.7\n")); ip != "203.0.113.7" {
+		t.Errorf("public IP body = %q, want 203.0.113.7", ip)
+	}
+}

--- a/internal/api/nodehost_admin_test.go
+++ b/internal/api/nodehost_admin_test.go
@@ -104,6 +104,37 @@ func TestLocalInterfaceCandidatesHidePrivateUnlessAsked(t *testing.T) {
 	}
 }
 
+// 推荐 doubles as the UI's permission to fill the field in one click, so it
+// must never land on a guess. The 访问地址 candidate is the one that is
+// routinely wrong (橙云 proxies it) and it is exactly what remains when the
+// probes are blocked — the case where an unearned 推荐 would do damage.
+func TestRecommendOnlyMeasuredCandidates(t *testing.T) {
+	noEcho := recommendMeasured([]nodeHostCandidate{
+		{Value: "panel.example.com", Source: "public_base"},
+		{Value: "1.2.3.4", Source: "server"},
+	})
+	for _, c := range noEcho {
+		if c.Recommended {
+			t.Errorf("unmeasured candidate recommended: %+v", c)
+		}
+	}
+
+	withEcho := recommendMeasured([]nodeHostCandidate{
+		{Value: "panel.example.com", Source: "public_base"},
+		{Value: "45.12.88.125", Source: "echo"},
+		{Value: "203.0.113.9", Source: "echo"},
+	})
+	var rec []string
+	for _, c := range withEcho {
+		if c.Recommended {
+			rec = append(rec, c.Value)
+		}
+	}
+	if len(rec) != 1 || rec[0] != "45.12.88.125" {
+		t.Errorf("want exactly the first measured candidate recommended, got %v", rec)
+	}
+}
+
 // The echo probe must reject anything that is not a usable public address —
 // a captive portal or an error page would otherwise be written into every
 // subscription link.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -215,6 +215,7 @@ func (a *API) Router() http.Handler {
 		ar.Put("/api/admin/settings", a.handlePutSettings)
 		ar.Get("/api/admin/settings/default-templates", a.handleGetDefaultTemplates)
 		ar.Post("/api/admin/settings/test-smtp", a.handleTestSMTP)
+		ar.Get("/api/admin/settings/detect-node-host", a.handleDetectNodeHost)
 		ar.Post("/api/admin/rebuild", a.handleAdminRebuild)
 		ar.Get("/api/admin/backup", a.handleAdminBackup)
 		// Which sing-box each node runs, plus a per-node reinstall.


### PR DESCRIPTION
## 为什么

节点跑在面板本机时，「节点对外地址」必须手填 —— 本机不是一条「服务器」记录（它不需要 SSH 下发），`nodeHost()` 的自动取值取不到，订阅静默为空，节点列表显示「共 0 个节点」。可这栏该填什么，面板一直没告诉过人：挂在 Cloudflare 橙云后面要填**源站 IP**，而源站 IP 恰恰是管理员手边最难查的一个值。

## 做了什么

新增 `GET /api/admin/settings/detect-node-host`（管理员鉴权），返回按可信度排序的候选：

1. **出口 IP 实测** —— 并发问 `api.ip.sb` / `ifconfig.me` / `ipinfo.io`，v4/v6 各探一遍分开列。
2. **面板访问地址** —— 只取配置过的 `public_base` / `QZ_PUBLIC_BASE`。
3. **第一台已启用服务器** —— 也就是 `nodeHost()` 现在的默认取值。
4. **本机网卡** —— 公网地址常驻，私网地址只在出口探测全失败时出现。

设置页输入框旁加「自动获取」，候选连同各自来源和「什么时候不能用」列出来让人点。

## 刻意没做的

**不静默兜底，`nodeHost()` 的取值链一行没动。** 留空的表现是「共 0 个节点」，一眼看得出；猜错则是「订阅里有链接但连不上」，排查成本高得多。同理只有实测到的出口地址才标「推荐」、才允许唯一候选时一键直接填入 —— 访问地址那条哪怕是唯一候选，也要人看过 CDN 提示再点。

## 几处只在真机上才会露头的取舍

- 探测客户端不设 `Proxy`：环境里的 `HTTP_PROXY` 会把代理的 IP 报成我们的。
- 不走 `publicBase()` 回落请求 Host 那条 —— 管理员从 SSH 隧道进来时那是 `localhost:8099`；内网 / loopback / `localhost` 一律不给。
- 回显体只接受公网 IP 字面量，错误页和内网地址一律丢弃。
- 私网网卡地址默认隐藏，否则 docker / WSL / hypervisor 那堆网卡会把真答案挤下去。
- 整个 handler 4s 封顶，离 30s WriteTimeout 很远。

## 验证

- 本地起面板（全新 DB）实跑：接口 1.2s 返回，探到出口 IPv4 并标为推荐；未配置访问地址时 `127.0.0.1` 那条不出现。
- 页面点「自动获取」→ 列出候选 → 点选 → 输入框填入并提示 → 保存后回读 `node_host_override` 一致。
- `go test ./internal/api/` 全绿，新增 6 个用例（`hostOnly` 剥 scheme/端口/v6 方括号、候选装配与去重、不可达 base 过滤、私网网卡默认隐藏、回显体解析）。`npx vite build` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
