### PR TITLE
fix: 未验证邮箱的账号可登录并获取节点订阅（email_verify_required 失效）

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -147,6 +147,16 @@ func (a *API) handleLogin(w http.ResponseWriter, r *http.Request) {
 		fail(w, http.StatusForbidden, "账号已被封禁")
 		return
 	}
+	// Email verification gate: when email_verify_required is on, an unverified
+	// account must not log in — registration deferred provisioning until verify,
+	// so letting them in would expose the account page while the account is still
+	// half-created. Admins are always pre-verified and exempt.
+	if u.Role != "admin" {
+		if verify, _ := a.st.GetSettingBool("email_verify_required"); verify && !u.EmailVerified {
+			fail(w, http.StatusForbidden, "请先完成邮箱验证后再登录，请查收注册邮件（若未收到请联系管理员）")
+			return
+		}
+	}
 
 	tok, err := a.issueLogin(w, r, u)
 	if err != nil {

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -842,6 +842,14 @@ func (a *API) handleSub(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().Unix()
 	serviceable := (u.ExpiryAt == 0 || u.ExpiryAt > now) &&
 		(u.TrafficLimit == 0 || u.UsedUp+u.UsedDown < u.TrafficLimit)
+	// Email verification gate: an unverified account must not be served any
+	// node links. External nodes carry raw upstream credentials that the panel
+	// cannot meter or revoke — with verify_required on, withholding them until
+	// verified is the whole point of the setting. Self-built access is moot too
+	// since provisioning is deferred until verification.
+	if verifyReq, _ := a.st.GetSettingBool("email_verify_required"); verifyReq && u.Role != "admin" && !u.EmailVerified {
+		serviceable = false
+	}
 
 	// Build the link list + a link→group map (drives the per-group auto-select
 	// groups), honoring the user's per-node blocklist.


### PR DESCRIPTION
## 问题

开启「注册邮箱认证」（`email_verify_required`）后，验证流程实际未闭环：

1. **登录不拦截**：`handleLogin` 只检查密码与封禁状态，不检查 `email_verified`，未验证用户可直接登录面板
2. **订阅不拦截（更严重）**：`handleSub` 不检查 `email_verified`，未验证用户拉订阅即获得全部节点链接。其中**外部节点（external）的 share_link 是上游真实凭据**，面板无法计量、也无法事后吊销——注册即可白嫖，邮箱验证形同虚设

实测（v0.2.51/v0.2.52）：注册后不点验证邮件 → 直接登录 200 → 拉订阅返回全部节点真实凭据。

## 修复

- `handleLogin`：开启验证时，未验证账号返回 403「请先完成邮箱验证后再登录」；admin 豁免（管理员创建的账号本就预验证）
- `handleSub`：开启验证时，未验证账号返回合法但**空的节点列表**（与超载/过期用户的既有处理方式一致）

自建节点不受影响——开启验证时 `provisionClient` 本就延迟到验证完成后才执行，未验证用户本就没有自建凭据，此次修复只是把外部节点的口子一并堵上。

## 说明

若认为「允许未验证登录查看面板」是有意设计（让用户能进个人中心重发验证邮件），可考虑折中：登录放行但订阅仍拦截。但当前状态下订阅泄漏凭据的问题无论如何都需要修。