### PR TITLE
fix(ui): 积分换算 yuan() 硬编码汇率 10，忽略管理员设置的 points_per_cny

### DIFF
--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,3 +1,4 @@
+import { useConfigStore } from '@/stores/config'
 export function fmtBytes(n: number | null | undefined): string {
   if (n == null || n <= 0) return '0 B'
   const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
@@ -38,9 +39,15 @@ export function daysLeft(ts: number | null | undefined): number | null {
   return Math.ceil((ts * 1000 - Date.now()) / 86400000)
 }
 
-export function yuan(points: number | null | undefined, rate = 10): string {
+
+// Converts a points balance to its CNY equivalent. The exchange rate comes
+// from site config (points_per_cny, admin-editable); the old hardcoded default
+// of 10 ignored that setting, so the shop/dashboard showed wrong prices
+// whenever the admin changed the rate.
+export function yuan(points: number | null | undefined, rate?: number): string {
+  const r = rate ?? useConfigStore().config.points_per_cny ?? 10
   if (!points) return '≈¥0'
-  return '≈¥' + (points / rate).toFixed(points % rate ? 1 : 0)
+  return '≈¥' + (points / r).toFixed(points % r ? 1 : 0)
 }
 
 export function pct(used: number | null | undefined, total: number | null | undefined): number {


### PR DESCRIPTION
## 问题

`/api/config` 已返回 `points_per_cny`（管理员可在系统设置中修改），但前端 `yuan()` 函数默认 `rate = 10`，且全部 6 处调用（商城标价、仪表盘、账户页、积分页、订单页）均未传参：

```ts
// 修复前：管理员把汇率设成 1 后，999 积分仍显示 ≈¥99.9
export function yuan(points, rate = 10) { ... }
```

导致管理员修改积分汇率后，所有积分换算金额仍按 10 积分 = 1 元显示。

## 修复

`rate` 改为可选参数，缺省时从 config store（`/api/config`）读取真实汇率，调用方无需改动：

```ts
export function yuan(points, rate?) {
  const r = rate ?? useConfigStore().config.points_per_cny ?? 10
  ...
}
```

依赖链 format.ts → stores/config → api → stores/auth，无循环依赖；已验证 vite build 通过。