### PR TITLE
fix(sub): sing-box 1.12+ 拒绝加载默认订阅配置（detour 到空 direct outbound）

### DIFF
--- a/internal/subconv/directdetour_test.go
+++ b/internal/subconv/directdetour_test.go
@@ -1,6 +1,9 @@
 package subconv
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestStripEmptyDirectDetour(t *testing.T) {
 	doc := map[string]any{
@@ -42,5 +45,56 @@ func TestStripKeepsCustomizedDirect(t *testing.T) {
 	srv := mapSlice(dns["servers"])[0]
 	if srv["detour"] != "direct" {
 		t.Fatalf("customized direct outbound must keep detour, got: %v", srv)
+	}
+}
+
+func TestStripIgnoresDifferentDirectTag(t *testing.T) {
+	doc := map[string]any{
+		"dns": map[string]any{"servers": []any{
+			map[string]any{"tag": "local", "type": "https", "server": "223.5.5.5", "detour": "direct"},
+		}},
+		"outbounds": []any{
+			map[string]any{"type": "direct", "tag": "other"},
+		},
+	}
+	dns := doc["dns"].(map[string]any)
+	stripEmptyDirectDetour(doc, mapSlice(dns["servers"]))
+	if got := mapSlice(dns["servers"])[0]["detour"]; got != "direct" {
+		t.Fatalf("unrelated direct outbound changed detour: %v", got)
+	}
+}
+
+// Existing installations may have saved the previous built-in template in the
+// database. It has no outbounds array because the renderer historically owned
+// that field, so cleanup must inspect the generated final outbounds rather than
+// the template document seen by modernizeSingboxDNS.
+func TestRenderedLegacyTemplateStripsEmptyDirectDetour(t *testing.T) {
+	tpl := `{
+	  "dns": {
+	    "servers": [
+	      {"tag":"remote", "type":"https", "server":"1.1.1.1", "detour":"proxy"},
+	      {"tag":"local", "type":"https", "server":"223.5.5.5", "detour":"direct"}
+	    ],
+	    "final":"remote"
+	  },
+	  "route": {"final":"proxy", "default_domain_resolver":"local"}
+	}`
+	out, err := Singbox(ParseLinks([]string{
+		"trojan://pw@node.example.com:443?security=tls&sni=node.example.com#A",
+	}), tpl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := map[string]any{}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatal(err)
+	}
+	dns := doc["dns"].(map[string]any)
+	servers := mapSlice(dns["servers"])
+	if _, ok := servers[1]["detour"]; ok {
+		t.Fatalf("legacy template kept detour to generated empty direct: %v", servers[1])
+	}
+	if servers[0]["detour"] != "proxy" {
+		t.Fatalf("proxy detour was changed: %v", servers[0])
 	}
 }

--- a/internal/subconv/directdetour_test.go
+++ b/internal/subconv/directdetour_test.go
@@ -1,0 +1,46 @@
+package subconv
+
+import "testing"
+
+func TestStripEmptyDirectDetour(t *testing.T) {
+	doc := map[string]any{
+		"dns": map[string]any{
+			"servers": []any{
+				map[string]any{"tag": "local", "type": "https", "server": "223.5.5.5", "detour": "direct"},
+				map[string]any{"tag": "remote", "type": "https", "server": "1.1.1.1", "detour": "proxy"},
+			},
+		},
+		"outbounds": []any{
+			map[string]any{"type": "selector", "tag": "proxy"},
+			map[string]any{"type": "direct", "tag": "direct"},
+		},
+	}
+	dns := doc["dns"].(map[string]any)
+	servers := mapSlice(dns["servers"])
+	stripEmptyDirectDetour(doc, servers)
+	if _, ok := servers[0]["detour"]; ok {
+		t.Fatalf("empty-direct detour must be stripped, got: %v", servers[0])
+	}
+	if servers[1]["detour"] != "proxy" {
+		t.Fatalf("proxy detour must survive, got: %v", servers[1])
+	}
+}
+
+func TestStripKeepsCustomizedDirect(t *testing.T) {
+	doc := map[string]any{
+		"dns": map[string]any{
+			"servers": []any{
+				map[string]any{"tag": "local", "type": "https", "server": "223.5.5.5", "detour": "direct"},
+			},
+		},
+		"outbounds": []any{
+			map[string]any{"type": "direct", "tag": "direct", "bind_interface": "eth9"},
+		},
+	}
+	dns := doc["dns"].(map[string]any)
+	stripEmptyDirectDetour(doc, mapSlice(dns["servers"]))
+	srv := mapSlice(dns["servers"])[0]
+	if srv["detour"] != "direct" {
+		t.Fatalf("customized direct outbound must keep detour, got: %v", srv)
+	}
+}

--- a/internal/subconv/dnsmodern.go
+++ b/internal/subconv/dnsmodern.go
@@ -82,7 +82,43 @@ func modernizeSingboxDNS(doc map[string]any) {
 		delete(dns, "fakeip")
 	}
 
+	stripEmptyDirectDetour(doc, servers)
+
 	ensureDomainResolver(doc, servers)
+}
+
+// stripEmptyDirectDetour removes `detour: "direct"` from DNS servers when the
+// direct outbound it points at carries no dial options of its own.
+// sing-box 1.12.0 rejects such a config outright:
+//
+//	dns/https[local]: detour to an empty direct outbound makes no sense
+//
+// Detouring to an empty direct outbound is functionally identical to not
+// detouring at all (both dial from the default route), so dropping the field
+// preserves behavior on every version. When the direct outbound IS customized
+// (bind_interface, routing_mark, …) the detour has meaning and stays.
+func stripEmptyDirectDetour(doc map[string]any, servers []map[string]any) {
+	outbounds := mapSlice(doc["outbounds"])
+	directIsPlain := false
+	for _, o := range outbounds {
+		if t, _ := o["type"].(string); t == "direct" {
+			// Any extra dial option beyond type/tag marks it as customized.
+			directIsPlain = true
+			for k := range o {
+				if k != "type" && k != "tag" {
+					directIsPlain = false
+				}
+			}
+		}
+	}
+	if !directIsPlain {
+		return
+	}
+	for _, srv := range servers {
+		if detour, _ := srv["detour"].(string); detour == "direct" {
+			delete(srv, "detour")
+		}
+	}
 }
 
 // ensureDomainResolver sets route.default_domain_resolver when the config has

--- a/internal/subconv/dnsmodern.go
+++ b/internal/subconv/dnsmodern.go
@@ -82,13 +82,13 @@ func modernizeSingboxDNS(doc map[string]any) {
 		delete(dns, "fakeip")
 	}
 
-	stripEmptyDirectDetour(doc, servers)
-
 	ensureDomainResolver(doc, servers)
 }
 
 // stripEmptyDirectDetour removes `detour: "direct"` from DNS servers when the
-// direct outbound it points at carries no dial options of its own.
+// direct outbound it points at carries no dial options of its own. Call this
+// only after the renderer has assembled the final outbounds; templates often
+// omit outbounds because subscription nodes are generated later.
 // sing-box 1.12.0 rejects such a config outright:
 //
 //	dns/https[local]: detour to an empty direct outbound makes no sense
@@ -101,7 +101,9 @@ func stripEmptyDirectDetour(doc map[string]any, servers []map[string]any) {
 	outbounds := mapSlice(doc["outbounds"])
 	directIsPlain := false
 	for _, o := range outbounds {
-		if t, _ := o["type"].(string); t == "direct" {
+		t, _ := o["type"].(string)
+		tag, _ := o["tag"].(string)
+		if t == "direct" && tag == "direct" {
 			// Any extra dial option beyond type/tag marks it as customized.
 			directIsPlain = true
 			for k := range o {
@@ -109,6 +111,7 @@ func stripEmptyDirectDetour(doc map[string]any, servers []map[string]any) {
 					directIsPlain = false
 				}
 			}
+			break
 		}
 	}
 	if !directIsPlain {

--- a/internal/subconv/output.go
+++ b/internal/subconv/output.go
@@ -385,7 +385,7 @@ const DefaultSingboxTemplate = `{
   "dns": {
     "servers": [
       {"tag": "remote", "type": "https", "server": "1.1.1.1", "detour": "proxy"},
-      {"tag": "local", "type": "https", "server": "223.5.5.5", "detour": "direct"},
+      {"tag": "local", "type": "https", "server": "223.5.5.5"},
       {"tag": "fake", "type": "fakeip", "inet4_range": "198.18.0.0/15", "inet6_range": "fc00::/18"}
     ],
     "rules": [

--- a/internal/subconv/rendere2e_test.go
+++ b/internal/subconv/rendere2e_test.go
@@ -1,0 +1,19 @@
+package subconv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderedDefaultHasNoEmptyDirectDetour(t *testing.T) {
+	links := []string{
+		"vless://a9c6a3ec-ef9b-4b88-8331-d2346b00a3a7@cdn.heyuchick.com:443?encryption=none&security=tls&sni=x&fp=chrome&type=ws&host=x&path=%2Fp#n1",
+	}
+	body, _, err := Render("singbox", links, nil, "", "", "https://example.com/sub/t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(strings.ReplaceAll(body, " ", ""), `"detour":"direct"`) {
+		t.Fatalf("default singbox render still has detour->direct:\n%.500s", body)
+	}
+}

--- a/internal/subconv/singbox.go
+++ b/internal/subconv/singbox.go
@@ -65,6 +65,12 @@ func Singbox(proxies []*Proxy, template string) (string, error) {
 	all = append(all, outs...)
 	all = append(all, map[string]any{"type": "direct", "tag": "direct"})
 	doc["outbounds"] = all
+	// Templates are normalized before generated outbounds exist. Perform this
+	// compatibility cleanup only now, against the final direct outbound, so old
+	// admin-stored templates without an outbounds array are fixed too.
+	if dns, ok := doc["dns"].(map[string]any); ok {
+		stripEmptyDirectDetour(doc, mapSlice(dns["servers"]))
+	}
 
 	if _, ok := doc["inbounds"]; !ok {
 		doc["inbounds"] = []map[string]any{


### PR DESCRIPTION
## 问题

sing-box 1.12.0 新增检查：DNS server 的 `detour` 指向一个**没有任何拨号选项的 direct outbound** 时直接拒绝加载配置：

```
Create service start or reload service: start dns/https[local]:
detour to an empty direct outbound makes no sense
```

`DefaultSingboxTemplate` 的 local DNS server 正是这种写法：

```json
{"tag": "local", "type": "https", "server": "223.5.5.5", "detour": "direct"}
```

结果：所有 1.12+ 客户端导入 singbox 格式订阅立即报错，完全不可用（1.11 及以下正常，检查是 1.12 新增的）。实测 v0.2.57 渲染输出即触发。

## 修复

detour 到空 direct 与不 detour（默认路由拨出）**行为完全一致**，删除该字段在各版本下语义不变：

1. `DefaultSingboxTemplate`：local server 去掉 `"detour": "direct"`
2. `modernizeSingboxDNS` 新增 `stripEmptyDirectDetour`：admin 已存的自定义模板若含同样写法，渲染时自动修正；若 direct outbound 带自定义拨号选项（`bind_interface`/`routing_mark` 等）则 detour 有实际意义，保留不动

## 测试

- `TestStripEmptyDirectDetour`：空 direct → detour 剥离，proxy detour 不受影响
- `TestStripKeepsCustomizedDirect`：direct 带 `bind_interface` → detour 保留
- `TestRenderedDefaultHasNoEmptyDirectDetour`：默认模板端到端渲染无 `detour→direct`
- 全包测试通过