### PR TITLE
feat(api): 可吊销带 scope 与过期的 API Token（#42）

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,12 +317,14 @@ systemctl daemon-reload && systemctl enable --now qingzhou
 
 ## 🔌 API 概览
 
-鉴权：`Authorization: Bearer <token>` 或 `qz_token` Cookie。
+鉴权：`Authorization: Bearer <JWT 或 API Token>` 或 `qz_token` Cookie。
+
+机器用 **API Token**（`qz_at_…`，管理页 `/admin/api-tokens`）：可 scope / 过期 / 吊销；首批 scope 为 `stats:read`、`users:read`、`nodes:read`、`servers:read`、`backup:write`。Token **不能**调用 `update/*`；管理 Token 本身只能用管理员登录会话。明文只在创建时返回一次，库内仅存哈希。
 
 - **公开**：`GET /api/health`、`GET /api/config`、`POST /api/auth/{login,register,forgot,reset}`、`GET /api/auth/verify`、`GET /sub/{token}`（聚合订阅，UA 自适应或 `?format=clash|singbox|surge`）、`GET /install-singbox.sh`、`GET /api/monitor/{public,heatmap,install.sh,agent/{arch}}`
 - **用户**：`/api/user/{dashboard,plans,subscription,reset-sub,reset-node-creds,packages,purchase,orders,points,announcements,sessions,nodes,proxies,stats/traffic,password,email}`、`GET /api/auth/me`
 - **管理**：
-  - 业务 `/api/admin/{users,user-groups,packages,orders,reg-codes,announcements,help,settings}`（含 `orders/{id}/refund-preview`、`packages/{id}/retire`）
+  - 业务 `/api/admin/{users,user-groups,packages,orders,reg-codes,announcements,help,settings,tokens}`（含 `orders/{id}/refund-preview`、`packages/{id}/retire`；`tokens` 为 API Token 创建/列表/吊销）
   - 节点 `/api/admin/{nodes,node-groups,node-sources,servers}`（含 `nodes/singbox` 版本探测与 `nodes/{id}/singbox/upgrade` 一键重装）
   - 原生 sing-box `/api/admin/sb/*`（TLS、入站、代理出口 `sb/egresses`、`sb/preview`、`sb/port-check`、`sb/sni-test`、`sb/import-remote/*`）
   - 证书中心 `/api/admin/certs/*`

--- a/frontend/src/components/DashboardLayout.vue
+++ b/frontend/src/components/DashboardLayout.vue
@@ -146,6 +146,7 @@ const adminOpsItems: MenuOption[] = [
   { label: '套餐管理', key: '/admin/packages', icon: renderIcon(ArchiveOutline) },
   { label: '订单管理', key: '/admin/orders', icon: renderIcon(ReceiptOutline) },
   { label: '注册码', key: '/admin/reg-codes', icon: renderIcon(KeyOutline) },
+  { label: 'API Token', key: '/admin/api-tokens', icon: renderIcon(KeyOutline) },
 ]
 const adminNodeItems: MenuOption[] = [
   { label: '节点管理', key: '/admin/nodes', icon: renderIcon(ServerOutline) },
@@ -188,7 +189,7 @@ const titleMap: Record<string, string> = {
   '/orders': '订单记录', '/points': '积分明细', '/notices': '公告通知', '/help': '帮助中心', '/account': '账户设置',
   '/admin': '管理概览', '/admin/users': '用户管理', '/admin/user-groups': '用户组', '/admin/packages': '套餐管理', '/admin/nodes': '节点管理',
   '/admin/singbox': 'sing-box', '/admin/certs': '证书管理', '/admin/orders': '订单管理', '/admin/servers': '服务器', '/admin/monitor': '监控管理',
-  '/admin/settings': '系统设置', '/admin/reg-codes': '注册码', '/admin/announcements': '公告管理', '/admin/manual-notifications': '手动通知', '/admin/help': '帮助文档',
+  '/admin/settings': '系统设置', '/admin/reg-codes': '注册码', '/admin/api-tokens': 'API Token', '/admin/announcements': '公告管理', '/admin/manual-notifications': '手动通知', '/admin/help': '帮助文档',
   '/admin/update': '在线更新',
 }
 const currentTitle = computed(() => titleMap[route.path] || config.config.site_name || '轻舟')

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -35,6 +35,7 @@ const router = createRouter({
         { path: 'admin/monitor/:id', name: 'admin-monitor-detail', component: () => import('@/views/AdminMonitorDetail.vue'), meta: { requiresAdmin: true } },
         { path: 'admin/settings', name: 'admin-settings', component: () => import('@/views/AdminSettings.vue'), meta: { requiresAdmin: true } },
         { path: 'admin/reg-codes', name: 'admin-regcodes', component: () => import('@/views/AdminRegCodes.vue'), meta: { requiresAdmin: true } },
+        { path: 'admin/api-tokens', name: 'admin-api-tokens', component: () => import('@/views/AdminAPITokens.vue'), meta: { requiresAdmin: true } },
         { path: 'admin/announcements', name: 'admin-announcements', component: () => import('@/views/AdminAnnouncements.vue'), meta: { requiresAdmin: true } },
         { path: 'admin/manual-notifications', name: 'admin-manual-notifications', component: () => import('@/views/AdminManualNotifications.vue'), meta: { requiresAdmin: true } },
         { path: 'admin/help', name: 'admin-help', component: () => import('@/views/AdminHelp.vue'), meta: { requiresAdmin: true } },

--- a/frontend/src/views/AdminAPITokens.vue
+++ b/frontend/src/views/AdminAPITokens.vue
@@ -1,0 +1,155 @@
+<template>
+  <div>
+    <div class="page-head">
+      <div>
+        <h2 class="page-title">API Token</h2>
+        <p class="page-sub">给脚本 / Telegram / 外部运维用的机器身份：可收窄 scope、可过期、可吊销。明文只在创建时展示一次。</p>
+      </div>
+    </div>
+
+    <n-alert type="warning" :bordered="false" style="margin-bottom:16px;">
+      不要把 <code>backup:write</code> 发给不可信集成；Token <b>不能</b>调用在线更新 / 回滚。管理 Token 本身只能用管理员登录会话。
+    </n-alert>
+
+    <n-card size="small" style="margin-bottom:16px;">
+      <div style="display:flex;gap:10px;align-items:flex-end;flex-wrap:wrap;">
+        <div style="flex:1;min-width:160px;">
+          <div style="font-size:12px;color:var(--text-3);margin-bottom:4px;">名称</div>
+          <n-input v-model:value="form.name" placeholder="如 telegram-bot" />
+        </div>
+        <div style="flex:2;min-width:240px;">
+          <div style="font-size:12px;color:var(--text-3);margin-bottom:4px;">Scopes</div>
+          <n-select v-model:value="form.scopes" :options="scopeOpts" multiple placeholder="至少选一个" />
+        </div>
+        <div>
+          <div style="font-size:12px;color:var(--text-3);margin-bottom:4px;">有效期</div>
+          <n-select v-model:value="form.ttl" :options="ttlOpts" style="width:140px;" />
+        </div>
+        <n-button type="primary" :loading="creating" @click="createToken">创建</n-button>
+      </div>
+      <div v-if="createdPlain" style="margin-top:12px;padding:10px;background:var(--bg-soft);border-radius:8px;">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;">
+          <span style="font-size:12px;font-weight:600;color:var(--warning);">请立即复制，关闭后无法再查看明文</span>
+          <n-button size="tiny" @click="copyPlain">复制</n-button>
+        </div>
+        <div style="font-family:monospace;font-size:12px;word-break:break-all;">{{ createdPlain }}</div>
+      </div>
+    </n-card>
+
+    <n-spin :show="loading">
+      <div v-if="tokens.length" class="card-grid">
+        <div v-for="t in tokens" :key="t.id" class="list-card">
+          <div class="lc-head">
+            <span class="lc-title">{{ t.name }}</span>
+            <n-tag :type="statusType(t)" size="tiny" :bordered="false">{{ statusLabel(t) }}</n-tag>
+          </div>
+          <div class="lc-meta">
+            <span class="kv">前缀 <b style="font-family:monospace;">{{ t.prefix }}…</b></span>
+            <span class="kv">创建 {{ fmtDateTime(t.created_at) }}</span>
+          </div>
+          <div class="lc-meta">
+            <span class="kv">Scopes <b>{{ (t.scopes || []).join(', ') }}</b></span>
+          </div>
+          <div class="lc-meta">
+            <span class="kv">过期 {{ t.expires_at ? fmtDateTime(t.expires_at) : '永不过期' }}</span>
+            <span class="kv">最近使用 {{ t.last_used_at ? fmtDateTime(t.last_used_at) : '从未' }}</span>
+          </div>
+          <div class="lc-foot">
+            <n-button v-if="!t.revoked_at" size="tiny" type="error" @click="revoke(t)">吊销</n-button>
+          </div>
+        </div>
+      </div>
+      <n-empty v-else-if="!loading" description="暂无 API Token" style="padding:40px 0;" />
+    </n-spin>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, onMounted } from 'vue'
+import { NCard, NInput, NButton, NTag, NSpin, NSelect, NEmpty, NAlert, useMessage, useDialog } from 'naive-ui'
+import { apiList, apiPost, apiDelete } from '@/api'
+import { fmtDateTime } from '@/utils/format'
+import { copyText } from '@/utils/clipboard'
+
+const message = useMessage()
+const dialog = useDialog()
+const tokens = ref<any[]>([])
+const loading = ref(false)
+const creating = ref(false)
+const createdPlain = ref('')
+
+const scopeOpts = [
+  { label: 'stats:read', value: 'stats:read' },
+  { label: 'users:read', value: 'users:read' },
+  { label: 'nodes:read', value: 'nodes:read' },
+  { label: 'servers:read', value: 'servers:read' },
+  { label: 'backup:write（敏感）', value: 'backup:write' },
+]
+const ttlOpts = [
+  { label: '永不过期', value: 0 },
+  { label: '7 天', value: 7 * 86400 },
+  { label: '30 天', value: 30 * 86400 },
+  { label: '90 天', value: 90 * 86400 },
+  { label: '365 天', value: 365 * 86400 },
+]
+const form = reactive({ name: '', scopes: ['stats:read'] as string[], ttl: 0 })
+
+function statusLabel(t: any) {
+  if (t.revoked_at) return '已吊销'
+  if (t.expires_at && t.expires_at * 1000 < Date.now()) return '已过期'
+  return '有效'
+}
+function statusType(t: any): 'success' | 'warning' | 'error' | 'default' {
+  if (t.revoked_at) return 'error'
+  if (t.expires_at && t.expires_at * 1000 < Date.now()) return 'warning'
+  return 'success'
+}
+
+async function load() {
+  loading.value = true
+  try { tokens.value = await apiList('/api/admin/tokens') || [] }
+  catch (e: any) { message.error(e.message) }
+  finally { loading.value = false }
+}
+
+async function createToken() {
+  if (!form.name.trim()) { message.warning('请填写名称'); return }
+  if (!form.scopes.length) { message.warning('请选择 scope'); return }
+  creating.value = true
+  createdPlain.value = ''
+  try {
+    const data = await apiPost<any>('/api/admin/tokens', {
+      name: form.name.trim(),
+      scopes: form.scopes,
+      expires_in: form.ttl || 0,
+    })
+    createdPlain.value = data.token
+    form.name = ''
+    message.success('已创建，请复制明文 Token')
+    await load()
+  } catch (e: any) { message.error(e.message) }
+  finally { creating.value = false }
+}
+
+function copyPlain() {
+  copyText(createdPlain.value)
+  message.success('已复制')
+}
+
+function revoke(t: any) {
+  dialog.warning({
+    title: '吊销 Token',
+    content: `确定吊销「${t.name}」？使用该 Token 的集成会立即失效。`,
+    positiveText: '吊销', negativeText: '取消',
+    onPositiveClick: async () => {
+      try {
+        await apiDelete('/api/admin/tokens/' + t.id)
+        message.success('已吊销')
+        await load()
+      } catch (e: any) { message.error(e.message) }
+    },
+  })
+}
+
+onMounted(load)
+</script>

--- a/internal/api/apitokens.go
+++ b/internal/api/apitokens.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"qingzhou/internal/store"
+)
+
+// handleAdminListAPITokens GET /api/admin/tokens
+func (a *API) handleAdminListAPITokens(w http.ResponseWriter, r *http.Request) {
+	if !a.requireJWTAdmin(w, r) {
+		return
+	}
+	list, err := a.st.ListAPITokens()
+	if err != nil {
+		fail(w, http.StatusInternalServerError, "读取失败")
+		return
+	}
+	ok(w, list)
+}
+
+type createAPITokenReq struct {
+	Name      string   `json:"name"`
+	Scopes    []string `json:"scopes"`
+	ExpiresIn int64    `json:"expires_in"` // seconds from now; 0 = never
+	ExpiresAt int64    `json:"expires_at"` // absolute unix; takes precedence if >0
+}
+
+// handleAdminCreateAPIToken POST /api/admin/tokens
+func (a *API) handleAdminCreateAPIToken(w http.ResponseWriter, r *http.Request) {
+	if !a.requireJWTAdmin(w, r) {
+		return
+	}
+	var req createAPITokenReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		fail(w, http.StatusBadRequest, "无效请求")
+		return
+	}
+	expiresAt := req.ExpiresAt
+	if expiresAt == 0 && req.ExpiresIn > 0 {
+		expiresAt = time.Now().Unix() + req.ExpiresIn
+	}
+	uid, _ := r.Context().Value(ctxUserID).(int64)
+	plain, tok, err := a.st.CreateAPIToken(req.Name, req.Scopes, uid, expiresAt)
+	if err != nil {
+		fail(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	log.Printf("audit: api_token created id=%d name=%q scopes=%v by=%d", tok.ID, tok.Name, tok.Scopes, uid)
+	ok(w, J{
+		"token":      plain, // shown once
+		"id":         tok.ID,
+		"name":       tok.Name,
+		"prefix":     tok.Prefix,
+		"scopes":     tok.Scopes,
+		"expires_at": tok.ExpiresAt,
+		"created_at": tok.CreatedAt,
+	})
+}
+
+// handleAdminRevokeAPIToken DELETE /api/admin/tokens/{id}
+func (a *API) handleAdminRevokeAPIToken(w http.ResponseWriter, r *http.Request) {
+	if !a.requireJWTAdmin(w, r) {
+		return
+	}
+	id := int64(atoi(chi.URLParam(r, "id")))
+	if id <= 0 {
+		fail(w, http.StatusBadRequest, "无效 id")
+		return
+	}
+	if err := a.st.RevokeAPIToken(id); err != nil {
+		fail(w, http.StatusNotFound, "令牌不存在")
+		return
+	}
+	uid, _ := r.Context().Value(ctxUserID).(int64)
+	log.Printf("audit: api_token revoked id=%d by=%d", id, uid)
+	ok(w, nil)
+}
+
+// requireJWTAdmin rejects API-token auth for token management endpoints.
+func (a *API) requireJWTAdmin(w http.ResponseWriter, r *http.Request) bool {
+	kind, _ := r.Context().Value(ctxAuthKind).(string)
+	if kind == "api_token" {
+		fail(w, http.StatusForbidden, "权限不足")
+		return false
+	}
+	role, _ := r.Context().Value(ctxRole).(string)
+	if role != "admin" {
+		fail(w, http.StatusForbidden, "需要管理员权限")
+		return false
+	}
+	return true
+}
+
+// scopeForAdminRequest maps an admin HTTP request to a required API token
+// scope. Empty means the route is not available to API tokens (JWT only).
+func scopeForAdminRequest(r *http.Request) string {
+	path := r.URL.Path
+	method := r.Method
+	if strings.HasPrefix(path, "/api/admin/tokens") {
+		return "" // JWT only
+	}
+	if strings.HasPrefix(path, "/api/admin/update") {
+		return "" // never for tokens
+	}
+	if method == http.MethodGet && strings.HasPrefix(path, "/api/admin/stats") {
+		return "stats:read"
+	}
+	if method == http.MethodGet && (path == "/api/admin/users" || strings.HasPrefix(path, "/api/admin/users/")) {
+		return "users:read"
+	}
+	if method == http.MethodGet && (path == "/api/admin/nodes" || strings.HasPrefix(path, "/api/admin/nodes/")) {
+		return "nodes:read"
+	}
+	if method == http.MethodGet && (path == "/api/admin/servers" || strings.HasPrefix(path, "/api/admin/servers/")) {
+		return "servers:read"
+	}
+	if method == http.MethodGet && path == "/api/admin/backup" {
+		return "backup:write"
+	}
+	return ""
+}
+
+// enforceAPITokenScope denies API-token callers that lack the mapped scope.
+// JWT sessions pass through unchanged.
+func (a *API) enforceAPITokenScope(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		kind, _ := r.Context().Value(ctxAuthKind).(string)
+		if kind != "api_token" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		need := scopeForAdminRequest(r)
+		if need == "" {
+			fail(w, http.StatusForbidden, "权限不足")
+			return
+		}
+		scopes, _ := r.Context().Value(ctxScopes).([]string)
+		if !store.APITokenHasScope(scopes, need) {
+			fail(w, http.StatusForbidden, "权限不足")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/api/apitokens_test.go
+++ b/internal/api/apitokens_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"qingzhou/internal/store"
+)
+
+func openAPITokenTestAPI(t *testing.T) (*API, *store.Store) {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	if err := st.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+	return &API{st: st, secret: []byte("test-secret-32-bytes-pad-pad-pad!")}, st
+}
+
+func TestAPIToken_AuthAndScopes(t *testing.T) {
+	a, st := openAPITokenTestAPI(t)
+	plain, _, err := st.CreateAPIToken("ci", []string{"stats:read"}, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := chi.NewRouter()
+	r.Use(a.authMiddleware)
+	r.Use(a.requireAdmin)
+	r.Use(a.enforceAPITokenScope)
+	r.Get("/api/admin/stats/overview", func(w http.ResponseWriter, r *http.Request) {
+		ok(w, J{"ok": true})
+	})
+	r.Get("/api/admin/users", func(w http.ResponseWriter, r *http.Request) {
+		ok(w, J{"ok": true})
+	})
+	r.Get("/api/admin/tokens", a.handleAdminListAPITokens)
+	r.Post("/api/admin/settings", func(w http.ResponseWriter, r *http.Request) {
+		ok(w, nil)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/stats/overview", nil)
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("stats with scope: got %d %s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/admin/users", nil)
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != 403 {
+		t.Fatalf("users without scope: got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/admin/settings", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != 403 {
+		t.Fatalf("settings write: got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/admin/tokens", nil)
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != 403 {
+		t.Fatalf("tokens list via api token: got %d", rec.Code)
+	}
+
+	list, _ := st.ListAPITokens()
+	_ = st.RevokeAPIToken(list[0].ID)
+	req = httptest.NewRequest(http.MethodGet, "/api/admin/stats/overview", nil)
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != 401 {
+		t.Fatalf("revoked: got %d", rec.Code)
+	}
+}
+
+func TestAPIToken_CreateHandlerJWT(t *testing.T) {
+	a, _ := openAPITokenTestAPI(t)
+	body, _ := json.Marshal(map[string]any{
+		"name": "n", "scopes": []string{"nodes:read"}, "expires_in": 3600,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/tokens", bytes.NewReader(body))
+	ctx := context.WithValue(req.Context(), ctxUserID, int64(7))
+	ctx = context.WithValue(ctx, ctxRole, "admin")
+	ctx = context.WithValue(ctx, ctxAuthKind, "jwt")
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	a.handleAdminCreateAPIToken(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("create: %d %s", rec.Code, rec.Body.String())
+	}
+	var env struct {
+		Code int `json:"code"`
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil || env.Data.Token == "" {
+		t.Fatalf("envelope: %v body=%s", err, rec.Body.String())
+	}
+}

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -17,9 +17,12 @@ import (
 type ctxKey string
 
 const (
-	ctxUserID ctxKey = "uid"
-	ctxRole   ctxKey = "role"
-	ctxJti    ctxKey = "jti"
+	ctxUserID   ctxKey = "uid"
+	ctxRole     ctxKey = "role"
+	ctxJti      ctxKey = "jti"
+	ctxAuthKind ctxKey = "auth_kind" // "jwt" | "api_token"
+	ctxScopes   ctxKey = "scopes"    // []string when auth_kind=api_token
+	ctxTokenID  ctxKey = "token_id"
 
 	cookieName = "qz_token"
 	tokenTTL   = 7 * 24 * time.Hour
@@ -202,6 +205,23 @@ func (a *API) authMiddleware(next http.Handler) http.Handler {
 			fail(w, http.StatusUnauthorized, "未登录")
 			return
 		}
+		// Machine API tokens (Bearer only). Cookie-bound browser sessions stay on JWT.
+		if strings.HasPrefix(tokStr, "qz_at_") && strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+			at, err := a.st.LookupAPIToken(tokStr)
+			if err != nil || at == nil {
+				// Same message as a bad JWT — do not advertise token existence.
+				fail(w, http.StatusUnauthorized, "登录已失效，请重新登录")
+				return
+			}
+			a.st.TouchAPIToken(at.ID)
+			ctx := context.WithValue(r.Context(), ctxUserID, at.CreatedBy)
+			ctx = context.WithValue(ctx, ctxRole, "admin")
+			ctx = context.WithValue(ctx, ctxAuthKind, "api_token")
+			ctx = context.WithValue(ctx, ctxScopes, at.Scopes)
+			ctx = context.WithValue(ctx, ctxTokenID, at.ID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
 		claims, err := auth.Parse(a.secret, tokStr)
 		if err != nil {
 			fail(w, http.StatusUnauthorized, "登录已过期，请重新登录")
@@ -216,6 +236,7 @@ func (a *API) authMiddleware(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), ctxUserID, claims.UserID)
 		ctx = context.WithValue(ctx, ctxRole, claims.Role)
 		ctx = context.WithValue(ctx, ctxJti, claims.ID)
+		ctx = context.WithValue(ctx, ctxAuthKind, "jwt")
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -267,6 +267,10 @@ func (a *API) Router() http.Handler {
 	r.Group(func(ar chi.Router) {
 		ar.Use(a.authMiddleware)
 		ar.Use(a.requireAdmin)
+		ar.Use(a.enforceAPITokenScope)
+		ar.Get("/api/admin/tokens", a.handleAdminListAPITokens)
+		ar.Post("/api/admin/tokens", a.handleAdminCreateAPIToken)
+		ar.Delete("/api/admin/tokens/{id}", a.handleAdminRevokeAPIToken)
 		ar.Get("/api/admin/settings", a.handleGetSettings)
 		ar.Put("/api/admin/settings", a.handlePutSettings)
 		ar.Get("/api/admin/settings/default-templates", a.handleGetDefaultTemplates)

--- a/internal/store/apitokens.go
+++ b/internal/store/apitokens.go
@@ -1,0 +1,223 @@
+package store
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// KnownAPITokenScopes is the whitelist of scopes a token may request.
+var KnownAPITokenScopes = []string{
+	"stats:read",
+	"users:read",
+	"nodes:read",
+	"servers:read",
+	"backup:write",
+}
+
+const apiTokenPlainPrefix = "qz_at_"
+
+// APIToken is a row from api_tokens. TokenHash is never exported in JSON.
+type APIToken struct {
+	ID         int64    `json:"id"`
+	Name       string   `json:"name"`
+	Prefix     string   `json:"prefix"`
+	Scopes     []string `json:"scopes"`
+	CreatedBy  int64    `json:"created_by"`
+	ExpiresAt  int64    `json:"expires_at"`
+	LastUsedAt int64    `json:"last_used_at"`
+	RevokedAt  int64    `json:"revoked_at"`
+	CreatedAt  int64    `json:"created_at"`
+	TokenHash  string   `json:"-"`
+}
+
+func hashAPIToken(plain string) string {
+	h := sha256.Sum256([]byte("qz-api-token:" + plain))
+	return hex.EncodeToString(h[:])
+}
+
+func normalizeScopes(in []string) ([]string, error) {
+	allowed := map[string]bool{}
+	for _, s := range KnownAPITokenScopes {
+		allowed[s] = true
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if !allowed[s] {
+			return nil, fmt.Errorf("未知 scope: %s", s)
+		}
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	if len(out) == 0 {
+		return nil, errors.New("至少选择一个 scope")
+	}
+	return out, nil
+}
+
+func scopesJSON(scopes []string) (string, error) {
+	b, err := json.Marshal(scopes)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func parseScopesJSON(raw string) []string {
+	var out []string
+	if raw == "" {
+		return out
+	}
+	_ = json.Unmarshal([]byte(raw), &out)
+	if out == nil {
+		return []string{}
+	}
+	return out
+}
+
+func mintAPITokenPlain() (plain, prefix string, err error) {
+	var b [24]byte
+	if _, err = rand.Read(b[:]); err != nil {
+		return "", "", err
+	}
+	plain = apiTokenPlainPrefix + hex.EncodeToString(b[:])
+	// Show a short stable prefix for list UI (never enough to recreate the token).
+	prefix = plain[:len(apiTokenPlainPrefix)+8]
+	return plain, prefix, nil
+}
+
+// CreateAPIToken mints a new token. The plaintext is returned once; only the
+// hash is persisted. expiresAt 0 means never expire.
+func (s *Store) CreateAPIToken(name string, scopes []string, createdBy, expiresAt int64) (plain string, tok *APIToken, err error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", nil, errors.New("名称不能为空")
+	}
+	scopes, err = normalizeScopes(scopes)
+	if err != nil {
+		return "", nil, err
+	}
+	if expiresAt < 0 {
+		return "", nil, errors.New("过期时间无效")
+	}
+	plain, prefix, err := mintAPITokenPlain()
+	if err != nil {
+		return "", nil, err
+	}
+	rawScopes, err := scopesJSON(scopes)
+	if err != nil {
+		return "", nil, err
+	}
+	now := time.Now().Unix()
+	res, err := s.db.Exec(`INSERT INTO api_tokens
+		(name, token_prefix, token_hash, scopes, created_by, expires_at, last_used_at, revoked_at, created_at)
+		VALUES (?,?,?,?,?,?,0,0,?)`,
+		name, prefix, hashAPIToken(plain), rawScopes, createdBy, expiresAt, now)
+	if err != nil {
+		return "", nil, err
+	}
+	id, _ := res.LastInsertId()
+	return plain, &APIToken{
+		ID: id, Name: name, Prefix: prefix, Scopes: scopes,
+		CreatedBy: createdBy, ExpiresAt: expiresAt, CreatedAt: now,
+	}, nil
+}
+
+// ListAPITokens returns non-deleted tokens (including revoked) newest first.
+func (s *Store) ListAPITokens() ([]*APIToken, error) {
+	rows, err := s.db.Query(`SELECT id, name, token_prefix, scopes, created_by, expires_at, last_used_at, revoked_at, created_at
+		FROM api_tokens ORDER BY id DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []*APIToken{}
+	for rows.Next() {
+		var t APIToken
+		var rawScopes string
+		if err := rows.Scan(&t.ID, &t.Name, &t.Prefix, &rawScopes, &t.CreatedBy, &t.ExpiresAt, &t.LastUsedAt, &t.RevokedAt, &t.CreatedAt); err != nil {
+			return nil, err
+		}
+		t.Scopes = parseScopesJSON(rawScopes)
+		out = append(out, &t)
+	}
+	return out, rows.Err()
+}
+
+// RevokeAPIToken marks a token revoked. Idempotent.
+func (s *Store) RevokeAPIToken(id int64) error {
+	now := time.Now().Unix()
+	res, err := s.db.Exec(`UPDATE api_tokens SET revoked_at=? WHERE id=? AND revoked_at=0`, now, id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		// Already revoked or missing — treat missing as not found.
+		var exists int
+		_ = s.db.QueryRow(`SELECT 1 FROM api_tokens WHERE id=?`, id).Scan(&exists)
+		if exists == 0 {
+			return sql.ErrNoRows
+		}
+	}
+	return nil
+}
+
+// LookupAPIToken authenticates a plaintext bearer. Returns nil,nil when the
+// token is unknown / revoked / expired — callers must not distinguish those
+// cases in the HTTP response.
+func (s *Store) LookupAPIToken(plain string) (*APIToken, error) {
+	if !strings.HasPrefix(plain, apiTokenPlainPrefix) {
+		return nil, nil
+	}
+	var t APIToken
+	var rawScopes string
+	err := s.db.QueryRow(`SELECT id, name, token_prefix, token_hash, scopes, created_by, expires_at, last_used_at, revoked_at, created_at
+		FROM api_tokens WHERE token_hash=?`, hashAPIToken(plain)).
+		Scan(&t.ID, &t.Name, &t.Prefix, &t.TokenHash, &rawScopes, &t.CreatedBy, &t.ExpiresAt, &t.LastUsedAt, &t.RevokedAt, &t.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().Unix()
+	if t.RevokedAt > 0 {
+		return nil, nil
+	}
+	if t.ExpiresAt > 0 && t.ExpiresAt <= now {
+		return nil, nil
+	}
+	t.Scopes = parseScopesJSON(rawScopes)
+	return &t, nil
+}
+
+// TouchAPIToken bumps last_used_at at most once per minute.
+func (s *Store) TouchAPIToken(id int64) {
+	now := time.Now().Unix()
+	_, _ = s.db.Exec(`UPDATE api_tokens SET last_used_at=? WHERE id=? AND last_used_at < ?`, now, id, now-60)
+}
+
+// APITokenHasScope reports whether scopes includes want.
+func APITokenHasScope(scopes []string, want string) bool {
+	for _, s := range scopes {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/apitokens_test.go
+++ b/internal/store/apitokens_test.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAPIToken_CreateListRevokeLookup(t *testing.T) {
+	st := openMigrated(t)
+	plain, tok, err := st.CreateAPIToken("bot", []string{"stats:read", "users:read"}, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plain == "" || tok.ID == 0 || tok.Prefix == "" {
+		t.Fatalf("bad create: plain=%q tok=%+v", plain, tok)
+	}
+	if got, err := st.LookupAPIToken(plain); err != nil || got == nil || got.ID != tok.ID {
+		t.Fatalf("lookup want id=%d got=%v err=%v", tok.ID, got, err)
+	}
+	list, err := st.ListAPITokens()
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list: %v len=%d", err, len(list))
+	}
+	// ListAPITokens does not select token_hash; TokenHash stays empty in the view.
+	if list[0].TokenHash != "" {
+		t.Fatal("list view must not carry token_hash")
+	}
+	if err := st.RevokeAPIToken(tok.ID); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := st.LookupAPIToken(plain); err != nil || got != nil {
+		t.Fatalf("revoked token must not authenticate, got=%v err=%v", got, err)
+	}
+}
+
+func TestAPIToken_ExpiryAndUnknownScope(t *testing.T) {
+	st := openMigrated(t)
+	if _, _, err := st.CreateAPIToken("x", []string{"admin:all"}, 1, 0); err == nil {
+		t.Fatal("unknown scope must fail")
+	}
+	exp := time.Now().Add(-time.Hour).Unix()
+	plain, _, err := st.CreateAPIToken("old", []string{"nodes:read"}, 1, exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := st.LookupAPIToken(plain); err != nil || got != nil {
+		t.Fatalf("expired must not authenticate, got=%v err=%v", got, err)
+	}
+	if got, err := st.LookupAPIToken("qz_at_deadbeef"); err != nil || got != nil {
+		t.Fatalf("unknown must be nil,nil got=%v err=%v", got, err)
+	}
+}

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -659,6 +659,22 @@ CREATE TABLE IF NOT EXISTS manual_notification_recipients (
   sent_at         INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (notification_id, user_id)
 );
+
+-- Machine API tokens for scripts / Telegram / ops automation. Plaintext is
+-- shown once at creation; only the hash is stored. Scopes are a JSON string
+-- array; expires_at/revoked_at 0 mean never.
+CREATE TABLE IF NOT EXISTS api_tokens (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  name         TEXT    NOT NULL,
+  token_prefix TEXT    NOT NULL,
+  token_hash   TEXT    NOT NULL UNIQUE,
+  scopes       TEXT    NOT NULL DEFAULT '[]',
+  created_by   INTEGER NOT NULL DEFAULT 0,
+  expires_at   INTEGER NOT NULL DEFAULT 0,
+  last_used_at INTEGER NOT NULL DEFAULT 0,
+  revoked_at   INTEGER NOT NULL DEFAULT 0,
+  created_at   INTEGER NOT NULL
+);
 `
 
 // indexes is the index DDL, kept OUT of schema above and applied AFTER the
@@ -715,6 +731,8 @@ CREATE INDEX IF NOT EXISTS idx_tg_bind_tokens_exp ON telegram_bind_tokens(expire
 CREATE INDEX IF NOT EXISTS idx_notify_log_user ON user_notify_log(user_id);
 CREATE INDEX IF NOT EXISTS idx_manual_notifications_created ON manual_notifications(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_manual_notify_recipients_status ON manual_notification_recipients(notification_id, status);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_hash ON api_tokens(token_hash);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_active ON api_tokens(revoked_at, expires_at);
 `
 
 // Migrate brings the schema up to date in three ordered phases: tables, then


### PR DESCRIPTION
## 摘要

实现 #42 机器身份 API Token：

- `POST/GET/DELETE /api/admin/tokens`（仅管理员 JWT；明文创建时返回一次）
- 首批 scopes：`stats:read` / `users:read` / `nodes:read` / `servers:read` / `backup:write`
- Bearer `qz_at_…` 与 JWT 并列；失败响应不便于枚举；库内仅哈希
- Token **禁止** `update/*`；管理 Token 本身不能用 Token
- 前端 `/admin/api-tokens`；README 警告勿把 backup 交给不可信集成

## 测试

- `go test ./internal/store/ -run APIToken`
- `go test ./internal/api/ -run APIToken`

Fixes #42