### PR TITLE
feat: 订阅 Clash UDP 开关与节点备注展示名（#40）

### DIFF
--- a/frontend/src/views/AdminNodes.vue
+++ b/frontend/src/views/AdminNodes.vue
@@ -236,6 +236,12 @@
       <n-drawer-content :title="editingNode ? '编辑节点' : '添加节点'" closable>
         <n-form label-placement="left" label-width="80">
           <n-form-item label="名称"><n-input v-model:value="nodeForm.name" /></n-form-item>
+          <n-form-item label="订阅备注">
+            <div style="width:100%;">
+              <n-input v-model:value="nodeForm.remark" placeholder="可选；优先作为订阅展示名，不影响计量 identity" />
+              <div class="form-tip">留空则用上方名称。客户端手动选中靠展示名记忆，请保持稳定。</div>
+            </div>
+          </n-form-item>
           <n-form-item label="类型">
             <n-radio-group v-model:value="nodeForm.type">
               <n-radio value="self_built">自建</n-radio>
@@ -709,13 +715,13 @@ const editingNode = ref<any>(null)
 // share_link must match store.Node's JSON tag — it was `link`, so the field was
 // never sent: created external nodes had no link at all, and saving an existing
 // one blanked its stored link.
-const nodeForm = reactive({ name: '', type: 'self_built', inbound_tag: '', route_upstream_inbound_id: 0, route_upstream_broken: false, share_link: '', group_ids: [] as number[], enabled: true })
+const nodeForm = reactive({ name: '', remark: '', type: 'self_built', inbound_tag: '', route_upstream_inbound_id: 0, route_upstream_broken: false, share_link: '', group_ids: [] as number[], enabled: true })
 function openNode(n?: any) {
   editingNode.value = n || null
   if (n) {
-    Object.assign(nodeForm, { name: n.name, type: n.type || 'self_built', inbound_tag: n.inbound_tag || '', route_upstream_inbound_id: n.route_upstream_inbound_id || 0, route_upstream_broken: !!n.route_upstream_broken, share_link: n.share_link || '', group_ids: n.group_ids || [], enabled: n.enabled })
+    Object.assign(nodeForm, { name: n.name, remark: n.remark || '', type: n.type || 'self_built', inbound_tag: n.inbound_tag || '', route_upstream_inbound_id: n.route_upstream_inbound_id || 0, route_upstream_broken: !!n.route_upstream_broken, share_link: n.share_link || '', group_ids: n.group_ids || [], enabled: n.enabled })
   } else {
-    Object.assign(nodeForm, { name: '', type: 'self_built', inbound_tag: '', route_upstream_inbound_id: 0, route_upstream_broken: false, share_link: '', group_ids: [], enabled: true })
+    Object.assign(nodeForm, { name: '', remark: '', type: 'self_built', inbound_tag: '', route_upstream_inbound_id: 0, route_upstream_broken: false, share_link: '', group_ids: [], enabled: true })
   }
   showNode.value = true
 }

--- a/frontend/src/views/AdminSettings.vue
+++ b/frontend/src/views/AdminSettings.vue
@@ -450,6 +450,15 @@
       <n-card v-show="activeSectionId === 'settings-template'" id="settings-template" class="settings-section" size="small">
         <p style="font-size:12px;color:var(--text-3);margin-bottom:12px;">自定义 Clash/sing-box 订阅输出模板。留空使用内置默认模板；改过之后会一直沿用你的版本（升级带来的新版内置模板不会自动生效），点「恢复内置默认」即可清空覆盖、跟随内置。</p>
         <n-form label-placement="top">
+          <n-form-item label="Clash 声明 UDP">
+            <div style="width:100%;">
+              <n-switch :value="form.sub_clash_udp !== '0' && form.sub_clash_udp !== 'false'"
+                        @update:value="(v: boolean) => form.sub_clash_udp = v ? '1' : '0'" />
+              <div style="font-size:12px;color:var(--text-3);margin-top:6px;line-height:1.6;">
+                开启时（默认）Clash 订阅对支持的协议写 <code>udp: true</code>。关闭则省略该字段。入站 egress 阻断 UDP 的节点仍会强制 <code>udp: false</code>。
+              </div>
+            </div>
+          </n-form-item>
           <n-form-item label="Clash 模板 (YAML)">
             <div style="width:100%;">
               <n-input v-model:value="form.sub_clash_template" type="textarea" :rows="8" placeholder="留空用内置模板" style="font-family:monospace;font-size:12px;" />
@@ -617,7 +626,7 @@ const settingsGroups: SettingsGroup[] = [
   { label: '节点与安全', sections: [
     { id: 'settings-cert', label: '证书 / ACME', note: 'Cloudflare DNS', description: '配置 Cloudflare DNS 验证所需的令牌与 ACME 邮箱。', keywords: '证书 ACME Cloudflare DNS Token Let’s Encrypt' },
     { id: 'settings-security', label: '出口安全', note: '内网访问防护', description: '控制节点是否阻断内网、链路本地地址和云元数据。', keywords: '安全 内网 元数据 127 192 169 阻断' },
-    { id: 'settings-template', label: '订阅模板', note: '客户端输出', description: '自定义 Clash 和 sing-box 的订阅输出模板。', keywords: '订阅 模板 Clash YAML sing-box JSON' },
+    { id: 'settings-template', label: '订阅模板', note: '客户端输出', description: '自定义 Clash / sing-box 订阅模板与 Clash UDP 声明。', keywords: '订阅 模板 Clash YAML sing-box JSON UDP' },
     { id: 'settings-runtime', label: '采集与同步', note: '节点负载', description: '调整探针采集、流量统计和健康检查频率。', keywords: '探针 采集 流量 统计 健康检查 同步 间隔 重建' },
   ] },
   { label: '系统维护', sections: [

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -116,6 +116,10 @@ func (a *API) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 	if all["sub_clash_template"] == "" {
 		all["sub_clash_template"] = subconv.DefaultClashTemplate
 	}
+	// Default on: missing key means advertise udp:true (historical behaviour).
+	if all["sub_clash_udp"] == "" {
+		all["sub_clash_udp"] = "1"
+	}
 	if all["sub_singbox_template"] == "" {
 		all["sub_singbox_template"] = subconv.DefaultSingboxTemplate
 	}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -964,7 +964,15 @@ func (a *API) handleSub(w http.ResponseWriter, r *http.Request) {
 		format = subconv.FormatForUA(r.Header.Get("User-Agent"))
 	}
 	format = subconv.NormalizeFormat(format)
-	body, ctype, err := subconv.RenderWithProfile(format, links, aiNodes, clashTpl, singboxTpl, subURL, profile)
+	clashUDP, _ := a.st.GetSettingBool("sub_clash_udp")
+	// Default true when unset: GetSettingBool returns false for missing keys.
+	if v, _ := a.st.GetSetting("sub_clash_udp"); strings.TrimSpace(v) == "" {
+		clashUDP = true
+	}
+	body, ctype, err := subconv.RenderWithOptions(format, links, aiNodes, clashTpl, singboxTpl, subURL, subconv.RenderOptions{
+		Profile:         profile,
+		ClashDisableUDP: !clashUDP,
+	})
 	if err != nil {
 		http.Error(w, "render error", http.StatusBadGateway)
 		return

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -147,6 +147,8 @@ CREATE TABLE IF NOT EXISTS nodes (
   source_id       INTEGER NOT NULL DEFAULT 0,
   enabled         INTEGER NOT NULL DEFAULT 1,
   sort_order      INTEGER NOT NULL DEFAULT 0,
+  -- Optional subscription display remark; preferred over name in #fragment.
+  remark          TEXT    NOT NULL DEFAULT '',
   created_at      INTEGER NOT NULL
 );
 
@@ -861,6 +863,9 @@ func (s *Store) Migrate() error {
 		// the legacy behaviour of inheriting the physical inbound's own chain.
 		`ALTER TABLE nodes ADD COLUMN route_upstream_inbound_id INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE nodes ADD COLUMN route_upstream_broken INTEGER NOT NULL DEFAULT 0`,
+		// Subscription display remark (optional). Preferred over name in share-link
+		// #fragment; never used as metering identity / v2ray_api user name.
+		`ALTER TABLE nodes ADD COLUMN remark TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE servers ADD COLUMN ssh_password TEXT NOT NULL DEFAULT ''`,
 		// sudo password for accounts without NOPASSWD (encrypted at rest, like the
 		// SSH password beside it), and the name of a key file in the panel's key

--- a/internal/store/nodes.go
+++ b/internal/store/nodes.go
@@ -13,6 +13,7 @@ type Node struct {
 	ID                     int64   `json:"id"`
 	Type                   string  `json:"type"` // self_built | external
 	Name                   string  `json:"name"`
+	Remark                 string  `json:"remark"`
 	Protocol               string  `json:"protocol"`
 	InboundTag             string  `json:"inbound_tag"`
 	RouteUpstreamInboundID int64   `json:"route_upstream_inbound_id"`
@@ -25,12 +26,12 @@ type Node struct {
 	GroupIDs               []int64 `json:"group_ids,omitempty"`
 }
 
-const nodeCols = `id, type, name, protocol, inbound_tag, route_upstream_inbound_id, route_upstream_broken, share_link, source_id, enabled, sort_order, created_at`
+const nodeCols = `id, type, name, remark, protocol, inbound_tag, route_upstream_inbound_id, route_upstream_broken, share_link, source_id, enabled, sort_order, created_at`
 
 func scanNode(sc scanner) (*Node, error) {
 	var n Node
 	var routeBroken int
-	err := sc.Scan(&n.ID, &n.Type, &n.Name, &n.Protocol, &n.InboundTag,
+	err := sc.Scan(&n.ID, &n.Type, &n.Name, &n.Remark, &n.Protocol, &n.InboundTag,
 		&n.RouteUpstreamInboundID, &routeBroken, &n.ShareLink, &n.SourceID, &n.Enabled, &n.SortOrder, &n.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -74,14 +75,15 @@ func (s *Store) ListNodes() ([]*Node, error) {
 	return out, nil
 }
 
-// SelfBuiltNodeNames maps each bound inbound tag to the display name the admin
-// gave that node on the 节点 page. Used as the subscription remark so clients
-// show the configured name instead of the raw inbound tag. A tag bound by more
-// than one node keeps the first (sort_order, id) — the same order the node page
-// lists them in.
+// SelfBuiltNodeNames maps each bound inbound tag to the subscription display
+// name (remark if set, otherwise name). A tag bound by more than one node keeps
+// the first (sort_order, id) — the same order the node page lists them in.
 func (s *Store) SelfBuiltNodeNames() (map[string]string, error) {
-	rows, err := s.db.Query(`SELECT inbound_tag, name FROM nodes
-		WHERE type='self_built' AND inbound_tag != '' AND name != ''
+	rows, err := s.db.Query(`SELECT inbound_tag,
+		CASE WHEN trim(remark) != '' THEN remark ELSE name END
+		FROM nodes
+		WHERE type='self_built' AND inbound_tag != ''
+		  AND (trim(remark) != '' OR name != '')
 		  AND route_upstream_inbound_id=0 AND route_upstream_broken=0
 		ORDER BY sort_order, id`)
 	if err != nil {
@@ -101,11 +103,22 @@ func (s *Store) SelfBuiltNodeNames() (map[string]string, error) {
 	return out, rows.Err()
 }
 
+// NodeDisplayName returns the subscription-facing name: remark preferred, else name.
+func NodeDisplayName(n *Node) string {
+	if n == nil {
+		return ""
+	}
+	if r := strings.TrimSpace(n.Remark); r != "" {
+		return r
+	}
+	return n.Name
+}
+
 func (s *Store) CreateNode(n Node) (int64, error) {
 	res, err := s.db.Exec(`INSERT INTO nodes
-		(type, name, protocol, inbound_tag, route_upstream_inbound_id, route_upstream_broken, share_link, source_id, enabled, sort_order, created_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
-		n.Type, n.Name, n.Protocol, n.InboundTag, n.RouteUpstreamInboundID, boolToInt(n.RouteUpstreamBroken), n.ShareLink, n.SourceID,
+		(type, name, remark, protocol, inbound_tag, route_upstream_inbound_id, route_upstream_broken, share_link, source_id, enabled, sort_order, created_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+		n.Type, n.Name, n.Remark, n.Protocol, n.InboundTag, n.RouteUpstreamInboundID, boolToInt(n.RouteUpstreamBroken), n.ShareLink, n.SourceID,
 		boolToInt(n.Enabled), n.SortOrder, time.Now().Unix())
 	if err != nil {
 		return 0, err
@@ -121,8 +134,8 @@ func (s *Store) CreateNode(n Node) (int64, error) {
 
 func (s *Store) UpdateNode(n Node) error {
 	_, err := s.db.Exec(`UPDATE nodes SET
-		type=?, name=?, protocol=?, inbound_tag=?, route_upstream_inbound_id=?, route_upstream_broken=?, share_link=?, enabled=?, sort_order=? WHERE id=?`,
-		n.Type, n.Name, n.Protocol, n.InboundTag, n.RouteUpstreamInboundID, boolToInt(n.RouteUpstreamBroken), n.ShareLink, boolToInt(n.Enabled), n.SortOrder, n.ID)
+		type=?, name=?, remark=?, protocol=?, inbound_tag=?, route_upstream_inbound_id=?, route_upstream_broken=?, share_link=?, enabled=?, sort_order=? WHERE id=?`,
+		n.Type, n.Name, n.Remark, n.Protocol, n.InboundTag, n.RouteUpstreamInboundID, boolToInt(n.RouteUpstreamBroken), n.ShareLink, boolToInt(n.Enabled), n.SortOrder, n.ID)
 	if err != nil {
 		return err
 	}

--- a/internal/store/singbox.go
+++ b/internal/store/singbox.go
@@ -854,9 +854,10 @@ func (s *Store) BuildSelfBuiltLinks(u *User, host string) []SelfBuiltLink {
 		}
 		_ = json.Unmarshal([]byte(ib.Options), &opts)
 
-		// Remark = the node's display name from the 节点 page; the raw inbound tag
-		// is only a fallback for an inbound no node is bound to.
-		remark := n.Name
+		// Remark = node remark (preferred) or name from the 节点 page; the raw
+		// inbound tag is only a fallback for an inbound no node is bound to.
+		// Metering identity (v2ray_api user name) is never derived from this.
+		remark := NodeDisplayName(n)
 		if logicalID == 0 {
 			remark = legacyNames[ib.Tag]
 		}

--- a/internal/store/subremark_test.go
+++ b/internal/store/subremark_test.go
@@ -87,3 +87,36 @@ func TestSelfBuiltLinks_RemarkFallsBackToTag(t *testing.T) {
 		t.Fatalf("unbound inbound should fall back to its tag, got %q", remark)
 	}
 }
+
+func TestSelfBuiltLinks_RemarkPrefersNodeRemark(t *testing.T) {
+	st := newRefundStore(t)
+	uid := mkUser(t, st, "carol")
+	pkg := mkPlan(t, st, "P", 10, 100, 30)
+	buy(t, st, uid, pkg)
+
+	if _, err := st.SaveSbInbound(&SbInbound{
+		Type: "vless", Tag: "vless-in", Listen: "::", ListenPort: 8443,
+		Options: "{}", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateNode(Node{
+		Type: "self_built", Name: "香港 01", Remark: "HK-VIP", Protocol: "vless",
+		InboundTag: "vless-in", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	bindPlanToInbound(t, st, pkg.ID, "vless-in")
+
+	u, err := st.UserByID(uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	links := st.BuildSelfBuiltLinks(u, "example.com")
+	if len(links) != 1 {
+		t.Fatalf("want 1 link, got %d", len(links))
+	}
+	if remark := subconv.LinkRemark(links[0].Link); remark != "HK-VIP" {
+		t.Fatalf("remark should prefer node remark, got %q", remark)
+	}
+}

--- a/internal/subconv/clash.go
+++ b/internal/subconv/clash.go
@@ -11,17 +11,30 @@ import (
 // Clash renders a mihomo/Clash YAML config, merging the anti-leak template
 // (dns/tun/sniffer/rules) with the generated proxies and a "Proxy" selector.
 func Clash(proxies []*Proxy, template string) (string, error) {
-	return clashWithProfile(proxies, template, ProfileLegacy)
+	return ClashWithOptions(proxies, template, ProfileLegacy, ClashOptions{})
 }
 
 // ClashWithProfile renders an explicitly selected routing profile. Clash keeps
 // the old entry point separate so no-profile subscriptions remain byte-for-byte
 // on the legacy path.
 func ClashWithProfile(proxies []*Proxy, template string, profile RoutingProfile) (string, error) {
-	return clashWithProfile(proxies, template, profile)
+	return ClashWithOptions(proxies, template, profile, ClashOptions{})
 }
 
-func clashWithProfile(proxies []*Proxy, template string, profile RoutingProfile) (string, error) {
+// ClashOptions tunes Clash subscription rendering.
+type ClashOptions struct {
+	// DisableUDP omits udp:true (and related packet-encoding keys) on proxies
+	// that would otherwise advertise UDP. Egress-blocked nodes still force
+	// udp:false when the key is already present. Default false = historical.
+	DisableUDP bool
+}
+
+// ClashWithOptions is ClashWithProfile plus render toggles.
+func ClashWithOptions(proxies []*Proxy, template string, profile RoutingProfile, opt ClashOptions) (string, error) {
+	return clashWithProfile(proxies, template, profile, opt)
+}
+
+func clashWithProfile(proxies []*Proxy, template string, profile RoutingProfile, opt ClashOptions) (string, error) {
 	if strings.TrimSpace(template) == "" {
 		template = DefaultClashTemplate
 	}
@@ -38,7 +51,7 @@ func clashWithProfile(proxies []*Proxy, template string, profile RoutingProfile)
 	}
 	var cs []conv
 	for _, p := range proxies {
-		if m := clashProxy(p); m != nil {
+		if m := clashProxy(p, opt); m != nil {
 			cs = append(cs, conv{m: m, p: p})
 		}
 	}
@@ -292,7 +305,7 @@ func clashFallback(name string, proxies []string) map[string]any {
 	}
 }
 
-func clashProxy(p *Proxy) map[string]any {
+func clashProxy(p *Proxy, opt ClashOptions) map[string]any {
 	m := map[string]any{"name": p.Name, "server": p.Server, "port": p.Port}
 	switch p.Protocol {
 	case "vless":
@@ -510,6 +523,12 @@ func clashProxy(p *Proxy) map[string]any {
 		if _, emitted := m["udp"]; emitted {
 			m["udp"] = false
 		}
+		delete(m, "xudp")
+		delete(m, "packet-addr")
+	} else if opt.DisableUDP {
+		// Global admin switch: do not advertise UDP. Omit the key rather than
+		// writing false, matching protocols that never had udp (hy2/tuic).
+		delete(m, "udp")
 		delete(m, "xudp")
 		delete(m, "packet-addr")
 	}

--- a/internal/subconv/clash_udp_opt_test.go
+++ b/internal/subconv/clash_udp_opt_test.go
@@ -1,0 +1,26 @@
+package subconv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClashDisableUDPOmitsKey(t *testing.T) {
+	ps := ParseLinks([]string{
+		"vless://11111111-1111-1111-1111-111111111111@1.2.3.4:443?security=tls&sni=a.example#n1",
+	})
+	out, err := ClashWithOptions(ps, "", ProfileLegacy, ClashOptions{DisableUDP: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "udp: true") || strings.Contains(out, "udp:true") {
+		t.Fatalf("DisableUDP must not emit udp: true:\n%s", out)
+	}
+	outOn, err := ClashWithOptions(ps, "", ProfileLegacy, ClashOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(outOn, "udp: true") && !strings.Contains(outOn, "udp:true") {
+		t.Fatalf("default must still emit udp: true:\n%s", outOn)
+	}
+}

--- a/internal/subconv/output.go
+++ b/internal/subconv/output.go
@@ -105,12 +105,41 @@ func Render(format string, links []string, aiNodes map[string]bool, clashTpl, si
 // pre-profile behavior, including Surge's historical CN bypass and base64's
 // node-only output.
 func RenderWithProfile(format string, links []string, aiNodes map[string]bool, clashTpl, singboxTpl, subURL string, profile RoutingProfile) (body string, contentType string, err error) {
-	if profile == ProfileLegacy {
+	return RenderWithOptions(format, links, aiNodes, clashTpl, singboxTpl, subURL, RenderOptions{Profile: profile})
+}
+
+// RenderOptions carries subscription render toggles beyond format selection.
+type RenderOptions struct {
+	Profile RoutingProfile
+	// ClashDisableUDP turns off Clash udp:true advertisement (setting sub_clash_udp=0).
+	ClashDisableUDP bool
+}
+
+// RenderWithOptions is the full render entry used by the subscription handler.
+func RenderWithOptions(format string, links []string, aiNodes map[string]bool, clashTpl, singboxTpl, subURL string, opt RenderOptions) (body string, contentType string, err error) {
+	profile := opt.Profile
+	clashOpt := ClashOptions{DisableUDP: opt.ClashDisableUDP}
+	if profile == ProfileLegacy && !opt.ClashDisableUDP {
 		return Render(format, links, aiNodes, clashTpl, singboxTpl, subURL)
+	}
+	if profile == ProfileLegacy {
+		// Legacy profile but with Clash UDP overridden — still use ClashWithOptions.
+		switch NormalizeFormat(format) {
+		case FormatClash:
+			out, e := ClashWithOptions(parseWithAI(links, aiNodes), clashTpl, ProfileLegacy, clashOpt)
+			return out, "text/yaml; charset=utf-8", e
+		case FormatSingbox:
+			out, e := Singbox(parseWithAI(links, aiNodes), singboxTpl)
+			return out, "application/json; charset=utf-8", e
+		case FormatSurge:
+			return Surge(parseWithAI(links, aiNodes), subURL), "text/plain; charset=utf-8", nil
+		default:
+			return Base64(links), "text/plain; charset=utf-8", nil
+		}
 	}
 	switch NormalizeFormat(format) {
 	case FormatClash:
-		out, e := ClashWithProfile(parseWithAI(links, aiNodes), clashTpl, profile)
+		out, e := ClashWithOptions(parseWithAI(links, aiNodes), clashTpl, profile, clashOpt)
 		return out, "text/yaml; charset=utf-8", e
 	case FormatSingbox:
 		out, e := SingboxWithProfile(parseWithAI(links, aiNodes), singboxTpl, profile)


### PR DESCRIPTION
## 摘要

订阅体验切片（#40）：

- **Clash UDP 开关**：系统设置 → 订阅模板 →「Clash 声明 UDP」（`sub_clash_udp`，默认开）
- **节点备注 → 展示名**：节点编辑增加「订阅备注」；分享链接 / 订阅优先用 remark，否则 name；**计量 identity 不变**
- Content-Disposition 友好文件名：既有实现保留
- 多机：`ApplyConfig` 已对远端字节相同配置跳过写盘/重启（等价认领）；证书随配置内联 + `sing-box check` 校验

## 测试

- `go test ./internal/subconv/ -run ClashDisableUDP`
- `go test ./internal/store/ -run Remark`

Fixes #40