### PR TITLE
release: pre → main（sing-box 1.14 + Hy2 + API Token + 订阅体验）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,25 +121,25 @@ jobs:
       # release therefore produces a node whose traffic is never metered and
       # whose quotas are never enforced, silently — the panel just shows zero.
       #
-      # The tag list is exactly what official 1.13.x ships, plus with_v2ray_api
-      # and the with_grpc it needs, so nothing an existing config relies on
-      # (TUN/gvisor, QUIC for hysteria/tuic, uTLS for Reality...) is lost.
+      # The tag list follows official 1.14.x DEFAULT_BUILD_TAGS for linux, plus
+      # with_v2ray_api and with_grpc (needed for StatsService), and with_purego
+      # so NaiveProxy outbound works on amd64/arm64 without CGO. New 1.14
+      # defaults (cloudflared / usbip / openvpn / openconnect) are included so
+      # a node reinstall does not silently lose protocol support relative to
+      # upstream's own linux build.
       #
       # SB_VERSION is pinned so a release is reproducible, which means it only
       # moves when someone moves it — and this binary is what every node ends up
-      # running, so a stale pin quietly holds every landing machine back. Worth
-      # re-checking against the current 1.13.x stable at each release: the
-      # v1.13.14 → v1.13.18 bump alone carried two server-side resource leaks
-      # (v2rayhttp upgrade, quic-go write), which is exactly the kind of thing
-      # that degrades a 1H1G box over days rather than failing outright.
+      # running, so a stale pin quietly holds every landing machine back. Re-check
+      # against the current 1.14.x stable at each release.
       - name: Build sing-box with v2ray_api
         env:
-          SB_VERSION: v1.13.19
+          SB_VERSION: v1.14.0
         run: |
           set -e
           git clone --depth 1 --branch "$SB_VERSION" https://github.com/SagerNet/sing-box.git /tmp/sing-box
           cd /tmp/sing-box
-          TAGS="with_gvisor,with_quic,with_grpc,with_dhcp,with_wireguard,with_utls,with_acme,with_clash_api,with_v2ray_api,with_tailscale,with_ccm,with_ocm,with_naive_outbound,with_purego,badlinkname,tfogo_checklinkname0"
+          TAGS="with_gvisor,with_quic,with_grpc,with_dhcp,with_wireguard,with_utls,with_acme,with_clash_api,with_v2ray_api,with_tailscale,with_ccm,with_ocm,with_cloudflared,with_naive_outbound,with_usbip,with_openvpn,with_openconnect,with_purego,badlinkname,tfogo_checklinkname0"
           for arch in amd64 arm64; do
             echo "== sing-box linux/$arch =="
             # -checklinkname=0 is required: sing-box's badtls reaches into

--- a/README.md
+++ b/README.md
@@ -317,12 +317,14 @@ systemctl daemon-reload && systemctl enable --now qingzhou
 
 ## 🔌 API 概览
 
-鉴权：`Authorization: Bearer <token>` 或 `qz_token` Cookie。
+鉴权：`Authorization: Bearer <JWT 或 API Token>` 或 `qz_token` Cookie。
+
+机器用 **API Token**（`qz_at_…`，管理页 `/admin/api-tokens`）：可 scope / 过期 / 吊销；首批 scope 为 `stats:read`、`users:read`、`nodes:read`、`servers:read`、`backup:write`。Token **不能**调用 `update/*`；管理 Token 本身只能用管理员登录会话。明文只在创建时返回一次，库内仅存哈希。
 
 - **公开**：`GET /api/health`、`GET /api/config`、`POST /api/auth/{login,register,forgot,reset}`、`GET /api/auth/verify`、`GET /sub/{token}`（聚合订阅，UA 自适应或 `?format=clash|singbox|surge`）、`GET /install-singbox.sh`、`GET /api/monitor/{public,heatmap,install.sh,agent/{arch}}`
 - **用户**：`/api/user/{dashboard,plans,subscription,reset-sub,reset-node-creds,packages,purchase,orders,points,announcements,sessions,nodes,proxies,stats/traffic,password,email}`、`GET /api/auth/me`
 - **管理**：
-  - 业务 `/api/admin/{users,user-groups,packages,orders,reg-codes,announcements,help,settings}`（含 `orders/{id}/refund-preview`、`packages/{id}/retire`）
+  - 业务 `/api/admin/{users,user-groups,packages,orders,reg-codes,announcements,help,settings,tokens}`（含 `orders/{id}/refund-preview`、`packages/{id}/retire`；`tokens` 为 API Token 创建/列表/吊销）
   - 节点 `/api/admin/{nodes,node-groups,node-sources,servers}`（含 `nodes/singbox` 版本探测与 `nodes/{id}/singbox/upgrade` 一键重装）
   - 原生 sing-box `/api/admin/sb/*`（TLS、入站、代理出口 `sb/egresses`、`sb/preview`、`sb/port-check`、`sb/sni-test`、`sb/import-remote/*`）
   - 证书中心 `/api/admin/certs/*`

--- a/frontend/src/components/DashboardLayout.vue
+++ b/frontend/src/components/DashboardLayout.vue
@@ -146,6 +146,7 @@ const adminOpsItems: MenuOption[] = [
   { label: '套餐管理', key: '/admin/packages', icon: renderIcon(ArchiveOutline) },
   { label: '订单管理', key: '/admin/orders', icon: renderIcon(ReceiptOutline) },
   { label: '注册码', key: '/admin/reg-codes', icon: renderIcon(KeyOutline) },
+  { label: 'API Token', key: '/admin/api-tokens', icon: renderIcon(KeyOutline) },
 ]
 const adminNodeItems: MenuOption[] = [
   { label: '节点管理', key: '/admin/nodes', icon: renderIcon(ServerOutline) },
@@ -188,7 +189,7 @@ const titleMap: Record<string, string> = {
   '/orders': '订单记录', '/points': '积分明细', '/notices': '公告通知', '/help': '帮助中心', '/account': '账户设置',
   '/admin': '管理概览', '/admin/users': '用户管理', '/admin/user-groups': '用户组', '/admin/packages': '套餐管理', '/admin/nodes': '节点管理',
   '/admin/singbox': 'sing-box', '/admin/certs': '证书管理', '/admin/orders': '订单管理', '/admin/servers': '服务器', '/admin/monitor': '监控管理',
-  '/admin/settings': '系统设置', '/admin/reg-codes': '注册码', '/admin/announcements': '公告管理', '/admin/manual-notifications': '手动通知', '/admin/help': '帮助文档',
+  '/admin/settings': '系统设置', '/admin/reg-codes': '注册码', '/admin/api-tokens': 'API Token', '/admin/announcements': '公告管理', '/admin/manual-notifications': '手动通知', '/admin/help': '帮助文档',
   '/admin/update': '在线更新',
 }
 const currentTitle = computed(() => titleMap[route.path] || config.config.site_name || '轻舟')

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -35,6 +35,7 @@ const router = createRouter({
         { path: 'admin/monitor/:id', name: 'admin-monitor-detail', component: () => import('@/views/AdminMonitorDetail.vue'), meta: { requiresAdmin: true } },
         { path: 'admin/settings', name: 'admin-settings', component: () => import('@/views/AdminSettings.vue'), meta: { requiresAdmin: true } },
         { path: 'admin/reg-codes', name: 'admin-regcodes', component: () => import('@/views/AdminRegCodes.vue'), meta: { requiresAdmin: true } },
+        { path: 'admin/api-tokens', name: 'admin-api-tokens', component: () => import('@/views/AdminAPITokens.vue'), meta: { requiresAdmin: true } },
         { path: 'admin/announcements', name: 'admin-announcements', component: () => import('@/views/AdminAnnouncements.vue'), meta: { requiresAdmin: true } },
         { path: 'admin/manual-notifications', name: 'admin-manual-notifications', component: () => import('@/views/AdminManualNotifications.vue'), meta: { requiresAdmin: true } },
         { path: 'admin/help', name: 'admin-help', component: () => import('@/views/AdminHelp.vue'), meta: { requiresAdmin: true } },

--- a/frontend/src/views/AdminAPITokens.vue
+++ b/frontend/src/views/AdminAPITokens.vue
@@ -1,0 +1,155 @@
+<template>
+  <div>
+    <div class="page-head">
+      <div>
+        <h2 class="page-title">API Token</h2>
+        <p class="page-sub">给脚本 / Telegram / 外部运维用的机器身份：可收窄 scope、可过期、可吊销。明文只在创建时展示一次。</p>
+      </div>
+    </div>
+
+    <n-alert type="warning" :bordered="false" style="margin-bottom:16px;">
+      不要把 <code>backup:write</code> 发给不可信集成；Token <b>不能</b>调用在线更新 / 回滚。管理 Token 本身只能用管理员登录会话。
+    </n-alert>
+
+    <n-card size="small" style="margin-bottom:16px;">
+      <div style="display:flex;gap:10px;align-items:flex-end;flex-wrap:wrap;">
+        <div style="flex:1;min-width:160px;">
+          <div style="font-size:12px;color:var(--text-3);margin-bottom:4px;">名称</div>
+          <n-input v-model:value="form.name" placeholder="如 telegram-bot" />
+        </div>
+        <div style="flex:2;min-width:240px;">
+          <div style="font-size:12px;color:var(--text-3);margin-bottom:4px;">Scopes</div>
+          <n-select v-model:value="form.scopes" :options="scopeOpts" multiple placeholder="至少选一个" />
+        </div>
+        <div>
+          <div style="font-size:12px;color:var(--text-3);margin-bottom:4px;">有效期</div>
+          <n-select v-model:value="form.ttl" :options="ttlOpts" style="width:140px;" />
+        </div>
+        <n-button type="primary" :loading="creating" @click="createToken">创建</n-button>
+      </div>
+      <div v-if="createdPlain" style="margin-top:12px;padding:10px;background:var(--bg-soft);border-radius:8px;">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;">
+          <span style="font-size:12px;font-weight:600;color:var(--warning);">请立即复制，关闭后无法再查看明文</span>
+          <n-button size="tiny" @click="copyPlain">复制</n-button>
+        </div>
+        <div style="font-family:monospace;font-size:12px;word-break:break-all;">{{ createdPlain }}</div>
+      </div>
+    </n-card>
+
+    <n-spin :show="loading">
+      <div v-if="tokens.length" class="card-grid">
+        <div v-for="t in tokens" :key="t.id" class="list-card">
+          <div class="lc-head">
+            <span class="lc-title">{{ t.name }}</span>
+            <n-tag :type="statusType(t)" size="tiny" :bordered="false">{{ statusLabel(t) }}</n-tag>
+          </div>
+          <div class="lc-meta">
+            <span class="kv">前缀 <b style="font-family:monospace;">{{ t.prefix }}…</b></span>
+            <span class="kv">创建 {{ fmtDateTime(t.created_at) }}</span>
+          </div>
+          <div class="lc-meta">
+            <span class="kv">Scopes <b>{{ (t.scopes || []).join(', ') }}</b></span>
+          </div>
+          <div class="lc-meta">
+            <span class="kv">过期 {{ t.expires_at ? fmtDateTime(t.expires_at) : '永不过期' }}</span>
+            <span class="kv">最近使用 {{ t.last_used_at ? fmtDateTime(t.last_used_at) : '从未' }}</span>
+          </div>
+          <div class="lc-foot">
+            <n-button v-if="!t.revoked_at" size="tiny" type="error" @click="revoke(t)">吊销</n-button>
+          </div>
+        </div>
+      </div>
+      <n-empty v-else-if="!loading" description="暂无 API Token" style="padding:40px 0;" />
+    </n-spin>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, onMounted } from 'vue'
+import { NCard, NInput, NButton, NTag, NSpin, NSelect, NEmpty, NAlert, useMessage, useDialog } from 'naive-ui'
+import { apiList, apiPost, apiDelete } from '@/api'
+import { fmtDateTime } from '@/utils/format'
+import { copyText } from '@/utils/clipboard'
+
+const message = useMessage()
+const dialog = useDialog()
+const tokens = ref<any[]>([])
+const loading = ref(false)
+const creating = ref(false)
+const createdPlain = ref('')
+
+const scopeOpts = [
+  { label: 'stats:read', value: 'stats:read' },
+  { label: 'users:read', value: 'users:read' },
+  { label: 'nodes:read', value: 'nodes:read' },
+  { label: 'servers:read', value: 'servers:read' },
+  { label: 'backup:write（敏感）', value: 'backup:write' },
+]
+const ttlOpts = [
+  { label: '永不过期', value: 0 },
+  { label: '7 天', value: 7 * 86400 },
+  { label: '30 天', value: 30 * 86400 },
+  { label: '90 天', value: 90 * 86400 },
+  { label: '365 天', value: 365 * 86400 },
+]
+const form = reactive({ name: '', scopes: ['stats:read'] as string[], ttl: 0 })
+
+function statusLabel(t: any) {
+  if (t.revoked_at) return '已吊销'
+  if (t.expires_at && t.expires_at * 1000 < Date.now()) return '已过期'
+  return '有效'
+}
+function statusType(t: any): 'success' | 'warning' | 'error' | 'default' {
+  if (t.revoked_at) return 'error'
+  if (t.expires_at && t.expires_at * 1000 < Date.now()) return 'warning'
+  return 'success'
+}
+
+async function load() {
+  loading.value = true
+  try { tokens.value = await apiList('/api/admin/tokens') || [] }
+  catch (e: any) { message.error(e.message) }
+  finally { loading.value = false }
+}
+
+async function createToken() {
+  if (!form.name.trim()) { message.warning('请填写名称'); return }
+  if (!form.scopes.length) { message.warning('请选择 scope'); return }
+  creating.value = true
+  createdPlain.value = ''
+  try {
+    const data = await apiPost<any>('/api/admin/tokens', {
+      name: form.name.trim(),
+      scopes: form.scopes,
+      expires_in: form.ttl || 0,
+    })
+    createdPlain.value = data.token
+    form.name = ''
+    message.success('已创建，请复制明文 Token')
+    await load()
+  } catch (e: any) { message.error(e.message) }
+  finally { creating.value = false }
+}
+
+function copyPlain() {
+  copyText(createdPlain.value)
+  message.success('已复制')
+}
+
+function revoke(t: any) {
+  dialog.warning({
+    title: '吊销 Token',
+    content: `确定吊销「${t.name}」？使用该 Token 的集成会立即失效。`,
+    positiveText: '吊销', negativeText: '取消',
+    onPositiveClick: async () => {
+      try {
+        await apiDelete('/api/admin/tokens/' + t.id)
+        message.success('已吊销')
+        await load()
+      } catch (e: any) { message.error(e.message) }
+    },
+  })
+}
+
+onMounted(load)
+</script>

--- a/frontend/src/views/AdminNodes.vue
+++ b/frontend/src/views/AdminNodes.vue
@@ -236,6 +236,12 @@
       <n-drawer-content :title="editingNode ? '编辑节点' : '添加节点'" closable>
         <n-form label-placement="left" label-width="80">
           <n-form-item label="名称"><n-input v-model:value="nodeForm.name" /></n-form-item>
+          <n-form-item label="订阅备注">
+            <div style="width:100%;">
+              <n-input v-model:value="nodeForm.remark" placeholder="可选；优先作为订阅展示名，不影响计量 identity" />
+              <div class="form-tip">留空则用上方名称。客户端手动选中靠展示名记忆，请保持稳定。</div>
+            </div>
+          </n-form-item>
           <n-form-item label="类型">
             <n-radio-group v-model:value="nodeForm.type">
               <n-radio value="self_built">自建</n-radio>
@@ -709,13 +715,13 @@ const editingNode = ref<any>(null)
 // share_link must match store.Node's JSON tag — it was `link`, so the field was
 // never sent: created external nodes had no link at all, and saving an existing
 // one blanked its stored link.
-const nodeForm = reactive({ name: '', type: 'self_built', inbound_tag: '', route_upstream_inbound_id: 0, route_upstream_broken: false, share_link: '', group_ids: [] as number[], enabled: true })
+const nodeForm = reactive({ name: '', remark: '', type: 'self_built', inbound_tag: '', route_upstream_inbound_id: 0, route_upstream_broken: false, share_link: '', group_ids: [] as number[], enabled: true })
 function openNode(n?: any) {
   editingNode.value = n || null
   if (n) {
-    Object.assign(nodeForm, { name: n.name, type: n.type || 'self_built', inbound_tag: n.inbound_tag || '', route_upstream_inbound_id: n.route_upstream_inbound_id || 0, route_upstream_broken: !!n.route_upstream_broken, share_link: n.share_link || '', group_ids: n.group_ids || [], enabled: n.enabled })
+    Object.assign(nodeForm, { name: n.name, remark: n.remark || '', type: n.type || 'self_built', inbound_tag: n.inbound_tag || '', route_upstream_inbound_id: n.route_upstream_inbound_id || 0, route_upstream_broken: !!n.route_upstream_broken, share_link: n.share_link || '', group_ids: n.group_ids || [], enabled: n.enabled })
   } else {
-    Object.assign(nodeForm, { name: '', type: 'self_built', inbound_tag: '', route_upstream_inbound_id: 0, route_upstream_broken: false, share_link: '', group_ids: [], enabled: true })
+    Object.assign(nodeForm, { name: '', remark: '', type: 'self_built', inbound_tag: '', route_upstream_inbound_id: 0, route_upstream_broken: false, share_link: '', group_ids: [], enabled: true })
   }
   showNode.value = true
 }

--- a/frontend/src/views/AdminSettings.vue
+++ b/frontend/src/views/AdminSettings.vue
@@ -450,6 +450,15 @@
       <n-card v-show="activeSectionId === 'settings-template'" id="settings-template" class="settings-section" size="small">
         <p style="font-size:12px;color:var(--text-3);margin-bottom:12px;">自定义 Clash/sing-box 订阅输出模板。留空使用内置默认模板；改过之后会一直沿用你的版本（升级带来的新版内置模板不会自动生效），点「恢复内置默认」即可清空覆盖、跟随内置。</p>
         <n-form label-placement="top">
+          <n-form-item label="Clash 声明 UDP">
+            <div style="width:100%;">
+              <n-switch :value="form.sub_clash_udp !== '0' && form.sub_clash_udp !== 'false'"
+                        @update:value="(v: boolean) => form.sub_clash_udp = v ? '1' : '0'" />
+              <div style="font-size:12px;color:var(--text-3);margin-top:6px;line-height:1.6;">
+                开启时（默认）Clash 订阅对支持的协议写 <code>udp: true</code>。关闭则省略该字段。入站 egress 阻断 UDP 的节点仍会强制 <code>udp: false</code>。
+              </div>
+            </div>
+          </n-form-item>
           <n-form-item label="Clash 模板 (YAML)">
             <div style="width:100%;">
               <n-input v-model:value="form.sub_clash_template" type="textarea" :rows="8" placeholder="留空用内置模板" style="font-family:monospace;font-size:12px;" />
@@ -617,7 +626,7 @@ const settingsGroups: SettingsGroup[] = [
   { label: '节点与安全', sections: [
     { id: 'settings-cert', label: '证书 / ACME', note: 'Cloudflare DNS', description: '配置 Cloudflare DNS 验证所需的令牌与 ACME 邮箱。', keywords: '证书 ACME Cloudflare DNS Token Let’s Encrypt' },
     { id: 'settings-security', label: '出口安全', note: '内网访问防护', description: '控制节点是否阻断内网、链路本地地址和云元数据。', keywords: '安全 内网 元数据 127 192 169 阻断' },
-    { id: 'settings-template', label: '订阅模板', note: '客户端输出', description: '自定义 Clash 和 sing-box 的订阅输出模板。', keywords: '订阅 模板 Clash YAML sing-box JSON' },
+    { id: 'settings-template', label: '订阅模板', note: '客户端输出', description: '自定义 Clash / sing-box 订阅模板与 Clash UDP 声明。', keywords: '订阅 模板 Clash YAML sing-box JSON UDP' },
     { id: 'settings-runtime', label: '采集与同步', note: '节点负载', description: '调整探针采集、流量统计和健康检查频率。', keywords: '探针 采集 流量 统计 健康检查 同步 间隔 重建' },
   ] },
   { label: '系统维护', sections: [

--- a/frontend/src/views/AdminSingbox.vue
+++ b/frontend/src/views/AdminSingbox.vue
@@ -633,8 +633,44 @@
             <n-form-item label="下行 Mbps"><n-input-number v-model:value="ie.down_mbps" :min="0" style="width:100%;" /></n-form-item>
           </template>
           <template v-if="ie.type === 'hysteria2'">
-            <n-form-item label="混淆密码"><n-input v-model:value="ie.obfs_password" placeholder="留空不混淆" /></n-form-item>
+            <n-form-item label="混淆类型">
+              <n-select v-model:value="ie.obfs_type" :options="[
+                {label:'关闭',value:''},
+                {label:'salamander',value:'salamander'},
+                {label:'gecko（1.14+）',value:'gecko'}
+              ]" />
+            </n-form-item>
+            <n-form-item v-if="ie.obfs_type" label="混淆密码"><n-input v-model:value="ie.obfs_password" placeholder="必填" /></n-form-item>
+            <template v-if="ie.obfs_type === 'gecko'">
+              <n-form-item label="gecko 最小包">
+                <n-input-number v-model:value="ie.obfs_min_packet" :min="0" placeholder="默认 512" style="width:100%;" />
+              </n-form-item>
+              <n-form-item label="gecko 最大包">
+                <n-input-number v-model:value="ie.obfs_max_packet" :min="0" placeholder="默认 1200" style="width:100%;" />
+              </n-form-item>
+            </template>
+            <n-form-item label="BBR 配置">
+              <n-select v-model:value="ie.bbr_profile" :options="[
+                {label:'默认（standard）',value:''},
+                {label:'conservative',value:'conservative'},
+                {label:'standard',value:'standard'},
+                {label:'aggressive',value:'aggressive'}
+              ]" />
+            </n-form-item>
+            <n-form-item label="关闭 Chrome QUIC 鹦鹉">
+              <n-switch v-model:value="ie.disable_chrome_parrot" />
+              <template #feedback>默认开启鹦鹉；Ed25519 证书或不兼容客户端可关闭。仅写入订阅出站，不下发入站。</template>
+            </n-form-item>
+            <n-form-item label="跳港间隔">
+              <n-input v-model:value="ie.hop_interval" placeholder="如 30s，留空不写" />
+            </n-form-item>
+            <n-form-item label="跳港间隔上限">
+              <n-input v-model:value="ie.hop_interval_max" placeholder="如 60s，与间隔组成随机区间" />
+            </n-form-item>
             <n-form-item label="伪装 URL"><n-input v-model:value="ie.masquerade" placeholder="留空不伪装" /></n-form-item>
+            <n-alert type="info" :bordered="false" style="margin-bottom:12px;">
+              Hysteria Realm（NAT 穿透）本版暂不提供表单；需要时请在自定义配置里写 realm 块，或等后续跟进。节点需 sing-box ≥ 1.14 才能使用 gecko / bbr_profile / parrot / hop。跳港字段为客户端提示，需配合 server_ports 才生效。
+            </n-alert>
           </template>
           <template v-if="ie.type === 'shadowsocks'">
             <n-form-item label="加密方式"><n-select v-model:value="ie.ss_method" :options="ssOpts" /></n-form-item>
@@ -1449,7 +1485,7 @@ function normFlow(v: any): string {
 const ie = reactive({
   id: 0, type: 'vless', tag: '', listen: '::', listen_port: 443, tls_id: 0, server_id: 0, enabled: true,
   tfo: false, mptcp: false, cc: 'bbr', zero_rtt: false,
-  up_mbps: 0, down_mbps: 0, obfs_password: '', masquerade: '',
+  up_mbps: 0, down_mbps: 0, obfs_type: '', obfs_password: '', obfs_min_packet: 0, obfs_max_packet: 0, bbr_profile: '', disable_chrome_parrot: false, hop_interval: '', hop_interval_max: '', masquerade: '',
   net: 'tcp', ws_path: '/', ws_host: '', ws_early_data: 0, grpc_service: '', grpc_multi: false,
   ss_method: '2022-blake3-aes-128-gcm', flow: 'xtls-rprx-vision',
   anytls_idle_check: 0, anytls_idle_timeout: 0, anytls_min_idle: 0,
@@ -1460,7 +1496,7 @@ function resetIe() {
   Object.assign(ie, {
     id: 0, type: 'vless', tag: '', listen: '::', listen_port: 443, tls_id: 0, server_id: 0, enabled: true,
     tfo: false, mptcp: false, cc: 'bbr', zero_rtt: false,
-    up_mbps: 0, down_mbps: 0, obfs_password: '', masquerade: '',
+    up_mbps: 0, down_mbps: 0, obfs_type: '', obfs_password: '', obfs_min_packet: 0, obfs_max_packet: 0, bbr_profile: '', disable_chrome_parrot: false, hop_interval: '', hop_interval_max: '', masquerade: '',
     net: 'tcp', ws_path: '/', ws_host: '', ws_early_data: 0, grpc_service: '', grpc_multi: false,
     ss_method: '2022-blake3-aes-128-gcm', flow: 'xtls-rprx-vision',
     anytls_idle_check: 0, anytls_idle_timeout: 0, anytls_min_idle: 0,
@@ -1477,7 +1513,12 @@ function openInbound(n?: any, clone = false) {
       tls_id: n.tls_id || 0, server_id: n.server_id || 0, enabled: clone ? false : n.enabled,
       tfo: !!o.tcp_fast_open, mptcp: !!o.tcp_multi_path, cc: o.congestion_control || 'bbr', zero_rtt: !!o.zero_rtt_handshake,
       up_mbps: o.up_mbps || 0, down_mbps: o.down_mbps || 0,
-      obfs_password: obfs.password || '', masquerade: typeof o.masquerade === 'string' ? o.masquerade : (o.masquerade?.url || ''),
+      obfs_type: obfs.type || (obfs.password ? 'salamander' : ''), obfs_password: obfs.password || '',
+      obfs_min_packet: obfs.min_packet_size || 0, obfs_max_packet: obfs.max_packet_size || 0,
+      bbr_profile: o.bbr_profile || '',
+      disable_chrome_parrot: !!o.disable_chrome_parrot,
+      hop_interval: o.hop_interval || '', hop_interval_max: o.hop_interval_max || '',
+      masquerade: typeof o.masquerade === 'string' ? o.masquerade : (o.masquerade?.url || ''),
       net: tr.type || 'tcp', ws_path: tr.path || '/', ws_host: tr.host || '', ws_early_data: tr.max_early_data || 0,
       grpc_service: tr.service_name || '', grpc_multi: !!tr.multi_mode,
       ss_method: o.method || '2022-blake3-aes-128-gcm', flow: normFlow(o.flow),
@@ -1530,7 +1571,21 @@ async function saveInbound() {
     if (ie.type === 'vless') o.flow = ie.flow
     if (ie.type === 'tuic') { o.congestion_control = ie.cc; o.zero_rtt_handshake = ie.zero_rtt }
     if (ie.type === 'hysteria2' || ie.type === 'hysteria') { if (ie.up_mbps) o.up_mbps = ie.up_mbps; if (ie.down_mbps) o.down_mbps = ie.down_mbps }
-    if (ie.type === 'hysteria2') { if (ie.obfs_password) o.obfs = { type: 'salamander', password: ie.obfs_password }; if (ie.masquerade) o.masquerade = ie.masquerade }
+    if (ie.type === 'hysteria2') {
+      if (ie.obfs_type && ie.obfs_password) {
+        const obfs: any = { type: ie.obfs_type, password: ie.obfs_password }
+        if (ie.obfs_type === 'gecko') {
+          if (ie.obfs_min_packet > 0) obfs.min_packet_size = ie.obfs_min_packet
+          if (ie.obfs_max_packet > 0) obfs.max_packet_size = ie.obfs_max_packet
+        }
+        o.obfs = obfs
+      }
+      if (ie.bbr_profile) o.bbr_profile = ie.bbr_profile
+      if (ie.disable_chrome_parrot) o.disable_chrome_parrot = true
+      if (ie.hop_interval) o.hop_interval = ie.hop_interval
+      if (ie.hop_interval_max) o.hop_interval_max = ie.hop_interval_max
+      if (ie.masquerade) o.masquerade = ie.masquerade
+    }
     if (ie.type === 'shadowsocks') o.method = ie.ss_method
     if (ie.type === 'anytls') {
       if (ie.anytls_idle_check) o.idle_session_check_interval = ie.anytls_idle_check

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -116,6 +116,10 @@ func (a *API) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 	if all["sub_clash_template"] == "" {
 		all["sub_clash_template"] = subconv.DefaultClashTemplate
 	}
+	// Default on: missing key means advertise udp:true (historical behaviour).
+	if all["sub_clash_udp"] == "" {
+		all["sub_clash_udp"] = "1"
+	}
 	if all["sub_singbox_template"] == "" {
 		all["sub_singbox_template"] = subconv.DefaultSingboxTemplate
 	}

--- a/internal/api/apitokens.go
+++ b/internal/api/apitokens.go
@@ -127,6 +127,21 @@ func scopeForAdminRequest(r *http.Request) string {
 	return ""
 }
 
+// rejectAPIToken denies machine API-token auth on user-facing routes.
+// API tokens impersonate their creator (admin) via authMiddleware; without this
+// gate a scoped token (e.g. stats:read) could call /api/user/* mutations.
+// Machine tokens are admin-API only; JWT/session remains for /api/user/* and /api/auth/me|logout.
+func (a *API) rejectAPIToken(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		kind, _ := r.Context().Value(ctxAuthKind).(string)
+		if kind == "api_token" {
+			fail(w, http.StatusForbidden, "权限不足")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // enforceAPITokenScope denies API-token callers that lack the mapped scope.
 // JWT sessions pass through unchanged.
 func (a *API) enforceAPITokenScope(next http.Handler) http.Handler {

--- a/internal/api/apitokens.go
+++ b/internal/api/apitokens.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"qingzhou/internal/store"
+)
+
+// handleAdminListAPITokens GET /api/admin/tokens
+func (a *API) handleAdminListAPITokens(w http.ResponseWriter, r *http.Request) {
+	if !a.requireJWTAdmin(w, r) {
+		return
+	}
+	list, err := a.st.ListAPITokens()
+	if err != nil {
+		fail(w, http.StatusInternalServerError, "读取失败")
+		return
+	}
+	ok(w, list)
+}
+
+type createAPITokenReq struct {
+	Name      string   `json:"name"`
+	Scopes    []string `json:"scopes"`
+	ExpiresIn int64    `json:"expires_in"` // seconds from now; 0 = never
+	ExpiresAt int64    `json:"expires_at"` // absolute unix; takes precedence if >0
+}
+
+// handleAdminCreateAPIToken POST /api/admin/tokens
+func (a *API) handleAdminCreateAPIToken(w http.ResponseWriter, r *http.Request) {
+	if !a.requireJWTAdmin(w, r) {
+		return
+	}
+	var req createAPITokenReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		fail(w, http.StatusBadRequest, "无效请求")
+		return
+	}
+	expiresAt := req.ExpiresAt
+	if expiresAt == 0 && req.ExpiresIn > 0 {
+		expiresAt = time.Now().Unix() + req.ExpiresIn
+	}
+	uid, _ := r.Context().Value(ctxUserID).(int64)
+	plain, tok, err := a.st.CreateAPIToken(req.Name, req.Scopes, uid, expiresAt)
+	if err != nil {
+		fail(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	log.Printf("audit: api_token created id=%d name=%q scopes=%v by=%d", tok.ID, tok.Name, tok.Scopes, uid)
+	ok(w, J{
+		"token":      plain, // shown once
+		"id":         tok.ID,
+		"name":       tok.Name,
+		"prefix":     tok.Prefix,
+		"scopes":     tok.Scopes,
+		"expires_at": tok.ExpiresAt,
+		"created_at": tok.CreatedAt,
+	})
+}
+
+// handleAdminRevokeAPIToken DELETE /api/admin/tokens/{id}
+func (a *API) handleAdminRevokeAPIToken(w http.ResponseWriter, r *http.Request) {
+	if !a.requireJWTAdmin(w, r) {
+		return
+	}
+	id := int64(atoi(chi.URLParam(r, "id")))
+	if id <= 0 {
+		fail(w, http.StatusBadRequest, "无效 id")
+		return
+	}
+	if err := a.st.RevokeAPIToken(id); err != nil {
+		fail(w, http.StatusNotFound, "令牌不存在")
+		return
+	}
+	uid, _ := r.Context().Value(ctxUserID).(int64)
+	log.Printf("audit: api_token revoked id=%d by=%d", id, uid)
+	ok(w, nil)
+}
+
+// requireJWTAdmin rejects API-token auth for token management endpoints.
+func (a *API) requireJWTAdmin(w http.ResponseWriter, r *http.Request) bool {
+	kind, _ := r.Context().Value(ctxAuthKind).(string)
+	if kind == "api_token" {
+		fail(w, http.StatusForbidden, "权限不足")
+		return false
+	}
+	role, _ := r.Context().Value(ctxRole).(string)
+	if role != "admin" {
+		fail(w, http.StatusForbidden, "需要管理员权限")
+		return false
+	}
+	return true
+}
+
+// scopeForAdminRequest maps an admin HTTP request to a required API token
+// scope. Empty means the route is not available to API tokens (JWT only).
+func scopeForAdminRequest(r *http.Request) string {
+	path := r.URL.Path
+	method := r.Method
+	if strings.HasPrefix(path, "/api/admin/tokens") {
+		return "" // JWT only
+	}
+	if strings.HasPrefix(path, "/api/admin/update") {
+		return "" // never for tokens
+	}
+	if method == http.MethodGet && strings.HasPrefix(path, "/api/admin/stats") {
+		return "stats:read"
+	}
+	if method == http.MethodGet && (path == "/api/admin/users" || strings.HasPrefix(path, "/api/admin/users/")) {
+		return "users:read"
+	}
+	if method == http.MethodGet && (path == "/api/admin/nodes" || strings.HasPrefix(path, "/api/admin/nodes/")) {
+		return "nodes:read"
+	}
+	if method == http.MethodGet && (path == "/api/admin/servers" || strings.HasPrefix(path, "/api/admin/servers/")) {
+		return "servers:read"
+	}
+	if method == http.MethodGet && path == "/api/admin/backup" {
+		return "backup:write"
+	}
+	return ""
+}
+
+// enforceAPITokenScope denies API-token callers that lack the mapped scope.
+// JWT sessions pass through unchanged.
+func (a *API) enforceAPITokenScope(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		kind, _ := r.Context().Value(ctxAuthKind).(string)
+		if kind != "api_token" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		need := scopeForAdminRequest(r)
+		if need == "" {
+			fail(w, http.StatusForbidden, "权限不足")
+			return
+		}
+		scopes, _ := r.Context().Value(ctxScopes).([]string)
+		if !store.APITokenHasScope(scopes, need) {
+			fail(w, http.StatusForbidden, "权限不足")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/api/apitokens_test.go
+++ b/internal/api/apitokens_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"qingzhou/internal/store"
+)
+
+func openAPITokenTestAPI(t *testing.T) (*API, *store.Store) {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	if err := st.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+	return &API{st: st, secret: []byte("test-secret-32-bytes-pad-pad-pad!")}, st
+}
+
+func TestAPIToken_AuthAndScopes(t *testing.T) {
+	a, st := openAPITokenTestAPI(t)
+	plain, _, err := st.CreateAPIToken("ci", []string{"stats:read"}, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := chi.NewRouter()
+	r.Use(a.authMiddleware)
+	r.Use(a.requireAdmin)
+	r.Use(a.enforceAPITokenScope)
+	r.Get("/api/admin/stats/overview", func(w http.ResponseWriter, r *http.Request) {
+		ok(w, J{"ok": true})
+	})
+	r.Get("/api/admin/users", func(w http.ResponseWriter, r *http.Request) {
+		ok(w, J{"ok": true})
+	})
+	r.Get("/api/admin/tokens", a.handleAdminListAPITokens)
+	r.Post("/api/admin/settings", func(w http.ResponseWriter, r *http.Request) {
+		ok(w, nil)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/stats/overview", nil)
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("stats with scope: got %d %s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/admin/users", nil)
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != 403 {
+		t.Fatalf("users without scope: got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/admin/settings", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != 403 {
+		t.Fatalf("settings write: got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/admin/tokens", nil)
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != 403 {
+		t.Fatalf("tokens list via api token: got %d", rec.Code)
+	}
+
+	list, _ := st.ListAPITokens()
+	_ = st.RevokeAPIToken(list[0].ID)
+	req = httptest.NewRequest(http.MethodGet, "/api/admin/stats/overview", nil)
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != 401 {
+		t.Fatalf("revoked: got %d", rec.Code)
+	}
+}
+
+func TestAPIToken_CreateHandlerJWT(t *testing.T) {
+	a, _ := openAPITokenTestAPI(t)
+	body, _ := json.Marshal(map[string]any{
+		"name": "n", "scopes": []string{"nodes:read"}, "expires_in": 3600,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/tokens", bytes.NewReader(body))
+	ctx := context.WithValue(req.Context(), ctxUserID, int64(7))
+	ctx = context.WithValue(ctx, ctxRole, "admin")
+	ctx = context.WithValue(ctx, ctxAuthKind, "jwt")
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	a.handleAdminCreateAPIToken(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("create: %d %s", rec.Code, rec.Body.String())
+	}
+	var env struct {
+		Code int `json:"code"`
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil || env.Data.Token == "" {
+		t.Fatalf("envelope: %v body=%s", err, rec.Body.String())
+	}
+}

--- a/internal/api/apitokens_test.go
+++ b/internal/api/apitokens_test.go
@@ -117,3 +117,37 @@ func TestAPIToken_CreateHandlerJWT(t *testing.T) {
 		t.Fatalf("envelope: %v body=%s", err, rec.Body.String())
 	}
 }
+
+func TestAPIToken_RejectedOnUserRoutes(t *testing.T) {
+	a, st := openAPITokenTestAPI(t)
+	plain, _, err := st.CreateAPIToken("ci", []string{"stats:read"}, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := chi.NewRouter()
+	r.Use(a.authMiddleware)
+	r.Use(a.rejectAPIToken)
+	r.Get("/api/user/dashboard", func(w http.ResponseWriter, r *http.Request) {
+		ok(w, J{"ok": true})
+	})
+	r.Post("/api/user/password", func(w http.ResponseWriter, r *http.Request) {
+		ok(w, nil)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/dashboard", nil)
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("dashboard with scoped api token: got %d %s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/user/password", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("password mutation with scoped api token: got %d %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -17,9 +17,12 @@ import (
 type ctxKey string
 
 const (
-	ctxUserID ctxKey = "uid"
-	ctxRole   ctxKey = "role"
-	ctxJti    ctxKey = "jti"
+	ctxUserID   ctxKey = "uid"
+	ctxRole     ctxKey = "role"
+	ctxJti      ctxKey = "jti"
+	ctxAuthKind ctxKey = "auth_kind" // "jwt" | "api_token"
+	ctxScopes   ctxKey = "scopes"    // []string when auth_kind=api_token
+	ctxTokenID  ctxKey = "token_id"
 
 	cookieName = "qz_token"
 	tokenTTL   = 7 * 24 * time.Hour
@@ -202,6 +205,23 @@ func (a *API) authMiddleware(next http.Handler) http.Handler {
 			fail(w, http.StatusUnauthorized, "未登录")
 			return
 		}
+		// Machine API tokens (Bearer only). Cookie-bound browser sessions stay on JWT.
+		if strings.HasPrefix(tokStr, "qz_at_") && strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+			at, err := a.st.LookupAPIToken(tokStr)
+			if err != nil || at == nil {
+				// Same message as a bad JWT — do not advertise token existence.
+				fail(w, http.StatusUnauthorized, "登录已失效，请重新登录")
+				return
+			}
+			a.st.TouchAPIToken(at.ID)
+			ctx := context.WithValue(r.Context(), ctxUserID, at.CreatedBy)
+			ctx = context.WithValue(ctx, ctxRole, "admin")
+			ctx = context.WithValue(ctx, ctxAuthKind, "api_token")
+			ctx = context.WithValue(ctx, ctxScopes, at.Scopes)
+			ctx = context.WithValue(ctx, ctxTokenID, at.ID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
 		claims, err := auth.Parse(a.secret, tokStr)
 		if err != nil {
 			fail(w, http.StatusUnauthorized, "登录已过期，请重新登录")
@@ -216,6 +236,7 @@ func (a *API) authMiddleware(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), ctxUserID, claims.UserID)
 		ctx = context.WithValue(ctx, ctxRole, claims.Role)
 		ctx = context.WithValue(ctx, ctxJti, claims.ID)
+		ctx = context.WithValue(ctx, ctxAuthKind, "jwt")
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -227,6 +227,7 @@ func (a *API) Router() http.Handler {
 	// Authenticated (any logged-in user)
 	r.Group(func(pr chi.Router) {
 		pr.Use(a.authMiddleware)
+		pr.Use(a.rejectAPIToken) // API tokens are admin-API only; never /api/user/*
 		pr.Get("/api/auth/me", a.handleMe)
 		pr.Post("/api/auth/logout", a.handleLogout)
 		pr.Get("/api/user/dashboard", a.handleDashboard)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -267,6 +267,10 @@ func (a *API) Router() http.Handler {
 	r.Group(func(ar chi.Router) {
 		ar.Use(a.authMiddleware)
 		ar.Use(a.requireAdmin)
+		ar.Use(a.enforceAPITokenScope)
+		ar.Get("/api/admin/tokens", a.handleAdminListAPITokens)
+		ar.Post("/api/admin/tokens", a.handleAdminCreateAPIToken)
+		ar.Delete("/api/admin/tokens/{id}", a.handleAdminRevokeAPIToken)
 		ar.Get("/api/admin/settings", a.handleGetSettings)
 		ar.Put("/api/admin/settings", a.handlePutSettings)
 		ar.Get("/api/admin/settings/default-templates", a.handleGetDefaultTemplates)

--- a/internal/api/subremark_test.go
+++ b/internal/api/subremark_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"encoding/base64"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"qingzhou/internal/store"
+	"qingzhou/internal/subconv"
+)
+
+func TestSubscriptionExternalRemark(t *testing.T) {
+	a, st := newUserEditAPI(t)
+	gid, err := st.CreateGroup(store.NodeGroup{Name: "free"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.SetSetting("free_group_id", strconv.FormatInt(gid, 10)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateUser(store.NewUser{Username: "remark-user", PasswordHash: "x", SubToken: "REMARK_TOKEN"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, remark := range []string{"", "HK-VIP"} {
+		if _, err := st.CreateNode(store.Node{Type: "external", Name: "admin-name", Remark: remark,
+			ShareLink: "trojan://secret@example.com:443#original", Enabled: true, GroupIDs: []int64{gid}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	router := a.Router()
+	for _, format := range []string{"base64", "clash", "singbox"} {
+		t.Run(format, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, httptest.NewRequest("GET", "/sub/REMARK_TOKEN?format="+format, nil))
+			if w.Code != 200 {
+				t.Fatalf("subscription: %d %s", w.Code, w.Body.String())
+			}
+			body := w.Body.String()
+			if format == "base64" {
+				decoded, err := base64.StdEncoding.DecodeString(body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				body = string(decoded)
+				if len(subconv.ParseLinks(strings.Split(body, "\n"))) != 2 {
+					t.Fatalf("missing nodes: %s", body)
+				}
+			}
+			if !strings.Contains(body, "original") || !strings.Contains(body, "HK-VIP") {
+				t.Fatalf("original or overridden remark missing: %s", body)
+			}
+		})
+	}
+}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -964,7 +964,15 @@ func (a *API) handleSub(w http.ResponseWriter, r *http.Request) {
 		format = subconv.FormatForUA(r.Header.Get("User-Agent"))
 	}
 	format = subconv.NormalizeFormat(format)
-	body, ctype, err := subconv.RenderWithProfile(format, links, aiNodes, clashTpl, singboxTpl, subURL, profile)
+	clashUDP, _ := a.st.GetSettingBool("sub_clash_udp")
+	// Default true when unset: GetSettingBool returns false for missing keys.
+	if v, _ := a.st.GetSetting("sub_clash_udp"); strings.TrimSpace(v) == "" {
+		clashUDP = true
+	}
+	body, ctype, err := subconv.RenderWithOptions(format, links, aiNodes, clashTpl, singboxTpl, subURL, subconv.RenderOptions{
+		Profile:         profile,
+		ClashDisableUDP: !clashUDP,
+	})
 	if err != nil {
 		http.Error(w, "render error", http.StatusBadGateway)
 		return

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -1127,7 +1127,7 @@ func (a *API) computeNodeEntries(u *store.User) []nodeEntry {
 	for _, n := range nodes {
 		switch n.Type {
 		case "external":
-			add(n.ShareLink, n.GroupID, gname[n.GroupID], "", 0, false, n.IsAI)
+			add(subconv.WithLinkRemark(n.ShareLink, n.Remark), n.GroupID, gname[n.GroupID], "", 0, false, n.IsAI)
 		case "self_built":
 			if n.InboundTag != "" {
 				if n.RouteUpstreamInboundID == 0 {

--- a/internal/singbox/generate.go
+++ b/internal/singbox/generate.go
@@ -217,6 +217,11 @@ func GenerateConfigWithOptions(base json.RawMessage, inbounds []Inbound, opt Opt
 		m["users"] = users
 		// flow 是 per-user 字段，从 inbound 级别移除，否则 sing-box check 会报错
 		delete(m, "flow")
+		// Hy2 client-only hints live in inbound options so share links / subconv
+		// can mirror them, but they are outbound fields — strip before emit.
+		delete(m, "disable_chrome_parrot")
+		delete(m, "hop_interval")
+		delete(m, "hop_interval_max")
 		ibList = append(ibList, m)
 		if tag, _ := m["tag"].(string); tag != "" {
 			emittedTags = append(emittedTags, tag)

--- a/internal/singbox/link.go
+++ b/internal/singbox/link.go
@@ -69,10 +69,15 @@ type LinkParams struct {
 	UpMbps   int
 	DownMbps int
 
-	// hysteria2 obfs (salamander). Both must be set on the client link or the
-	// handshake fails when the inbound has obfs enabled.
-	Obfs         string // obfs type, e.g. "salamander"
+	// hysteria2 obfs (salamander / gecko). Type+password must be set on the
+	// client link or the handshake fails when the inbound has obfs enabled.
+	Obfs         string // obfs type, e.g. "salamander" | "gecko"
 	ObfsPassword string
+	// Gecko-only on-wire packet size hints (sing-box 1.14+). 0 = omit (defaults).
+	ObfsMinPacket int
+	ObfsMaxPacket int
+	// Optional BBR profile mirrored from the inbound (sing-box 1.14+).
+	BBRProfile string
 
 	// TCP dial tuning (TCP-based protocols only). TCP Fast Open and MPTCP each
 	// need BOTH ends enabled to do anything, so 轻舟 mirrors the inbound's
@@ -301,6 +306,15 @@ func BuildShareLink(p LinkParams) string {
 			if p.ObfsPassword != "" {
 				q = append(q, "obfs-password="+url.QueryEscape(p.ObfsPassword))
 			}
+			if p.ObfsMinPacket > 0 {
+				q = append(q, "obfs-min-packet="+strconv.Itoa(p.ObfsMinPacket))
+			}
+			if p.ObfsMaxPacket > 0 {
+				q = append(q, "obfs-max-packet="+strconv.Itoa(p.ObfsMaxPacket))
+			}
+		}
+		if p.BBRProfile != "" {
+			q = append(q, "bbr-profile="+esc(p.BBRProfile))
 		}
 		if p.NoUDP {
 			q = append(q, noUDPParam)

--- a/internal/singbox/link.go
+++ b/internal/singbox/link.go
@@ -78,6 +78,11 @@ type LinkParams struct {
 	ObfsMaxPacket int
 	// Optional BBR profile mirrored from the inbound (sing-box 1.14+).
 	BBRProfile string
+	// Client-only Hy2 hints (sing-box 1.14+). Stored on the inbound as options
+	// and stripped before server config emit — they belong on the outbound.
+	DisableChromeParrot bool
+	HopInterval         string // duration, e.g. "30s"
+	HopIntervalMax      string // duration upper bound for hop randomization
 
 	// TCP dial tuning (TCP-based protocols only). TCP Fast Open and MPTCP each
 	// need BOTH ends enabled to do anything, so 轻舟 mirrors the inbound's
@@ -315,6 +320,15 @@ func BuildShareLink(p LinkParams) string {
 		}
 		if p.BBRProfile != "" {
 			q = append(q, "bbr-profile="+esc(p.BBRProfile))
+		}
+		if p.DisableChromeParrot {
+			q = append(q, "disable-chrome-parrot=1")
+		}
+		if p.HopInterval != "" {
+			q = append(q, "hop-interval="+esc(p.HopInterval))
+		}
+		if p.HopIntervalMax != "" {
+			q = append(q, "hop-interval-max="+esc(p.HopIntervalMax))
 		}
 		if p.NoUDP {
 			q = append(q, noUDPParam)

--- a/internal/store/apitokens.go
+++ b/internal/store/apitokens.go
@@ -1,0 +1,223 @@
+package store
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// KnownAPITokenScopes is the whitelist of scopes a token may request.
+var KnownAPITokenScopes = []string{
+	"stats:read",
+	"users:read",
+	"nodes:read",
+	"servers:read",
+	"backup:write",
+}
+
+const apiTokenPlainPrefix = "qz_at_"
+
+// APIToken is a row from api_tokens. TokenHash is never exported in JSON.
+type APIToken struct {
+	ID         int64    `json:"id"`
+	Name       string   `json:"name"`
+	Prefix     string   `json:"prefix"`
+	Scopes     []string `json:"scopes"`
+	CreatedBy  int64    `json:"created_by"`
+	ExpiresAt  int64    `json:"expires_at"`
+	LastUsedAt int64    `json:"last_used_at"`
+	RevokedAt  int64    `json:"revoked_at"`
+	CreatedAt  int64    `json:"created_at"`
+	TokenHash  string   `json:"-"`
+}
+
+func hashAPIToken(plain string) string {
+	h := sha256.Sum256([]byte("qz-api-token:" + plain))
+	return hex.EncodeToString(h[:])
+}
+
+func normalizeScopes(in []string) ([]string, error) {
+	allowed := map[string]bool{}
+	for _, s := range KnownAPITokenScopes {
+		allowed[s] = true
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if !allowed[s] {
+			return nil, fmt.Errorf("未知 scope: %s", s)
+		}
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	if len(out) == 0 {
+		return nil, errors.New("至少选择一个 scope")
+	}
+	return out, nil
+}
+
+func scopesJSON(scopes []string) (string, error) {
+	b, err := json.Marshal(scopes)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func parseScopesJSON(raw string) []string {
+	var out []string
+	if raw == "" {
+		return out
+	}
+	_ = json.Unmarshal([]byte(raw), &out)
+	if out == nil {
+		return []string{}
+	}
+	return out
+}
+
+func mintAPITokenPlain() (plain, prefix string, err error) {
+	var b [24]byte
+	if _, err = rand.Read(b[:]); err != nil {
+		return "", "", err
+	}
+	plain = apiTokenPlainPrefix + hex.EncodeToString(b[:])
+	// Show a short stable prefix for list UI (never enough to recreate the token).
+	prefix = plain[:len(apiTokenPlainPrefix)+8]
+	return plain, prefix, nil
+}
+
+// CreateAPIToken mints a new token. The plaintext is returned once; only the
+// hash is persisted. expiresAt 0 means never expire.
+func (s *Store) CreateAPIToken(name string, scopes []string, createdBy, expiresAt int64) (plain string, tok *APIToken, err error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", nil, errors.New("名称不能为空")
+	}
+	scopes, err = normalizeScopes(scopes)
+	if err != nil {
+		return "", nil, err
+	}
+	if expiresAt < 0 {
+		return "", nil, errors.New("过期时间无效")
+	}
+	plain, prefix, err := mintAPITokenPlain()
+	if err != nil {
+		return "", nil, err
+	}
+	rawScopes, err := scopesJSON(scopes)
+	if err != nil {
+		return "", nil, err
+	}
+	now := time.Now().Unix()
+	res, err := s.db.Exec(`INSERT INTO api_tokens
+		(name, token_prefix, token_hash, scopes, created_by, expires_at, last_used_at, revoked_at, created_at)
+		VALUES (?,?,?,?,?,?,0,0,?)`,
+		name, prefix, hashAPIToken(plain), rawScopes, createdBy, expiresAt, now)
+	if err != nil {
+		return "", nil, err
+	}
+	id, _ := res.LastInsertId()
+	return plain, &APIToken{
+		ID: id, Name: name, Prefix: prefix, Scopes: scopes,
+		CreatedBy: createdBy, ExpiresAt: expiresAt, CreatedAt: now,
+	}, nil
+}
+
+// ListAPITokens returns non-deleted tokens (including revoked) newest first.
+func (s *Store) ListAPITokens() ([]*APIToken, error) {
+	rows, err := s.db.Query(`SELECT id, name, token_prefix, scopes, created_by, expires_at, last_used_at, revoked_at, created_at
+		FROM api_tokens ORDER BY id DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []*APIToken{}
+	for rows.Next() {
+		var t APIToken
+		var rawScopes string
+		if err := rows.Scan(&t.ID, &t.Name, &t.Prefix, &rawScopes, &t.CreatedBy, &t.ExpiresAt, &t.LastUsedAt, &t.RevokedAt, &t.CreatedAt); err != nil {
+			return nil, err
+		}
+		t.Scopes = parseScopesJSON(rawScopes)
+		out = append(out, &t)
+	}
+	return out, rows.Err()
+}
+
+// RevokeAPIToken marks a token revoked. Idempotent.
+func (s *Store) RevokeAPIToken(id int64) error {
+	now := time.Now().Unix()
+	res, err := s.db.Exec(`UPDATE api_tokens SET revoked_at=? WHERE id=? AND revoked_at=0`, now, id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		// Already revoked or missing — treat missing as not found.
+		var exists int
+		_ = s.db.QueryRow(`SELECT 1 FROM api_tokens WHERE id=?`, id).Scan(&exists)
+		if exists == 0 {
+			return sql.ErrNoRows
+		}
+	}
+	return nil
+}
+
+// LookupAPIToken authenticates a plaintext bearer. Returns nil,nil when the
+// token is unknown / revoked / expired — callers must not distinguish those
+// cases in the HTTP response.
+func (s *Store) LookupAPIToken(plain string) (*APIToken, error) {
+	if !strings.HasPrefix(plain, apiTokenPlainPrefix) {
+		return nil, nil
+	}
+	var t APIToken
+	var rawScopes string
+	err := s.db.QueryRow(`SELECT id, name, token_prefix, token_hash, scopes, created_by, expires_at, last_used_at, revoked_at, created_at
+		FROM api_tokens WHERE token_hash=?`, hashAPIToken(plain)).
+		Scan(&t.ID, &t.Name, &t.Prefix, &t.TokenHash, &rawScopes, &t.CreatedBy, &t.ExpiresAt, &t.LastUsedAt, &t.RevokedAt, &t.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().Unix()
+	if t.RevokedAt > 0 {
+		return nil, nil
+	}
+	if t.ExpiresAt > 0 && t.ExpiresAt <= now {
+		return nil, nil
+	}
+	t.Scopes = parseScopesJSON(rawScopes)
+	return &t, nil
+}
+
+// TouchAPIToken bumps last_used_at at most once per minute.
+func (s *Store) TouchAPIToken(id int64) {
+	now := time.Now().Unix()
+	_, _ = s.db.Exec(`UPDATE api_tokens SET last_used_at=? WHERE id=? AND last_used_at < ?`, now, id, now-60)
+}
+
+// APITokenHasScope reports whether scopes includes want.
+func APITokenHasScope(scopes []string, want string) bool {
+	for _, s := range scopes {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/apitokens_test.go
+++ b/internal/store/apitokens_test.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAPIToken_CreateListRevokeLookup(t *testing.T) {
+	st := openMigrated(t)
+	plain, tok, err := st.CreateAPIToken("bot", []string{"stats:read", "users:read"}, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plain == "" || tok.ID == 0 || tok.Prefix == "" {
+		t.Fatalf("bad create: plain=%q tok=%+v", plain, tok)
+	}
+	if got, err := st.LookupAPIToken(plain); err != nil || got == nil || got.ID != tok.ID {
+		t.Fatalf("lookup want id=%d got=%v err=%v", tok.ID, got, err)
+	}
+	list, err := st.ListAPITokens()
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list: %v len=%d", err, len(list))
+	}
+	// ListAPITokens does not select token_hash; TokenHash stays empty in the view.
+	if list[0].TokenHash != "" {
+		t.Fatal("list view must not carry token_hash")
+	}
+	if err := st.RevokeAPIToken(tok.ID); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := st.LookupAPIToken(plain); err != nil || got != nil {
+		t.Fatalf("revoked token must not authenticate, got=%v err=%v", got, err)
+	}
+}
+
+func TestAPIToken_ExpiryAndUnknownScope(t *testing.T) {
+	st := openMigrated(t)
+	if _, _, err := st.CreateAPIToken("x", []string{"admin:all"}, 1, 0); err == nil {
+		t.Fatal("unknown scope must fail")
+	}
+	exp := time.Now().Add(-time.Hour).Unix()
+	plain, _, err := st.CreateAPIToken("old", []string{"nodes:read"}, 1, exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := st.LookupAPIToken(plain); err != nil || got != nil {
+		t.Fatalf("expired must not authenticate, got=%v err=%v", got, err)
+	}
+	if got, err := st.LookupAPIToken("qz_at_deadbeef"); err != nil || got != nil {
+		t.Fatalf("unknown must be nil,nil got=%v err=%v", got, err)
+	}
+}

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -659,6 +659,22 @@ CREATE TABLE IF NOT EXISTS manual_notification_recipients (
   sent_at         INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (notification_id, user_id)
 );
+
+-- Machine API tokens for scripts / Telegram / ops automation. Plaintext is
+-- shown once at creation; only the hash is stored. Scopes are a JSON string
+-- array; expires_at/revoked_at 0 mean never.
+CREATE TABLE IF NOT EXISTS api_tokens (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  name         TEXT    NOT NULL,
+  token_prefix TEXT    NOT NULL,
+  token_hash   TEXT    NOT NULL UNIQUE,
+  scopes       TEXT    NOT NULL DEFAULT '[]',
+  created_by   INTEGER NOT NULL DEFAULT 0,
+  expires_at   INTEGER NOT NULL DEFAULT 0,
+  last_used_at INTEGER NOT NULL DEFAULT 0,
+  revoked_at   INTEGER NOT NULL DEFAULT 0,
+  created_at   INTEGER NOT NULL
+);
 `
 
 // indexes is the index DDL, kept OUT of schema above and applied AFTER the
@@ -715,6 +731,8 @@ CREATE INDEX IF NOT EXISTS idx_tg_bind_tokens_exp ON telegram_bind_tokens(expire
 CREATE INDEX IF NOT EXISTS idx_notify_log_user ON user_notify_log(user_id);
 CREATE INDEX IF NOT EXISTS idx_manual_notifications_created ON manual_notifications(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_manual_notify_recipients_status ON manual_notification_recipients(notification_id, status);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_hash ON api_tokens(token_hash);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_active ON api_tokens(revoked_at, expires_at);
 `
 
 // Migrate brings the schema up to date in three ordered phases: tables, then

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -147,6 +147,8 @@ CREATE TABLE IF NOT EXISTS nodes (
   source_id       INTEGER NOT NULL DEFAULT 0,
   enabled         INTEGER NOT NULL DEFAULT 1,
   sort_order      INTEGER NOT NULL DEFAULT 0,
+  -- Optional subscription display remark; preferred over name in #fragment.
+  remark          TEXT    NOT NULL DEFAULT '',
   created_at      INTEGER NOT NULL
 );
 
@@ -861,6 +863,9 @@ func (s *Store) Migrate() error {
 		// the legacy behaviour of inheriting the physical inbound's own chain.
 		`ALTER TABLE nodes ADD COLUMN route_upstream_inbound_id INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE nodes ADD COLUMN route_upstream_broken INTEGER NOT NULL DEFAULT 0`,
+		// Subscription display remark (optional). Preferred over name in share-link
+		// #fragment; never used as metering identity / v2ray_api user name.
+		`ALTER TABLE nodes ADD COLUMN remark TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE servers ADD COLUMN ssh_password TEXT NOT NULL DEFAULT ''`,
 		// sudo password for accounts without NOPASSWD (encrypted at rest, like the
 		// SSH password beside it), and the name of a key file in the panel's key

--- a/internal/store/nodegroups_ai_test.go
+++ b/internal/store/nodegroups_ai_test.go
@@ -13,7 +13,7 @@ func TestNodeGroupAIFlagPersistsAndAggregatesAcrossMemberships(t *testing.T) {
 		t.Fatal(err)
 	}
 	nodeID, err := st.CreateNode(Node{
-		Type: "external", Name: "shared", ShareLink: "trojan://pw@example.com:443#shared",
+		Type: "external", Name: "shared", Remark: "订阅备注", ShareLink: "trojan://pw@example.com:443#shared",
 		Enabled: true, GroupIDs: []int64{ordinary, aiGroup},
 	})
 	if err != nil {
@@ -33,6 +33,9 @@ func TestNodeGroupAIFlagPersistsAndAggregatesAcrossMemberships(t *testing.T) {
 	}
 	if len(nodes) != 1 || nodes[0].ID != nodeID || !nodes[0].IsAI {
 		t.Fatalf("multi-group AI aggregation = %+v", nodes)
+	}
+	if nodes[0].Remark != "订阅备注" || nodes[0].ShareLink != "trojan://pw@example.com:443#shared" {
+		t.Fatalf("grouped node fields were not preserved: %+v", nodes[0].Node)
 	}
 
 	groups[1].IsAI = false

--- a/internal/store/nodes.go
+++ b/internal/store/nodes.go
@@ -13,6 +13,7 @@ type Node struct {
 	ID                     int64   `json:"id"`
 	Type                   string  `json:"type"` // self_built | external
 	Name                   string  `json:"name"`
+	Remark                 string  `json:"remark"`
 	Protocol               string  `json:"protocol"`
 	InboundTag             string  `json:"inbound_tag"`
 	RouteUpstreamInboundID int64   `json:"route_upstream_inbound_id"`
@@ -25,12 +26,12 @@ type Node struct {
 	GroupIDs               []int64 `json:"group_ids,omitempty"`
 }
 
-const nodeCols = `id, type, name, protocol, inbound_tag, route_upstream_inbound_id, route_upstream_broken, share_link, source_id, enabled, sort_order, created_at`
+const nodeCols = `id, type, name, remark, protocol, inbound_tag, route_upstream_inbound_id, route_upstream_broken, share_link, source_id, enabled, sort_order, created_at`
 
 func scanNode(sc scanner) (*Node, error) {
 	var n Node
 	var routeBroken int
-	err := sc.Scan(&n.ID, &n.Type, &n.Name, &n.Protocol, &n.InboundTag,
+	err := sc.Scan(&n.ID, &n.Type, &n.Name, &n.Remark, &n.Protocol, &n.InboundTag,
 		&n.RouteUpstreamInboundID, &routeBroken, &n.ShareLink, &n.SourceID, &n.Enabled, &n.SortOrder, &n.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -74,14 +75,15 @@ func (s *Store) ListNodes() ([]*Node, error) {
 	return out, nil
 }
 
-// SelfBuiltNodeNames maps each bound inbound tag to the display name the admin
-// gave that node on the 节点 page. Used as the subscription remark so clients
-// show the configured name instead of the raw inbound tag. A tag bound by more
-// than one node keeps the first (sort_order, id) — the same order the node page
-// lists them in.
+// SelfBuiltNodeNames maps each bound inbound tag to the subscription display
+// name (remark if set, otherwise name). A tag bound by more than one node keeps
+// the first (sort_order, id) — the same order the node page lists them in.
 func (s *Store) SelfBuiltNodeNames() (map[string]string, error) {
-	rows, err := s.db.Query(`SELECT inbound_tag, name FROM nodes
-		WHERE type='self_built' AND inbound_tag != '' AND name != ''
+	rows, err := s.db.Query(`SELECT inbound_tag,
+		CASE WHEN trim(remark) != '' THEN remark ELSE name END
+		FROM nodes
+		WHERE type='self_built' AND inbound_tag != ''
+		  AND (trim(remark) != '' OR name != '')
 		  AND route_upstream_inbound_id=0 AND route_upstream_broken=0
 		ORDER BY sort_order, id`)
 	if err != nil {
@@ -101,11 +103,22 @@ func (s *Store) SelfBuiltNodeNames() (map[string]string, error) {
 	return out, rows.Err()
 }
 
+// NodeDisplayName returns the subscription-facing name: remark preferred, else name.
+func NodeDisplayName(n *Node) string {
+	if n == nil {
+		return ""
+	}
+	if r := strings.TrimSpace(n.Remark); r != "" {
+		return r
+	}
+	return n.Name
+}
+
 func (s *Store) CreateNode(n Node) (int64, error) {
 	res, err := s.db.Exec(`INSERT INTO nodes
-		(type, name, protocol, inbound_tag, route_upstream_inbound_id, route_upstream_broken, share_link, source_id, enabled, sort_order, created_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
-		n.Type, n.Name, n.Protocol, n.InboundTag, n.RouteUpstreamInboundID, boolToInt(n.RouteUpstreamBroken), n.ShareLink, n.SourceID,
+		(type, name, remark, protocol, inbound_tag, route_upstream_inbound_id, route_upstream_broken, share_link, source_id, enabled, sort_order, created_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+		n.Type, n.Name, n.Remark, n.Protocol, n.InboundTag, n.RouteUpstreamInboundID, boolToInt(n.RouteUpstreamBroken), n.ShareLink, n.SourceID,
 		boolToInt(n.Enabled), n.SortOrder, time.Now().Unix())
 	if err != nil {
 		return 0, err
@@ -121,8 +134,8 @@ func (s *Store) CreateNode(n Node) (int64, error) {
 
 func (s *Store) UpdateNode(n Node) error {
 	_, err := s.db.Exec(`UPDATE nodes SET
-		type=?, name=?, protocol=?, inbound_tag=?, route_upstream_inbound_id=?, route_upstream_broken=?, share_link=?, enabled=?, sort_order=? WHERE id=?`,
-		n.Type, n.Name, n.Protocol, n.InboundTag, n.RouteUpstreamInboundID, boolToInt(n.RouteUpstreamBroken), n.ShareLink, boolToInt(n.Enabled), n.SortOrder, n.ID)
+		type=?, name=?, remark=?, protocol=?, inbound_tag=?, route_upstream_inbound_id=?, route_upstream_broken=?, share_link=?, enabled=?, sort_order=? WHERE id=?`,
+		n.Type, n.Name, n.Remark, n.Protocol, n.InboundTag, n.RouteUpstreamInboundID, boolToInt(n.RouteUpstreamBroken), n.ShareLink, boolToInt(n.Enabled), n.SortOrder, n.ID)
 	if err != nil {
 		return err
 	}

--- a/internal/store/nodes.go
+++ b/internal/store/nodes.go
@@ -396,7 +396,7 @@ func (s *Store) NodesInGroupsTagged(groupIDs []int64) ([]GroupedNode, error) {
 		var gid int64
 		var isAI bool
 		var routeBroken int
-		if err := rows.Scan(&n.ID, &n.Type, &n.Name, &n.Protocol, &n.InboundTag, &n.RouteUpstreamInboundID, &routeBroken, &n.ShareLink,
+		if err := rows.Scan(&n.ID, &n.Type, &n.Name, &n.Remark, &n.Protocol, &n.InboundTag, &n.RouteUpstreamInboundID, &routeBroken, &n.ShareLink,
 			&n.SourceID, &n.Enabled, &n.SortOrder, &n.CreatedAt, &gid, &isAI); err != nil {
 			return nil, err
 		}

--- a/internal/store/relay.go
+++ b/internal/store/relay.go
@@ -363,6 +363,9 @@ func (s *Store) relayOutbound(landing *SbInbound, serverCache map[int64]*Server,
 	if v := mapStr(opts, "bbr_profile"); v != "" {
 		lp.BBRProfile = v
 	}
+	lp.DisableChromeParrot = mapBool(opts, "disable_chrome_parrot")
+	lp.HopInterval = mapStr(opts, "hop_interval")
+	lp.HopIntervalMax = mapStr(opts, "hop_interval_max")
 	if tr, ok := opts["transport"].(map[string]interface{}); ok {
 		lp.Network = mapStr(tr, "type")
 		lp.Path = mapStr(tr, "path")

--- a/internal/store/relay.go
+++ b/internal/store/relay.go
@@ -357,6 +357,11 @@ func (s *Store) relayOutbound(landing *SbInbound, serverCache map[int64]*Server,
 	if obfs, ok := opts["obfs"].(map[string]interface{}); ok {
 		lp.Obfs = mapStr(obfs, "type")
 		lp.ObfsPassword = mapStr(obfs, "password")
+		lp.ObfsMinPacket = mapInt(obfs, "min_packet_size")
+		lp.ObfsMaxPacket = mapInt(obfs, "max_packet_size")
+	}
+	if v := mapStr(opts, "bbr_profile"); v != "" {
+		lp.BBRProfile = v
 	}
 	if tr, ok := opts["transport"].(map[string]interface{}); ok {
 		lp.Network = mapStr(tr, "type")

--- a/internal/store/singbox.go
+++ b/internal/store/singbox.go
@@ -854,9 +854,10 @@ func (s *Store) BuildSelfBuiltLinks(u *User, host string) []SelfBuiltLink {
 		}
 		_ = json.Unmarshal([]byte(ib.Options), &opts)
 
-		// Remark = the node's display name from the 节点 page; the raw inbound tag
-		// is only a fallback for an inbound no node is bound to.
-		remark := n.Name
+		// Remark = node remark (preferred) or name from the 节点 page; the raw
+		// inbound tag is only a fallback for an inbound no node is bound to.
+		// Metering identity (v2ray_api user name) is never derived from this.
+		remark := NodeDisplayName(n)
 		if logicalID == 0 {
 			remark = legacyNames[ib.Tag]
 		}

--- a/internal/store/singbox.go
+++ b/internal/store/singbox.go
@@ -915,7 +915,15 @@ func (s *Store) BuildSelfBuiltLinks(u *User, host string) []SelfBuiltLink {
 		if obfs, ok := opts["obfs"].(map[string]interface{}); ok {
 			p.Obfs = mapStr(obfs, "type")
 			p.ObfsPassword = mapStr(obfs, "password")
+			p.ObfsMinPacket = mapInt(obfs, "min_packet_size")
+			p.ObfsMaxPacket = mapInt(obfs, "max_packet_size")
 		}
+		if v := mapStr(opts, "bbr_profile"); v != "" {
+			p.BBRProfile = v
+		}
+		p.DisableChromeParrot = mapBool(opts, "disable_chrome_parrot")
+		p.HopInterval = mapStr(opts, "hop_interval")
+		p.HopIntervalMax = mapStr(opts, "hop_interval_max")
 		// transport (ws/grpc/httpupgrade) for vless/vmess/trojan
 		if tr, ok := opts["transport"].(map[string]interface{}); ok {
 			p.Network = mapStr(tr, "type")

--- a/internal/store/subremark_test.go
+++ b/internal/store/subremark_test.go
@@ -87,3 +87,36 @@ func TestSelfBuiltLinks_RemarkFallsBackToTag(t *testing.T) {
 		t.Fatalf("unbound inbound should fall back to its tag, got %q", remark)
 	}
 }
+
+func TestSelfBuiltLinks_RemarkPrefersNodeRemark(t *testing.T) {
+	st := newRefundStore(t)
+	uid := mkUser(t, st, "carol")
+	pkg := mkPlan(t, st, "P", 10, 100, 30)
+	buy(t, st, uid, pkg)
+
+	if _, err := st.SaveSbInbound(&SbInbound{
+		Type: "vless", Tag: "vless-in", Listen: "::", ListenPort: 8443,
+		Options: "{}", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateNode(Node{
+		Type: "self_built", Name: "香港 01", Remark: "HK-VIP", Protocol: "vless",
+		InboundTag: "vless-in", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	bindPlanToInbound(t, st, pkg.ID, "vless-in")
+
+	u, err := st.UserByID(uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	links := st.BuildSelfBuiltLinks(u, "example.com")
+	if len(links) != 1 {
+		t.Fatalf("want 1 link, got %d", len(links))
+	}
+	if remark := subconv.LinkRemark(links[0].Link); remark != "HK-VIP" {
+		t.Fatalf("remark should prefer node remark, got %q", remark)
+	}
+}

--- a/internal/subconv/clash.go
+++ b/internal/subconv/clash.go
@@ -398,6 +398,13 @@ func clashProxy(p *Proxy) map[string]any {
 		if p.tlsInsecure() {
 			m["skip-cert-verify"] = true
 		}
+		// Share-link carries obfs (+ password). mihomo uses obfs / obfs-password.
+		if v := p.param("obfs"); v != "" {
+			m["obfs"] = v
+		}
+		if v := p.param("obfs-password"); v != "" {
+			m["obfs-password"] = v
+		}
 	case "anytls":
 		// Requires mihomo >= v1.19.3. An older core does not skip an unknown
 		// proxy type — ParseProxy returns "unsupport proxy type" and parseProxies

--- a/internal/subconv/clash.go
+++ b/internal/subconv/clash.go
@@ -11,17 +11,30 @@ import (
 // Clash renders a mihomo/Clash YAML config, merging the anti-leak template
 // (dns/tun/sniffer/rules) with the generated proxies and a "Proxy" selector.
 func Clash(proxies []*Proxy, template string) (string, error) {
-	return clashWithProfile(proxies, template, ProfileLegacy)
+	return ClashWithOptions(proxies, template, ProfileLegacy, ClashOptions{})
 }
 
 // ClashWithProfile renders an explicitly selected routing profile. Clash keeps
 // the old entry point separate so no-profile subscriptions remain byte-for-byte
 // on the legacy path.
 func ClashWithProfile(proxies []*Proxy, template string, profile RoutingProfile) (string, error) {
-	return clashWithProfile(proxies, template, profile)
+	return ClashWithOptions(proxies, template, profile, ClashOptions{})
 }
 
-func clashWithProfile(proxies []*Proxy, template string, profile RoutingProfile) (string, error) {
+// ClashOptions tunes Clash subscription rendering.
+type ClashOptions struct {
+	// DisableUDP omits udp:true (and related packet-encoding keys) on proxies
+	// that would otherwise advertise UDP. Egress-blocked nodes still force
+	// udp:false when the key is already present. Default false = historical.
+	DisableUDP bool
+}
+
+// ClashWithOptions is ClashWithProfile plus render toggles.
+func ClashWithOptions(proxies []*Proxy, template string, profile RoutingProfile, opt ClashOptions) (string, error) {
+	return clashWithProfile(proxies, template, profile, opt)
+}
+
+func clashWithProfile(proxies []*Proxy, template string, profile RoutingProfile, opt ClashOptions) (string, error) {
 	if strings.TrimSpace(template) == "" {
 		template = DefaultClashTemplate
 	}
@@ -38,7 +51,7 @@ func clashWithProfile(proxies []*Proxy, template string, profile RoutingProfile)
 	}
 	var cs []conv
 	for _, p := range proxies {
-		if m := clashProxy(p); m != nil {
+		if m := clashProxy(p, opt); m != nil {
 			cs = append(cs, conv{m: m, p: p})
 		}
 	}
@@ -292,7 +305,7 @@ func clashFallback(name string, proxies []string) map[string]any {
 	}
 }
 
-func clashProxy(p *Proxy) map[string]any {
+func clashProxy(p *Proxy, opt ClashOptions) map[string]any {
 	m := map[string]any{"name": p.Name, "server": p.Server, "port": p.Port}
 	switch p.Protocol {
 	case "vless":
@@ -510,6 +523,12 @@ func clashProxy(p *Proxy) map[string]any {
 		if _, emitted := m["udp"]; emitted {
 			m["udp"] = false
 		}
+		delete(m, "xudp")
+		delete(m, "packet-addr")
+	} else if opt.DisableUDP {
+		// Global admin switch: do not advertise UDP. Omit the key rather than
+		// writing false, matching protocols that never had udp (hy2/tuic).
+		delete(m, "udp")
 		delete(m, "xudp")
 		delete(m, "packet-addr")
 	}

--- a/internal/subconv/clash_udp_opt_test.go
+++ b/internal/subconv/clash_udp_opt_test.go
@@ -1,0 +1,26 @@
+package subconv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClashDisableUDPOmitsKey(t *testing.T) {
+	ps := ParseLinks([]string{
+		"vless://11111111-1111-1111-1111-111111111111@1.2.3.4:443?security=tls&sni=a.example#n1",
+	})
+	out, err := ClashWithOptions(ps, "", ProfileLegacy, ClashOptions{DisableUDP: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "udp: true") || strings.Contains(out, "udp:true") {
+		t.Fatalf("DisableUDP must not emit udp: true:\n%s", out)
+	}
+	outOn, err := ClashWithOptions(ps, "", ProfileLegacy, ClashOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(outOn, "udp: true") && !strings.Contains(outOn, "udp:true") {
+		t.Fatalf("default must still emit udp: true:\n%s", outOn)
+	}
+}

--- a/internal/subconv/output.go
+++ b/internal/subconv/output.go
@@ -105,12 +105,41 @@ func Render(format string, links []string, aiNodes map[string]bool, clashTpl, si
 // pre-profile behavior, including Surge's historical CN bypass and base64's
 // node-only output.
 func RenderWithProfile(format string, links []string, aiNodes map[string]bool, clashTpl, singboxTpl, subURL string, profile RoutingProfile) (body string, contentType string, err error) {
-	if profile == ProfileLegacy {
+	return RenderWithOptions(format, links, aiNodes, clashTpl, singboxTpl, subURL, RenderOptions{Profile: profile})
+}
+
+// RenderOptions carries subscription render toggles beyond format selection.
+type RenderOptions struct {
+	Profile RoutingProfile
+	// ClashDisableUDP turns off Clash udp:true advertisement (setting sub_clash_udp=0).
+	ClashDisableUDP bool
+}
+
+// RenderWithOptions is the full render entry used by the subscription handler.
+func RenderWithOptions(format string, links []string, aiNodes map[string]bool, clashTpl, singboxTpl, subURL string, opt RenderOptions) (body string, contentType string, err error) {
+	profile := opt.Profile
+	clashOpt := ClashOptions{DisableUDP: opt.ClashDisableUDP}
+	if profile == ProfileLegacy && !opt.ClashDisableUDP {
 		return Render(format, links, aiNodes, clashTpl, singboxTpl, subURL)
+	}
+	if profile == ProfileLegacy {
+		// Legacy profile but with Clash UDP overridden — still use ClashWithOptions.
+		switch NormalizeFormat(format) {
+		case FormatClash:
+			out, e := ClashWithOptions(parseWithAI(links, aiNodes), clashTpl, ProfileLegacy, clashOpt)
+			return out, "text/yaml; charset=utf-8", e
+		case FormatSingbox:
+			out, e := Singbox(parseWithAI(links, aiNodes), singboxTpl)
+			return out, "application/json; charset=utf-8", e
+		case FormatSurge:
+			return Surge(parseWithAI(links, aiNodes), subURL), "text/plain; charset=utf-8", nil
+		default:
+			return Base64(links), "text/plain; charset=utf-8", nil
+		}
 	}
 	switch NormalizeFormat(format) {
 	case FormatClash:
-		out, e := ClashWithProfile(parseWithAI(links, aiNodes), clashTpl, profile)
+		out, e := ClashWithOptions(parseWithAI(links, aiNodes), clashTpl, profile, clashOpt)
 		return out, "text/yaml; charset=utf-8", e
 	case FormatSingbox:
 		out, e := SingboxWithProfile(parseWithAI(links, aiNodes), singboxTpl, profile)

--- a/internal/subconv/parse.go
+++ b/internal/subconv/parse.go
@@ -427,6 +427,34 @@ func canonicalLink(link string) string {
 	return base + "?" + strings.Join(kept, "&")
 }
 
+// WithLinkRemark overrides only the display name, preserving credentials and
+// protocol options. An empty remark keeps the original link byte-for-byte.
+func WithLinkRemark(link, remark string) string {
+	remark = strings.TrimSpace(remark)
+	if remark == "" || link == "" {
+		return link
+	}
+	if strings.HasPrefix(link, "vmess://") {
+		payload, _, _ := strings.Cut(strings.TrimPrefix(link, "vmess://"), "#")
+		decoded, err := b64decode(payload)
+		if err != nil {
+			return link
+		}
+		var fields map[string]json.RawMessage
+		if json.Unmarshal(decoded, &fields) != nil || fields == nil {
+			return link
+		}
+		fields["ps"], _ = json.Marshal(remark)
+		encoded, err := json.Marshal(fields)
+		if err != nil {
+			return link
+		}
+		return "vmess://" + base64.StdEncoding.EncodeToString(encoded)
+	}
+	base, _, _ := strings.Cut(link, "#")
+	return base + "#" + url.QueryEscape(remark)
+}
+
 // LinkRemark returns the (url-decoded) #fragment remark of a share link.
 func LinkRemark(link string) string {
 	if i := strings.LastIndex(link, "#"); i >= 0 {

--- a/internal/subconv/remark_test.go
+++ b/internal/subconv/remark_test.go
@@ -1,0 +1,53 @@
+package subconv
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestWithLinkRemarkPreservesConnection(t *testing.T) {
+	vmess := "vmess://" + base64.StdEncoding.EncodeToString([]byte(`{"v":"2","ps":"old","add":"example.com","port":"443","id":"11111111-1111-1111-1111-111111111111","aid":"0","net":"tcp","tls":"tls","custom":{"keep":true}}`))
+	for _, link := range []string{
+		"trojan://secret@example.com:443?sni=example.com#old",
+		"hysteria2://secret@example.com:443?obfs=salamander&obfs-password=pw#old",
+		vmess,
+	} {
+		t.Run(strings.Split(link, ":")[0], func(t *testing.T) {
+			if got := WithLinkRemark(link, "  "); got != link {
+				t.Fatal("empty remark changed legacy link")
+			}
+			remark := "香港 #1 + VIP"
+			got := WithLinkRemark(link, remark)
+			if strings.HasPrefix(link, "vmess://") {
+				decoded, err := b64decode(strings.TrimPrefix(got, "vmess://"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				var fields map[string]json.RawMessage
+				if err := json.Unmarshal(decoded, &fields); err != nil {
+					t.Fatal(err)
+				}
+				var name string
+				_ = json.Unmarshal(fields["ps"], &name)
+				if name != remark || string(fields["custom"]) != `{"keep":true}` {
+					t.Fatalf("VMess remark or unknown fields lost: %s", decoded)
+				}
+			} else {
+				base, _, _ := strings.Cut(link, "#")
+				if got != base+"#"+url.QueryEscape(remark) {
+					t.Fatalf("unexpected link: %s", got)
+				}
+			}
+			before, after := ParseLinks([]string{link}), ParseLinks([]string{got})
+			if len(before) != 1 || len(after) != 1 {
+				t.Fatal("link no longer parses")
+			}
+			if before[0].Server != after[0].Server || before[0].Port != after[0].Port || before[0].Password != after[0].Password || before[0].UUID != after[0].UUID {
+				t.Fatal("connection credentials changed")
+			}
+		})
+	}
+}

--- a/internal/subconv/singbox.go
+++ b/internal/subconv/singbox.go
@@ -534,6 +534,33 @@ func singboxOutbound(p *Proxy) map[string]any {
 		o["type"] = "hysteria2"
 		o["password"] = p.Password
 		o["tls"] = sbTLS(p, "tls")
+		if v := p.param("obfs"); v != "" {
+			obfs := map[string]any{"type": v}
+			if pw := p.param("obfs-password"); pw != "" {
+				obfs["password"] = pw
+			}
+			if n := atoi(p.param("obfs-min-packet")); n > 0 {
+				obfs["min_packet_size"] = n
+			}
+			if n := atoi(p.param("obfs-max-packet")); n > 0 {
+				obfs["max_packet_size"] = n
+			}
+			o["obfs"] = obfs
+		}
+		if v := p.param("bbr-profile"); v != "" {
+			o["bbr_profile"] = v
+		}
+		// Client Chrome QUIC parrot is on by default in sing-box 1.14; only
+		// emit the opt-out when the share link asks for it.
+		if p.param("disable-chrome-parrot") == "1" {
+			o["disable_chrome_parrot"] = true
+		}
+		if v := p.param("hop-interval"); v != "" {
+			o["hop_interval"] = v
+		}
+		if v := p.param("hop-interval-max"); v != "" {
+			o["hop_interval_max"] = v
+		}
 	case "anytls":
 		// sing-box >= 1.12.0. tls is required by the outbound constructor.
 		o["type"] = "anytls"


### PR DESCRIPTION
## Summary

将预发分支 `pre` 合入 `main`，包含本期上游跟进与面板能力：

- **#38 / #43**：面板发行 sing-box 升到 **1.14.0**（保留 `with_v2ray_api`）
- **#39 / #44+#45**：Hysteria2 跟进 1.14（Clash/订阅镜像、入站 UI：gecko/obfs/bbr 等；Realm 本版暂不支持表单）
- **#42 / #46**：可吊销、带 scope 与过期的自动化 API Token
- **#40 / #47**：Clash UDP 开关 + 节点备注作订阅展示名（多机「按指纹认领」仍为后续债务）

`pre` 相对 `main`：**领先 5、落后 0**。

## Test plan

- [ ] CI（go / frontend / shell）全绿
- [ ] 新装或升级节点：发行二进制为 1.14，配置生成可用
- [ ] Hy2 入站：salamander/gecko、bbr_profile 写入与订阅镜像抽查
- [ ] API Token：创建 / scope / 过期 / 吊销
- [ ] 订阅：Clash `udp` 开关、备注展示名；旧链接行为无回归
- [ ] 管理端相关页面可打开（Singbox / API Tokens / Settings / Nodes）