### PR TITLE
fix(api): reject API tokens on /api/user/* routes

### DIFF
--- a/internal/api/apitokens.go
+++ b/internal/api/apitokens.go
@@ -127,6 +127,21 @@ func scopeForAdminRequest(r *http.Request) string {
 	return ""
 }
 
+// rejectAPIToken denies machine API-token auth on user-facing routes.
+// API tokens impersonate their creator (admin) via authMiddleware; without this
+// gate a scoped token (e.g. stats:read) could call /api/user/* mutations.
+// Machine tokens are admin-API only; JWT/session remains for /api/user/* and /api/auth/me|logout.
+func (a *API) rejectAPIToken(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		kind, _ := r.Context().Value(ctxAuthKind).(string)
+		if kind == "api_token" {
+			fail(w, http.StatusForbidden, "权限不足")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // enforceAPITokenScope denies API-token callers that lack the mapped scope.
 // JWT sessions pass through unchanged.
 func (a *API) enforceAPITokenScope(next http.Handler) http.Handler {

--- a/internal/api/apitokens_test.go
+++ b/internal/api/apitokens_test.go
@@ -117,3 +117,37 @@ func TestAPIToken_CreateHandlerJWT(t *testing.T) {
 		t.Fatalf("envelope: %v body=%s", err, rec.Body.String())
 	}
 }
+
+func TestAPIToken_RejectedOnUserRoutes(t *testing.T) {
+	a, st := openAPITokenTestAPI(t)
+	plain, _, err := st.CreateAPIToken("ci", []string{"stats:read"}, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := chi.NewRouter()
+	r.Use(a.authMiddleware)
+	r.Use(a.rejectAPIToken)
+	r.Get("/api/user/dashboard", func(w http.ResponseWriter, r *http.Request) {
+		ok(w, J{"ok": true})
+	})
+	r.Post("/api/user/password", func(w http.ResponseWriter, r *http.Request) {
+		ok(w, nil)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/dashboard", nil)
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("dashboard with scoped api token: got %d %s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/user/password", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Authorization", "Bearer "+plain)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("password mutation with scoped api token: got %d %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -227,6 +227,7 @@ func (a *API) Router() http.Handler {
 	// Authenticated (any logged-in user)
 	r.Group(func(pr chi.Router) {
 		pr.Use(a.authMiddleware)
+		pr.Use(a.rejectAPIToken) // API tokens are admin-API only; never /api/user/*
 		pr.Get("/api/auth/me", a.handleMe)
 		pr.Post("/api/auth/logout", a.handleLogout)
 		pr.Get("/api/user/dashboard", a.handleDashboard)


### PR DESCRIPTION
## Summary
- Block `auth_kind=api_token` on the authenticated user router group (`/api/user/*`, `/api/auth/me|logout`, help). Machine API tokens remain admin-API only (still gated by `enforceAPITokenScope`).
- Fixes the #48 release blocker: a scoped token (e.g. `stats:read`) could call user mutations because `authMiddleware` sets `ctxUserID=CreatedBy` / `ctxRole=admin` while scope enforcement only wrapped `/api/admin/*`.

## Test plan
- [x] `go test ./internal/api/ -run TestAPIToken_`
- [x] New `TestAPIToken_RejectedOnUserRoutes`: Bearer scoped token → 403 on `/api/user/dashboard` and `POST /api/user/password`
- [ ] CI green on this PR